### PR TITLE
Docstrings

### DIFF
--- a/METADATA
+++ b/METADATA
@@ -1,0 +1,101 @@
+## -*- mode:shell-script -*-
+
+## This file contains metadata about this grammar resource to be read by
+## the script that extracts information about the resource for publication
+## on the GrammarCatalogue page and in OLAC repositories.  Variables left
+## as empty strings will lead to empty fields in the grammar catalogue.
+
+## The script supplements the data provided here with information from
+## several grammar files, provided they are located in the expected
+## places.  In particular, all grammars should have the following files
+## in their root directories:
+
+## METADATA (this file)
+## LICENSE (first line containing summary e.g., "License: MIT")
+## canonical.bib (canonical citation for this resource)
+
+## In addition, information about treebanks and testsuites is drawn
+## from the following paths (which may be soft links):
+
+## tsdb/gold 
+## tsdb/skeletons
+
+
+
+## Grammar maintainers and contributors
+
+MAINTAINER="Olga Zamaraeva"
+CONTRIBUTORS="Montserrat Marimon, Lorena Suarez"
+CONTACT_EMAIL="olga.zamaraeva@gmail.com"
+
+## Grammar name and web presence
+## Note: if SHORT_GRAMMAR_NAME is not defined, the directory name is used.
+
+GRAMMAR_NAME="Spanish Resource Grammar"
+SHORT_GRAMMAR_NAME="SRG"
+WEBSITE=""
+DEMO_WEBSITE=""
+DOCUMENTATION_URL=""
+ISSUE_TRACKER=""
+LICENSE="MIT"
+
+## You may optionally specify a release date for the grammar. If unspecified,
+## the grammar catalogue script will attempt to extract a date from the
+## Version.l(i)sp file.
+LATEST_RELEASE=""
+
+## Citation data
+## If this is not provided, the text of citation.bib or canonical.bib
+## will be used in the Grammar Catalogue
+BIB_URL=""
+PDF_URL=""
+CITE="Marimon 2010"
+
+## Version Control
+## If this is not provided, it is automatically extracted from the
+## local version control info. You only need to modify this if the
+## version control URL you use locally is not the one you want published
+VCS=""
+
+## Semi-colon separated list of required external resources 
+## e.g.
+## EXTERNAL_RESOURCES="TnT tagger; SPRouT named-entity tagger"
+
+EXTERNAL_RESOURCES="Freeling 4.1"
+
+ASSOCIATED_RESOURCES=""
+
+## Grammar type:
+##    Resource grammar: Broad coverage, used in one or more
+##    applications 
+##
+##    Treebank trained grammar: Cheetah-style grammar
+##    built out of combination of hand-crafted rules and
+##    treebank-derived grammatical and statistical information
+##
+##    Medium-sized linguistic grammar: Grammar with a growing number
+##    of analyses, not yet (big enough to be) used in applications.
+##
+##    Experimental grammar: Small grammar fragment used for
+##    developing/testing one or a small set of linguistic analyses
+
+
+## Uncomment one:
+GRAMMAR_TYPE="Resource grammar"
+#GRAMMAR_TYPE="Treebank trained grammar"
+#GRAMMAR_TYPE="Medium-sized linguistic grammar"
+#GRAMMAR_TYPE="Experimental grammar"
+
+
+## Language identification
+## Iso-codes can be looked up at http://www.sil.org/iso639-3/codes.asp
+
+LANGUAGE_NAME="Spanish"
+ISO_CODE="spa"
+
+## File locations of LKB script file and .grm file read by cheap
+## Paths relative to top of grammar directory
+
+LKB_SCRIPT_FILE=""
+CHEAP_GRM_FILE_NAME=""
+ACE_CONFIG_FILE="ace/config.tdl"

--- a/generics.tdl
+++ b/generics.tdl
@@ -13,7 +13,7 @@
 
 n_-_mc_ge := n_-_mc_le &
 [ STEM < "n_-_mc_le" >,
-  SYNSEM.LKEYS.KEYREL.PRED "_generic_n_rel".
+  SYNSEM.LKEYS.KEYREL.PRED "_generic_n_rel",
   TRAITS generic_token_list ].
 
 n_pp_mc_ge := n_pp_mc_le &

--- a/generics.tdl
+++ b/generics.tdl
@@ -11,14 +11,14 @@
 ;;; in srg.tdl.
 
 
-;n_-_mc_ge := n_-_mc_le &
-;[ STEM < "n_-_mc_le" >,
-;  SYNSEM.LKEYS.KEYREL.PRED "_generic_n_rel".
-;  TRAITS generic_token_list ].
+n_-_mc_ge := n_-_mc_le &
+[ STEM < "n_-_mc_le" >,
+  SYNSEM.LKEYS.KEYREL.PRED "_generic_n_rel".
+  TRAITS generic_token_list ].
 
-;n_pp_mc_ge := n_pp_mc_le &
-;[ STEM < *top* >,
-;  SYNSEM.LKEYS.KEYREL.PRED "_generic_n_rel" ].
+n_pp_mc_ge := n_pp_mc_le &
+[ STEM < *top* >,
+  SYNSEM.LKEYS.KEYREL.PRED "_generic_n_rel" ].
 
 ;;; Generic lexical entries for noun tags
 

--- a/generics.tdl
+++ b/generics.tdl
@@ -11,14 +11,15 @@
 ;;; in srg.tdl.
 
 
-n_-_mc_ge := n_-_mc_le &
-[ STEM < "n_-_mc_le" >,
-  SYNSEM.LKEYS.KEYREL.PRED "_generic_n_rel",
-  TRAITS generic_token_list ].
+;n_-_mc_ge := n_-_mc_le &
+;[ STEM < "n_-_mc_le" >,
+;  SYNSEM.LKEYS.KEYREL.PRED "_generic_n_rel",
+;  TOKENS.+LIST generic_token_list ].
 
-n_pp_mc_ge := n_pp_mc_le &
-[ STEM < *top* >,
-  SYNSEM.LKEYS.KEYREL.PRED "_generic_n_rel" ].
+;n_pp_mc_ge := n_pp_mc_le &
+;[ STEM < *top* >,
+;  SYNSEM.LKEYS.KEYREL.PRED "_generic_n_rel",
+;  TOKENS.+LIST generic_token_list ].
 
 ;;; Generic lexical entries for noun tags
 

--- a/inflr.tdl
+++ b/inflr.tdl
@@ -9,38 +9,49 @@
 ; --- non-inflecting categories
 
 ; -- adverbs 
+
 rg := 
 %suffix (rg rg) 
-rg_ilr.
+rg_ilr
+"""adverb""".
 
 rn :=
 %suffix (rn rn) 
-rg_ilr.
+rg_ilr
+"""adverb""".
 
 ; (-- advnp)
+
 nc00000 := 
 %suffix (nc00000 nc00000)
-nc00000_ilr.
+nc00000_ilr
+"""advnp (? OZ: not sure what this means...)""".
 
 ; (-- interj).
 i :=
 %suffix (i i)
-i_ilr.
+i_ilr
+"""interj""".
 
 ; -- prepositions
+
 sp := 
 %suffix (sp sp)
-sp_ilr.
+sp_ilr
+"""preposition""".
 
 ; -- sub. conjunctions
+
 cs := 
 %suffix (cs cs) 
-cs_ilr.
+cs_ilr
+"""sub. conjunction""".
 
 ; -- coord. conjunctions
 cc := 
 %suffix (cc cc) 
-cc_ilr.
+cc_ilr
+"""coord. conjunction""".
 
 
 ; --- named entities
@@ -48,163 +59,177 @@ cc_ilr.
 ; -- proper names
 np00sp0 :=
 %suffix (np00sp0 np00sp0)
-np00sp0_ilr.
+np00sp0_ilr
+"""proper name""".
 
-; OZ: Is there anything special about np00g00, compared to np00sp0?
+
 np00g00 :=
 %suffix (np00g00 np00g00)
-np00sp0_ilr.
+np00sp0_ilr
+"""OZ: Is there anything special about np00g00, compared to np00sp0?""".
 
-; OZ: Freeling returns this tag for some named entities.
+
 np00o00 := 
 %suffix (np00o00 np00o00)
-np00sp0_ilr.
+np00sp0_ilr
+"""OZ: Freeling returns this tag for some named entities.""".
 
-; OZ: I will use this for various cases which cause Freeling to not return an analysis
 np00v00 :=
 %suffix (np00v00 np00v00)
-np00v00_ilr.
+np00v00_ilr
+"""OZ: I will use this for various cases which cause Freeling to not return an analysis""".
 
 ; -- numbers
+
 z := 
 %suffix (z z)
-ne_ilr. 
+ne_ilr
+"""number""". 
 
 zp := 
 %suffix (zp zp)
-ne_ilr. 
+ne_ilr
+"""number""". 
 
 ; -- currencies
+
 zm := 
 %suffix (zm zm)
-ne_ilr. 
+ne_ilr
+"""currency""". 
 
 zd := 
 %suffix (zd zd)
-ne_ilr. 
+ne_ilr
+"""currency""". 
 
 ; -- measures
+
 zu := 
 %suffix (zu zu)
-ne_ilr. 
+ne_ilr
+"""measure""". 
 
 ; -- dates
+
 w := 
 %suffix (w w)
-ne_ilr. 
+ne_ilr
+"""date""". 
 
 
 ; --- punctuation marks
 
-; -- semi colon ;
+
 fx := 
 %suffix (fx fx)
-infl-ltow-rule.
+infl-ltow-rule
+""" -- semi colon ;""".
 
-; -- colon :
 fd := 
 %suffix (fd fd)
-infl-ltow-rule.
+infl-ltow-rule
+"""-- colon :""".
 
-; -- full-stop .
 fp := 
 %suffix (fp fp)
-infl-ltow-rule.
+infl-ltow-rule
+""" -- full-stop .""".
 
-; -- 3dots ...
 fs := 
 %suffix (fs fs)
-infl-ltow-rule.
+infl-ltow-rule
+"""-- 3dots ...""".
 
-; -- comma ,
 fc := 
 %suffix (fc fc)
-infl-ltow-rule.
+infl-ltow-rule
+""" -- comma ,""".
 
-; -- quotes "
 fe := 
 %suffix (fe fe)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- quotes " """.
 
-; -- hyphen -
 fg := 
 %suffix (fg fg)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- hyphen -""".
 
-; -- question mark open ¿
 fia := 
 %suffix (fia fia)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- question mark open ¿""".
 
-; -- question mark close ?
 fit := 
 %suffix (fit fit)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- question mark close ?""".
 
-; -- exclamative open ¡
 faa := 
 %suffix (faa faa)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- exclamative open ¡""".
 
-; -- exclamative close !
 fat := 
 %suffix (fat fat)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- exclamative close !""".
 
-; -- bracket open (
 fpa := 
 %suffix (fpa fpa)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- bracket open (""".
 
-; -- bracket close )
 fpt := 
 %suffix (fpt fpt)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- bracket close )""".
 
-; -- <<
 fra := 
 %suffix (fra fra)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- <<""".
 
-; -- >>
 frc := 
 %suffix (frc frc)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- >>""".
 
-; -- square bracket open [
 fca := 
 %suffix (fca fca)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- square bracket open [""".
 
-; -- square bracket close ]
 fct := 
 %suffix (fct fct)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- square bracket close ]""".
 
-; -- {
 fla := 
 %suffix (fla fla)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- {""".
 
-; -- }
 flt := 
 %suffix (flt flt)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- }""".
 
-; -- percentage %
 ft := 
 %suffix (ft ft)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- percentage %""".
 
-; -- mathematical symbols (+, -, =)
 fz := 
 %suffix (fz fz)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- mathematical symbols (+, -, =)""".
 
-; -- /
 fh := 
 %suffix (fh fh)
-infl-ltow-rule.
+infl-ltow-rule
+"""; -- /""".
 
 
 ; --- inflecting categories
@@ -212,608 +237,704 @@ infl-ltow-rule.
 ; --- determiners
 
 ; --- definite articles (el, los, la, las, lo)
+
 da0ms0 := 
 %suffix (da0ms0 da0ms0)
-da0ms0_ilr.
+da0ms0_ilr
+"""definite article (el)""".
 
 da0mp0 := 
 %suffix (da0mp0 da0mp0)
-da0mp0_ilr.
+da0mp0_ilr
+"""definite article (los)""".
 
 da0fs0 := 
 %suffix (da0fs0 da0fs0)
-da0fs0_ilr.
+da0fs0_ilr
+"""definite article (la)""".
 
 da0fp0 := 
 %suffix (da0fp0 da0fp0)
-da0fp0_ilr.
+da0fp0_ilr
+"""definite article (las)""".
 
 da00s0 := 
 %suffix (da00s0 da00s0)
-da00s0_ilr.
+da00s0_ilr
+"""definite article (lo)""".
 
 
 ; --- demonstrative determiners
-; este, ese, aquel
+
+
 dd0ms0 := 
 %suffix (dd0ms0 dd0ms0)
-dd0ms0_ilr.
+dd0ms0_ilr
+"""; este, ese, aquel""".
 
-; estos, esos, aquellos
 dd0mp0 := 
 %suffix (dd0mp0 dd0mp0)
-dd0mp0_ilr.
+dd0mp0_ilr
+"""; estos, esos, aquellos""".
 
-; esta, esa, aquella
 dd0fs0 := 
 %suffix (dd0fs0 dd0fs0)
-dd0fs0_ilr.
+dd0fs0_ilr
+"""; esta, esa, aquella""".
 
-; estas, esas, aquellas
 dd0fp0 := 
 %suffix (dd0fp0 dd0fp0)
-dd0fp0_ilr.
+dd0fp0_ilr
+"""; estas, esas, aquellas""".
 
-; tal, semejante
 dd0cs0 := 
 %suffix (dd0cs0 dd0cs0)
-dd0cs0_ilr.
+dd0cs0_ilr
+"""; tal, semejante""".
 
-; tales, semejantes
 dd0cp0 := 
 %suffix (dd0cp0 dd0cp0)
-dd0cp0_ilr.
+dd0cp0_ilr
+"""; tales, semejantes""".
 
 
 ; -- possessive determiners
-; mi
+
 dp1css := 
 %suffix (dp1css dp1css)
-dp1css_ilr.
+dp1css_ilr
+"""; mi""".
 
-; mis
 dp1cps := 
 %suffix (dp1cps dp1cps)
-dp1cps_ilr.
+dp1cps_ilr
+"""; mis""".
 
-; OZ: It is not clear to me at the moment why mi/mis get a dp tag while the rest get the ap ones.
-; If this changes, then the TAGS dictionary in util/override_freeling.py will need to be modified.
-; nuestros
 ;dp1mpp := 
 ;%suffix (dp1mpp dp1mpp)
-;ap0mp1p_ilr.
+;ap0mp1p_ilr
+;"""; nuestros""".
 
-
-; nuestro
 ap0ms1p := 
 %suffix (ap0ms1p ap0ms1p)
-ap0ms1p_ilr.
+ap0ms1p_ilr
+"""; nuestro""".
 
-; nuestros
 ap0mp1p := 
 %suffix (ap0mp1p ap0mp1p)
-ap0mp1p_ilr.
+ap0mp1p_ilr
+"""; nuestros""".
 
-
-; nuestra
 ap0fs1p := 
 %suffix (ap0fs1p ap0fs1p)
-ap0fs1p_ilr.
+ap0fs1p_ilr
+"""; nuestra""".
 
-; nuestras
 ap0fp1p := 
 %suffix (ap0fp1p ap0fp1p)
-ap0fp1p_ilr.
+ap0fp1p_ilr
+"""; nuestras""".
 
-; tu
 dp2css := 
 %suffix (dp2css dp2css)
-dp2css_ilr.
+dp2css_ilr
+"""; tu""".
 
-; tus
 dp2cps := 
 %suffix (dp2cps dp2cps)
-dp2cps_ilr.
+dp2cps_ilr
+"""; tus""".
 
-; vuestro
 ap0ms2p := 
 %suffix (ap0ms2p ap0ms2p)
-ap0ms2p_ilr.
+ap0ms2p_ilr
+"""; vuestro""".
 
-; vuestros
 ap0mp2p := 
 %suffix (ap0mp2p ap0mp2p)
-ap0mp2p_ilr.
+ap0mp2p_ilr
+"""; vuestros""".
 
-; vuestra
 ap0fs2p := 
 %suffix (ap0fs2p ap0fs2p)
-ap0fs2p_ilr.
+ap0fs2p_ilr
+"""; vuestra""".
 
-; vuestras
 ap0fp2p := 
 %suffix (ap0fp2p ap0fp2p)
-ap0fp2p_ilr.
+ap0fp2p_ilr
+"""; vuestras""".
 
-; su
 dp3csn := 
 %suffix (dp3csn dp3csn)
-dp3csn_ilr.
+dp3csn_ilr
+"""; su""".
 
-; sus
 dp3cpn := 
 %suffix (dp3cpn dp3cp0)
-dp3cpn_ilr.
+dp3cpn_ilr
+"""; sus""".
 
 
 ; -- indefinite determiners
-; algún
+
 di0ms0 := 
 %suffix (di0ms0 di0ms0)
-di0ms0_ilr.
+di0ms0_ilr
+"""; algún""".
 
-; algunos
 di0mp0 := 
 %suffix (di0mp0 di0mp0)
-di0mp0_ilr.
+di0mp0_ilr
+"""; algunos""".
 
-; alguna
 di0fs0 := 
 %suffix (di0fs0 di0fs0)
-di0fs0_ilr.
+di0fs0_ilr
+"""; alguna""".
 
-; algunas
 di0fp0 := 
 %suffix (di0fp0 di0fp0)
-di0fp0_ilr.
+di0fp0_ilr
+"""; algunas""".
 
-; bastante
 di0cs0 := 
 %suffix (di0cs0 di0cs0)
-di0cs0_ilr.
+di0cs0_ilr
+"""; bastante""".
 
-; bastantes
 di0cp0 := 
 %suffix (di0cp0 di0cp0)
-di0cp0_ilr.
+di0cp0_ilr
+"""; bastantes""".
 
 
 ; -- interrogative determiners
-; cuánto
+
 dt0ms0 := 
 %suffix (dt0ms0 dt0ms0)
-dt0ms0_ilr.
+dt0ms0_ilr
+"""; cuánto""".
 
-; cuántos
 dt0mp0 := 
 %suffix (dt0mp0 dt0mp0)
-dt0mp0_ilr.
+dt0mp0_ilr
+"""; cuántos""".
 
-; cuánta
 dt0fs0 := 
 %suffix (dt0fs0 dt0fs0)
-dt0fs0_ilr.
+dt0fs0_ilr
+"""; cuánta""".
 
-; cuántas
 dt0fp0 := 
 %suffix (dt0fp0 dt0fp0)
-dt0fp0_ilr.
+dt0fp0_ilr
+"""; cuántas""".
 
-; cuál
 dt0cs0 := 
 %suffix (dt0cs0 dt0cs0)
-dt0cs0_ilr.
+dt0cs0_ilr
+"""; cuál""".
 
-; cuáles
 dt0cp0 := 
 %suffix (dt0cp0 dt0cp0)
-dt0cp0_ilr.
+dt0cp0_ilr
+"""; cuáles""".
 
-; qué
 dt0cn0 := 
 %suffix (dt0cn0 dt0cn0)
-dt0cn0_ilr.
+dt0cn0_ilr
+"""; qué""".
 
 ; -- exclamative determiners
-; cuánto
+
 de0ms0 := 
 %suffix (de0ms0 de0ms0)
-de0ms0_ilr.
+de0ms0_ilr
+"""; cuánto
+""".
 
-; cuántos
 de0mp0 := 
 %suffix (de0mp0 de0mp0)
-de0mp0_ilr.
+de0mp0_ilr
+"""; cuántos""".
 
-; cuánta
 de0fs0 := 
 %suffix (de0fs0 de0fs0)
-de0fs0_ilr.
+de0fs0_ilr
+"""; cuánta""".
 
-; cuántas
 de0fp0 := 
 %suffix (de0fp0 de0fp0)
-de0fp0_ilr.
+de0fp0_ilr
+"""; cuántas""".
 
-; cuál
 de0cs0 := 
 %suffix (de0cs0 de0cs0)
-de0cs0_ilr.
+de0cs0_ilr
+"""; cuál""".
 
-; cuáles
 de0cp0 := 
 %suffix (de0cp0 de0cp0)
-de0cp0_ilr.
+de0cp0_ilr
+"""; cuáles""".
 
-; qué
 de0cn0 := 
 %suffix (de0cn0 de0cn0)
-de0cn0_ilr.
+de0cn0_ilr
+"""; qué""".
 
 
 ; --- pronouns 
 
 ; -- demonstrative pronouns
-; este, ese, aquel, estotro, esotro, ello
+
 pd0ms00 := 
 %suffix (pd0ms00 pd0ms00)
-pd0ms00_ilr.
+pd0ms00_ilr
+"""; este, ese, aquel, estotro, esotro, ello
+""".
 
-; estos, esos, aquellos
 pd0mp00 := 
 %suffix (pd0mp00 pd0mp00)
-pd0mp00_ilr.
+pd0mp00_ilr
+"""; estos, esos, aquellos
+""".
 
-; esta, esa, aquella, estotra, esotra
 pd0fs00 := 
 %suffix (pd0fs00 pd0fs00)
-pd0fs00_ilr.
+pd0fs00_ilr
+"""; esta, esa, aquella, estotra, esotra
+""".
 
-; estas, esas, aquellas
 pd0fp00 := 
 %suffix (pd0fp00 pd0fp00)
-pd0fp00_ilr.
+pd0fp00_ilr
+"""; estas, esas, aquellas
+""".
 
-; esto, eso, aquello
 pd00s00 := 
 %suffix (pd00s00 pd00s00)
-pd00s00_ilr.
+pd00s00_ilr
+"""; esto, eso, aquello
+""".
 
-; tal
 pd0cs00 := 
 %suffix (pd0cs00 pd0cs00)
-pd0cs00_ilr.
+pd0cs00_ilr
+"""; tal
+""".
 
-; tales
 pd0cp00 := 
 %suffix (pd0cp00 pd0cp00)
-pd0cp00_ilr.
+pd0cp00_ilr
+"""; tales
+""".
 
 
 ; -- indefinite pronouns
-; alguno
+
 pi0ms00 := 
 %suffix (pi0ms00 pi0ms00)
-pi0ms00_ilr.
+pi0ms00_ilr
+"""; alguno
+""".
 
-; algunos
 pi0mp00 := 
 %suffix (pi0mp00 pi0mp00)
-pi0mp00_ilr.
+pi0mp00_ilr
+"""; algunos
+""".
 
-; alguna
 pi0fs00 := 
 %suffix (pi0fs00 pi0fs00)
-pi0fs00_ilr.
+pi0fs00_ilr
+"""; alguna
+""".
 
-; algunas
 pi0fp00 := 
 %suffix (pi0fp00 pi0fp00)
-pi0fp00_ilr.
+pi0fp00_ilr
+"""; algunas
+""".
 
-; bastante
 pi0cs00 := 
 %suffix (pi0cs00 pi0cs00)
-pi0cs00_ilr.
+pi0cs00_ilr
+"""; bastante
+""".
 
-; bastantes
 pi0cp00 := 
 %suffix (pi0cp00 pi0cp00)
-pi0cp00_ilr.
+pi0cp00_ilr
+"""; bastantes
+""".
 
-; lo/los/las demás
 pi0cc000 := 
 %suffix (pi0cc000 pi0cc000)
-pi0cc000_ilr.
+pi0cc000_ilr
+"""; lo/los/las demás
+""".
 
 
 ; -- relative pronouns 
-; cuanto, cuyo
+
 pr0ms00 := 
 %suffix (pr0ms00 pr0ms00)
-dr0ms0_ilr.
+dr0ms0_ilr
+"""; relative: cuanto, cuyo
+""".
 
-; cuantos, cuyos
 pr0mp00 := 
 %suffix (pr0mp00 pr0mp00)
-dr0mp0_ilr.
+dr0mp0_ilr
+"""; relative: cuantos, cuyos
+""".
 
-; cuanta, cuya
 pr0fs00 := 
 %suffix (pr0fs00 pr0fs00)
-dr0fs0_ilr.
+dr0fs0_ilr
+"""; relative: cuanta, cuya
+""".
 
-; cuantas, cuyas
 pr0fp00 := 
 %suffix (pr0fp00 pr0fp00)
-dr0fp0_ilr.
+dr0fp0_ilr
+"""; relative: cuantas, cuyas
+""".
 
-; quien, cual
 pr0cs00 := 
 %suffix (pr0cs00 pr0cs00)
-pr0cs00_ilr.
+pr0cs00_ilr
+""" ; relative: quien, cual
+""".
 
-; quienes, cuales
 pr0cp00 := 
 %suffix (pr0cp00 pr0cp00)
-pr0cp00_ilr.
+pr0cp00_ilr
+""" ; relative quienes, cuales
+""".
 
-; que
 pr0cn00 := 
 %suffix (pr0cn00 pr0cn00)
-pr0cn00_ilr.
+pr0cn00_ilr
+"""; relative: que
+""".
 
-; (a)donde, como, cuando
 pr00000 := 
 %suffix (pr00000 pr00000)
-pr00000_ilr.
+pr00000_ilr
+"""; relative: (a)donde, como, cuando
+""".
 
 
 ; -- interrogative pronouns
-; cuánto
+
 pt0ms00 := 
 %suffix (pt0ms00 pt0ms00)
-pt0ms00_ilr.
+pt0ms00_ilr
+"""; interrogative: cuánto
+""".
 
-; cuántos
 pt0mp00 := 
 %suffix (pt0mp00 pt0mp00)
-pt0mp00_ilr.
+pt0mp00_ilr
+"""; interrogative: cuántos
+""".
 
-; cuánta
 pt0fs00 := 
 %suffix (pt0fs00 pt0fs00)
-pt0fs00_ilr.
+pt0fs00_ilr
+"""; interrogative: cuánta
+""".
 
-; cuántas
 pt0fp00 := 
 %suffix (pt0fp00 pt0fp00)
-pt0fp00_ilr.
+pt0fp00_ilr
+"""; interrogative: cuántas
+""".
 
-; cuál, quién
 pt0cs00 := 
 %suffix (pt0cs00 pt0cs00)
-pt0cs00_ilr.
+pt0cs00_ilr
+"""; interrogative: cuál, quién
+""".
 
-; cuáles, quiénes
 pt0cp00 := 
 %suffix (pt0cp00 pt0cp00)
-pt0cp00_ilr.
+pt0cp00_ilr
+"""; interrogative: cuáles, quiénes
+""".
 
-; qué
-; (a)dónde, cómo, cuándo
 pt00000 := 
 %suffix (pt00000 pt00000)
-pt00000_ilr.
+pt00000_ilr
+"""; interrogative: qué
+; (a)dónde, cómo, cuándo
+""".
 
 ; -- exclamative pronouns
-; cuánto
+
+
 pe0ms00 := 
 %suffix (pe0ms00 pe0ms00)
-pe0ms00_ilr.
+pe0ms00_ilr
+""" exclamative pronoun: ; cuánto
+""".
 
-; cuántos
 pe0mp00 := 
 %suffix (pe0mp00 pe0mp00)
-pe0mp00_ilr.
+pe0mp00_ilr
+""" exclamative pronoun: ; cuántos
+""".
 
-; cuánta
 pe0fs00 := 
 %suffix (pe0fs00 pe0fs00)
-pe0fs00_ilr.
+pe0fs00_ilr
+""" exclamative pronoun: ; cuánta
+""".
 
-; cuántas
 pe0fp00 := 
 %suffix (pe0fp00 pe0fp00)
-pe0fp00_ilr.
+pe0fp00_ilr
+""" exclamative pronoun: ; cuántas
+""".
 
-; cuál, quién
 pe0cs00 := 
 %suffix (pe0cs00 pe0cs00)
-pe0cs00_ilr.
+pe0cs00_ilr
+""" exclamative pronoun: ; cuál, quién
+""".
 
-; cuáles, quiénes
 pe0cp00 := 
 %suffix (pe0cp00 pe0cp00)
-pe0cp00_ilr.
+pe0cp00_ilr
+""" exclamative pronoun: ; cuáles, quiénes
+""".
 
-; qué, (a)dónde, cómo, cuándo
 pe00000 := 
 %suffix (pe00000 pe00000)
-pe00000_ilr.
+pe00000_ilr
+""" exclamative pronoun: ; qué, (a)dónde, cómo, cuándo
+""".
 
 ; -- personal pronouns
-; yo
+
 pp1csn0 :=
 %suffix (pp1csn0 pp1csn0) 
-pp1csn0_ilr.
+pp1csn0_ilr
+""" ; yo
+""".
 
-; tú
 pp2csn0 :=
 %suffix (pp2csn0 pp2csn0) 
-pp2csn0_ilr.
+pp2csn0_ilr
+""" ; tú
+""".
 
-; él
 pp3ms00 :=
 %suffix (pp3ms00 pp3ms00) 
-pp3ms00_ilr.
+pp3ms00_ilr
+""" ; él
+""".
 
-; ella
 pp3fs00 :=
 %suffix (pp3fs00 pp3fs00) 
-pp3fs00_ilr.
+pp3fs00_ilr
+""" ; ella
+""".
 
-; ello
 pp3ns000 :=
 %suffix (pp3ns000 pp3ns000) 
-pp3ns000_ilr.
+pp3ns000_ilr
+""" ; ello
+""".
 
-; nosotros
 pp1mp00 :=
 %suffix (pp1mp00 pp1mp00) 
-pp1mp00_ilr.
+pp1mp00_ilr
+""" ; nosotros
+""".
 
-; nosotras
 pp1fp00 :=
 %suffix (pp1fp00 pp1fp00) 
-pp1fp00_ilr.
+pp1fp00_ilr
+""" ; nosotras
+""".
 
-; vosotros
 pp2mp00 :=
 %suffix (pp2mp00 pp2mp00) 
-pp2mp00_ilr.
+pp2mp00_ilr
+""" ; vosotros
+""".
 
-; vosotras
 pp2fp00 :=
 %suffix (pp2fp00 pp2fp00) 
-pp2fp00_ilr.
+pp2fp00_ilr
+""" ; vosotras
+""".
 
-; ellos
 pp3mp00 :=
 %suffix (pp3mp00 pp3mp00) 
-pp3mp00_ilr.
+pp3mp00_ilr
+"""; ellos
+""".
 
-; ellas
 pp3fp00 :=
 %suffix (pp3fp00 pp3fp00) 
-pp3fp00_ilr.
+pp3fp00_ilr
+"""; ellas
+""".
 
-; usted
 pp2cs0p :=
 %suffix (pp2cs0p pp2cs0p) 
-pp2cs0p_ilr.
+pp2cs0p_ilr
+"""; usted
+""".
 
-; ustedes
 pp2cp0p :=
 %suffix (pp2cp0p pp2cp0p) 
-pp2cp0p_ilr.
+pp2cp0p_ilr
+"""; ustedes
+""".
 
 
-; mí, conmigo
 pp1cso0 := 
 %suffix (pp1cso0 pp1cso0) 
-pp1cso0_ilr.
+pp1cso0_ilr
+"""; mí, conmigo
+""".
 
-; tí, contigo,
 pp2cso0 := 
 %suffix (pp2cso0 pp2cso0) 
-pp2cso0_ilr.
+pp2cso0_ilr
+"""; tí, contigo,
+""".
 
-; sí, consigo
 pp3cno0 := 
 %suffix (pp3cno0 pp3cno0) 
-pp3cno0_ilr.
+pp3cno0_ilr
+"""; sí, consigo
+""".
 
 
 ; --- clitics (affixes)
-; la
+
 pp3fsa0 := 
 %suffix (pp3fsa0 pp3fsa0) 
-affx_3sg-fem_ilr.
+affx_3sg-fem_ilr
+""" clitics (affixes): ; la
+""".
 
-; las
 pp3fpa0 := 
 %suffix (pp3fpa0 pp3fpa0) 
-affx_3pl-fem_ilr.
+affx_3pl-fem_ilr
+""" clitics (affixes): ; las
+""".
 
-; lo
 pp3cna00 := 
 %suffix (pp3cna00 pp3cna00) 
-affx_3sg-masc_ilr.
+affx_3sg-masc_ilr
+""" clitics (affixes): ; lo
+""".
 
-; lo
 pp3msa0 := 
 %suffix (pp3msa0 pp3msa0) 
-affx_3sg-masc_ilr.
+affx_3sg-masc_ilr
+""" clitics (affixes): ; lo
+""".
 
-; los
 pp3mpa0 := 
 %suffix (pp3mpa0 pp3mpa0) 
-affx_3pl-masc_ilr.
+affx_3pl-masc_ilr
+""" clitics (affixes): ; los
+""".
 
-; me
 pp1cs00 := 
 %suffix (pp1cs00 pp1cs00) 
-pp1cs00_ilr.
+pp1cs00_ilr
+""" clitics (affixes): ; me
+""".
 
 p01cs00 := 
 %suffix (p01cs00 p01cs00) 
-p01cs00_ilr.
+p01cs00_ilr
+""" clitics (affixes)
 ;no_ilr.
+""".
 
-; nos
 pp1cp00 := 
 %suffix (pp1cp00 pp1cp00)
-affx_1pl_ilr. 
+affx_1pl_ilr
+""" clitics (affixes): ; nos
+""". 
 
 p01cp00 := 
 %suffix (p01cp00 p01cp00) 
-affx_1pl_ilr. 
+affx_1pl_ilr
+""" clitics (affixes)
 ;no_ilr.
+""". 
 
-; te
 pp2cs00 := 
 %suffix (pp2cs00 pp2cs00) 
-affx_2sg_ilr.
+affx_2sg_ilr
+""" clitics (affixes):
+; te
+""".
 
 p02cs00 := 
 %suffix (p02cs00 p02cs00) 
-affx_2sg_ilr.
+affx_2sg_ilr
+""" clitics (affixes)
 ;no_ilr.
+""".
 
-; os
+
 pp2cp00 := 
 %suffix (pp2cp00 pp2cp00) 
-affx_2pl_ilr.
+affx_2pl_ilr
+""" clitics (affixes): ; os
+""".
 
 p02cp00 := 
 %suffix (p02cp00 p02cp00) 
-affx_2pl_ilr.
+affx_2pl_ilr
+""" clitics (affixes)
 ;no_ilr.
+""".
 
-; se
 pp3cn00 := 
 %suffix (pp3cn00 pp3cn00) 
-affx_3per_ilr.
+affx_3per_ilr
+""" clitics (affixes): ; se
+""".
 
 p03cn00 := 
 %suffix (p03cn00 p03cn00) 
-affx_3per_ilr.
+affx_3per_ilr
+""" clitics (affixes)
+""".
 
 p00cn00 := 
 %suffix (p00cn00 p00cn00) 
-affx_3per_ilr.
+affx_3per_ilr
+""" clitics (affixes):
 ;no_ilr. 
+""".
 
-; le
 pp3csd0 := 
 %suffix (pp3csd0 pp3csd0) 
-affx_3sg_ilr.
+affx_3sg_ilr
+""" clitics (affixes):
+; le
+""".
 
-; les
 pp3cpd0 := 
 %suffix (pp3cpd0 pp3cpd0) 
-affx_3pl_ilr.
+affx_3pl_ilr
+""" clitics (affixes): ; les
+""".
 
 
 ; --- common nouns
@@ -923,152 +1044,183 @@ n_com_ilr.
 ; --- adjectives
 
 ; -- ordinals
-; primera
+
 ao0fs00 := 
 %suffix (ao0fs00 ao0fs00)
-a_fem-sg_ilr.
+a_fem-sg_ilr
+"""; ordinals: primera
+""".
 
-; primeras
 ao0fp00 := 
 %suffix (ao0fp00 ao0fp00)
-a_fem-pl_ilr.
+a_fem-pl_ilr
+"""; ordinals: ; primeras
+""".
 
-; primer, primero
 ao0ms00 := 
 %suffix (ao0ms00 ao0ms00) 
-infl-ltow-rule.
+infl-ltow-rule
+"""; ordinals: ; primer, primero
 ;a_masc-sg_ilr.
+""".
 
-; primeros
 ao0mp00 := 
 %suffix (ao0mp00 ao0mp00)
-a_masc-pl_ilr.
+a_masc-pl_ilr
+"""; ordinals: ; primeros
+""".
 
 ; -- possessives
-; mía
+
 ap0fs1s := 
 %suffix (ap0fs1s ap0fs1s) 
-a_fem-sg_ilr.
+a_fem-sg_ilr
+"""; mía
+""".
 
-; mías
 ap0fp1s := 
 %suffix (ap0fp1s ap0fp1s) 
-a_fem-pl_ilr.
+a_fem-pl_ilr
+"""; mías
+""".
 
-; mío
 ap0ms1s := 
 %suffix (ap0ms1s ap0ms1s) 
-a_masc-sg_ilr.
+a_masc-sg_ilr
+"""; mío
+""".
 
-; mío
 px1ns0s0 := 
 %suffix (px1ns0s0 px1ns0s0) 
-a_neut-sg_ilr.
+a_neut-sg_ilr
+"""; mío
+""".
 
-; míos
 ap0mp1s := 
 %suffix (ap0mp1s ap0mp1s) 
-a_masc-pl_ilr.
+a_masc-pl_ilr
+"""; míos
+""".
 
-; nuestra
 px1fs0p0 := 
 %suffix (px1fs0p0 px1fs0p0) 
-a_fem-sg_ilr.
+a_fem-sg_ilr
+"""; nuestra
+""".
 
-; nuestras
 px1fp0p0 := 
 %suffix (px1fp0p0 px1fp0p0) 
-a_fem-pl_ilr.
+a_fem-pl_ilr
+"""; nuestras
+""".
 
-; nuestro
 px1ms0p0 := 
 %suffix (px1ms0p0 px1ms0p0) 
-a_masc-sg_ilr.
+a_masc-sg_ilr
+"""; nuestro
+""".
 
-; nuestro
 px1ns0p0 := 
 %suffix (px1ns0p0 px1ns0p0) 
-a_neut-sg_ilr.
+a_neut-sg_ilr
+"""; nuestro
+""".
 
-; nuestros
 px1mp0p0 := 
 %suffix (px1mp0p0 px1mp0p0)
-a_masc-pl_ilr. 
+a_masc-pl_ilr
+"""; nuestros
+""". 
 
-; tuya
 ap0fs2s := 
 %suffix (ap0fs2s ap0fs2s)  
-a_fem-sg_ilr.
+a_fem-sg_ilr
+"""; tuya
+""".
 
-; tuyas
 ap0fp2s := 
 %suffix (ap0fp2s ap0fp2s) 
-a_fem-pl_ilr.
+a_fem-pl_ilr
+"""; tuyas
+""".
 
-; tuyo
 ap0ms2s := 
 %suffix (ap0ms2s ap0ms2s) 
-a_masc-sg_ilr.
+a_masc-sg_ilr
+"""; tuyo
+""".
 
-; tuyo
 px2ns0s0 := 
 %suffix (px2ns0s0 px2ns0s0) 
-a_neut-sg_ilr.
+a_neut-sg_ilr
+"""; tuyo
+""".
 
-; tuyos 
 ap0mp2s := 
 %suffix (ap0mp2s ap0mp2s) 
-a_masc-pl_ilr.
+a_masc-pl_ilr
+"""; tuyos 
+""".
 
-; vuestra
 px2fs0p0 := 
 %suffix (px2fs0p0 px2fs0p0)  
-a_fem-sg_ilr.
+a_fem-sg_ilr
+"""; vuestra
+""".
 
-; vuestras
 px2fp0p0 := 
 %suffix (px2fp0p0 px2fp0p0) 
-a_fem-pl_ilr.
+a_fem-pl_ilr
+"""; vuestras
+""".
 
-; vuestro
 px2ms0p0 := 
 %suffix (px2ms0p0 px2ms0p0) 
-a_masc-sg_ilr.
+a_masc-sg_ilr
+"""; vuestro
+""".
 
-; vuestro
 px2ns0p0 := 
 %suffix (px2ns0p0 px2ns0p0) 
-a_neut-sg_ilr.
+a_neut-sg_ilr
+"""; vuestro
+""".
 
-; vuestros
 px2mp0p0 := 
 %suffix (px2mp0p0 px2mp0p0) 
-a_masc-pl_ilr.
+a_masc-pl_ilr
+"""; vuestros
+""".
 
-; suya
 ap0fs3n := 
 %suffix (ap0fs3n ap0fs3n) 
-a_fem-sg_ilr.
+a_fem-sg_ilr
+"""; suya
+""".
 
-; suyas
 ap0fp3n := 
 %suffix (ap0fp3n ap0fp3n) 
-a_fem-pl_ilr.
+a_fem-pl_ilr
+"""; suyas
+""".
 
-; suyo
 ap0ms3n := 
 %suffix (ap0ms3n ap0ms3n) 
-a_masc-sg_ilr.
+a_masc-sg_ilr
+"""; suyo
+""".
 
-; suyo
 px3ns0c0 := 
 %suffix (px3ns0c0 px3ns0c0) 
-a_neut-sg_ilr.
+a_neut-sg_ilr
+"""; suyo
+""".
 
-; suyos
 ap0mp3n := 
 %suffix (ap0ms3n pap0ms3n) 
-a_masc-pl_ilr.
+a_masc-pl_ilr
+"""; suyos
+""".
 
 ; -- qualitatives
 
@@ -1076,98 +1228,118 @@ a_masc-pl_ilr.
 ;%suffix (aq00000 aq00000)
 ;a_masc-sg_ilr.
 
-; bonito
 aq0ms00 := 
 %suffix (aq0ms00 aq0ms00) 
-a_masc-sg_ilr.
+a_masc-sg_ilr
+"""; bonito
+""".
 
-; bonitos
 aq0mp00 := 
 %suffix (aq0mp00 aq0mp00)
-a_masc-pl_ilr.
+a_masc-pl_ilr
+"""; bonitos
+""".
 
 ; pequeñitos
 ;aqvmp00 := 
 ;%suffix (aqvmp00 aqvmp00)
 ;a_masc-pl_ilr.
 
-; bonita
 aq0fs00 := 
 %suffix (aq0fs00 aq0fs00)
-a_fem-sg_ilr.
+a_fem-sg_ilr
+"""; bonita
+""".
 
-; bonitas
 aq0fp00 := 
 %suffix (aq0fp00 aq0fp00)
-a_fem-pl_ilr.
+a_fem-pl_ilr
+"""; bonitas
+""".
 
-; alegre
 aq0cs00 := 
 %suffix (aq0cs00 aq0cs00)
-a_sg_ilr.
+a_sg_ilr
+"""; alegre
+""".
 
-; alegres
 aq0cp00 := 
 %suffix (aq0cp00 aq0cp00) 
-a_pl_ilr.
+a_pl_ilr
+"""; alegres
+""".
 
-; antiarrugas
 aq0cn00 := 
 %suffix (aq0cn00 aq0cn00) 
-a_ilr.
+a_ilr
+"""; antiarrugas
+""".
 
 ; -- comparatives
-; e.g. mejor
+
 aqccs00 := 
 %suffix (aqccs00 aqccs00)
-a_sg_ilr.
+a_sg_ilr
+"""; e.g. mejor
+""".
 
-; e.g. mejores
 aqccp00 := 
 %suffix (aqccp00 aqccp00) 
-a_pl_ilr.
+a_pl_ilr
+"""; e.g. mejores
+""".
 
 ; -- superlatives
-; e.g. dificilísimo 
+
 aqsms00 := 
 %suffix (aqsms00 aqsms00)
-a_masc-sg_ilr.
+a_masc-sg_ilr
+"""; e.g. dificilísimo 
+""".
 
-; e.g. dificilísimos
 aqsmp00 := 
 %suffix (aqsmp00 aqsmp00)
-a_masc-pl_ilr.
+a_masc-pl_ilr
+"""; e.g. dificilísimos
+""".
 
-; e.g. dificilísima 
 aqsfs00 := 
 %suffix (aqsfs00 aqsfs00)
-a_fem-sg_ilr.
+a_fem-sg_ilr
+"""; e.g. dificilísima 
+""".
 
-; e.g. dificilísimas
 aqsfp00 := 
 %suffix (aqsfp00 aqsfp00)
-a_fem-pl_ilr.
+a_fem-pl_ilr
+"""; e.g. dificilísimas
+""".
 
 ; -- diminutives
-; e.g. pequeñísimo
+
 aqdms00 := 
 %suffix (aqdms00 aqdms00)
-a_masc-sg_ilr.
+a_masc-sg_ilr
+"""; e.g. pequeñísimo
+""".
 
-; e.g. pequeñísimos
 aqdmp00 := 
 %suffix (aqdmp00 aqdmp00)
-a_masc-pl_ilr.
+a_masc-pl_ilr
+"""; e.g. pequeñísimos
+""".
 
-; e.g. pequeñísima
 aqdfs00 := 
 %suffix (aqdfs00 aqdfs00)
-a_fem-sg_ilr.
+a_fem-sg_ilr
+"""; e.g. pequeñísima
+""".
 
-; e.g. pequeñísimos
 aqdfp00 := 
 %suffix (aqdfp00 aqdfp00)
-a_fem-pl_ilr.
+a_fem-pl_ilr
+"""; e.g. pequeñísimos
+""".
 
 aq00000 := 
 %suffix (aq00000 aq00000)
@@ -1175,25 +1347,35 @@ no_ilr.
 
 
 ; -- pastpart (only for 3 verbs)
-; desnudo, sujeto, inadvertido
+
 aq0msp := 
 %suffix (aq0msp aq0msp) 
-a_masc-sg_ilr.
+a_masc-sg_ilr
+"""
+; -- pastpart (only for 3 verbs)
+; desnudo, sujeto, inadvertido
+""".
 
-; desnudos, sujetos, inadvertido
 aq0mpp := 
 %suffix (aq0mpp aq0mpp)
-a_masc-pl_ilr.
+a_masc-pl_ilr
+"""; -- pastpart (only for 3 verbs)
+; desnudos, sujetos, inadvertido
+""".
 
-; desnuda, sujeta, inadvertida
 aq0fsp := 
 %suffix (aq0fsp aq0fsp)
-a_fem-sg_ilr.
+a_fem-sg_ilr
+"""; -- pastpart (only for 3 verbs)
+; desnuda, sujeta, inadvertida
+""".
 
-; desnudas, sujetas, inadvertidas
 aq0fpp := 
 %suffix (aq0fpp aq0fpp)
-a_fem-pl_ilr.
+a_fem-pl_ilr
+"""; -- pastpart (only for 3 verbs)
+; desnudas, sujetas, inadvertidas
+""".
 
 
 ; --- verbal inflection rules

--- a/irtypes.tdl
+++ b/irtypes.tdl
@@ -58,7 +58,18 @@ lexeme-to-word-rule := lex-rule &
     DTR [ INFLECTED -,
           KEY-ARG #keyarg,   
           SYNSEM #synsem ],
-    C-CONT.RELS <! !> ].
+    C-CONT.RELS <! !> ]
+    """; Lexical rules vary on two dimensions: whether they are lexeme-to-lexeme
+; or lexeme-to-word and whether or not they involve spelling changes.
+; Accordingly, we define four subtypes of lex-rule, which have
+; four cross-classified glb subtypes. Note that the lexeme/word distinction 
+; is represented via a feature [INFLECTED bool] rather than as a type.  
+; We find this more convenient, as it allows certain words to be [INFLECTED +] 
+; from the start without having to twist the hierarchy too much (especially 
+; if one makes use of defaults).
+
+; Lexeme-to-word rules are hypothesized to monotonically add synsem information.
+""".
 
 non_cann-lexeme-to-word-rule := non_cann-lex-rule & 
   [ INFLECTED +,
@@ -68,14 +79,14 @@ non_cann-lexeme-to-word-rule := non_cann-lex-rule &
           KEY-ARG #keyarg,   
           SYNSEM #synsem ] ].
 
-; Lexeme-to-lexeme rules can make more radical changes to the SYNSEM value.
 lexeme-to-lexeme-rule := lex-rule & 
   [ INFLECTED #infl,
     SYNSEM.LOCAL.CAT.MC #mc,
     DTR [ INFLECTED #infl,
-          SYNSEM.LOCAL.CAT.MC #mc ] ].
+          SYNSEM.LOCAL.CAT.MC #mc ] ]
+          """; Lexeme-to-lexeme rules can make more radical changes to the SYNSEM value.
+""".
 
-; Spelling changing rules. The LKB identifies these rules based on the NEEDS-AFFIX value. 
 inflecting-lex-rule := lex-rule &
   [ NEEDS-AFFIX +,
     SYNSEM.SLSHD #slshd, 
@@ -83,15 +94,19 @@ inflecting-lex-rule := lex-rule &
     DTR [ SYNSEM.SLSHD #slshd, 
           ALTS #alts,
           ARG-ST #arg-st ],
-    ALTS #alts ].
+    ALTS #alts ]
+    """; Spelling changing rules. The LKB identifies these rules based on the NEEDS-AFFIX value. 
+""".
 
-; Spelling-preserving rules copy up the STEM (orthography) of the daughter.
 constant-lex-rule := lex-rule &
   [ STEM #stem,
-    DTR.STEM #stem ].
+    DTR.STEM #stem ]
+    """; Spelling-preserving rules copy up the STEM (orthography) of the daughter.
+""".
 
 
 ; Cross-classified glb types
+
 infl-ltol-rule := lexeme-to-lexeme-rule & inflecting-lex-rule.
 infl-ltow-rule := lexeme-to-word-rule & inflecting-lex-rule.
 non_cann-infl-ltow-rule := non_cann-lexeme-to-word-rule & inflecting-lex-rule.
@@ -109,20 +124,23 @@ const-ltol-rule-noncont := basic-lex-rule & phrase-or-lexrule &
 
 ; --- inflectional lexical rule types
 
-; -- FL tags which have no lexical entry
 no_ilr :=  infl-ltow-rule &
-  [ SYNSEM.LOCAL.CAT.HEAD no-head ].
+  [ SYNSEM.LOCAL.CAT.HEAD no-head ]
+  """; -- FL tags which have no lexical entry
+""".
 
-; -- non-inflecting categories
 rg_ilr := infl-ltow-rule & 
-  [ SYNSEM.LOCAL.CAT.HEAD +nr ].
+  [ SYNSEM.LOCAL.CAT.HEAD +nr ]
+  """; -- non-inflecting categories
+""".
 
 nc00000_ilr :=  infl-ltow-rule & 
   [ SYNSEM.LOCAL.CAT.HEAD noun ].
 
-; foreign words sometimes get this tag.  
 np00v00_ilr := infl-ltow-rule & 
-  [ SYNSEM.LOCAL.CAT.HEAD noun ].
+  [ SYNSEM.LOCAL.CAT.HEAD noun ]
+  """; foreign words sometimes get this tag.  
+""".
 
 i_ilr := infl-ltow-rule & 
   [ SYNSEM.LOCAL.CAT.HEAD interj ].
@@ -136,9 +154,10 @@ cs_ilr :=  infl-ltow-rule &
 cc_ilr :=  infl-ltow-rule & 
   [ SYNSEM.LOCAL.CAT.HEAD conj ].
 
-; -- named entities
 np00sp0_ilr :=  infl-ltow-rule & 
-  [ SYNSEM.LOCAL.CAT.HEAD noun & [ KEYS.KEY named_rel ] ].
+  [ SYNSEM.LOCAL.CAT.HEAD noun & [ KEYS.KEY named_rel ] ]
+  """; -- named entities
+""".
 
 ne_ilr :=  infl-ltow-rule & 
   [ SYNSEM.LOCAL.CAT.HEAD head ].
@@ -215,67 +234,122 @@ dr_ilr :=  d_ilr &
   [ SYNSEM.NON-LOCAL.REL 1-dlist ].
 
 ; -- definite articles
-da0ms0_ilr := da_ilr & masc_3sg_ilr.
-da0mp0_ilr := da_ilr & masc_3pl_ilr.
-da0fs0_ilr := da_ilr & fem_3sg_ilr.
-da0fp0_ilr := da_ilr & fem_3pl_ilr.
-da00s0_ilr := da_ilr & 3sg_ilr.
+
+da0ms0_ilr := da_ilr & masc_3sg_ilr
+"""definite article""".
+da0mp0_ilr := da_ilr & masc_3pl_ilr
+"""definite article""".
+da0fs0_ilr := da_ilr & fem_3sg_ilr
+"""definite article""".
+da0fp0_ilr := da_ilr & fem_3pl_ilr
+"""definite article""".
+da00s0_ilr := da_ilr & 3sg_ilr
+"""definite article""".
 
 ; -- demonstrative det.
-dd0ms0_ilr := dd_ilr & masc_3sg_ilr.
-dd0mp0_ilr := dd_ilr & masc_3pl_ilr.
-dd0fs0_ilr := dd_ilr & fem_3sg_ilr.
-dd0fp0_ilr := dd_ilr & fem_3pl_ilr.
-dd0cs0_ilr := d_ilr & 3sg_ilr.
-dd0cp0_ilr := d_ilr & 3pl_ilr.
+
+dd0ms0_ilr := dd_ilr & masc_3sg_ilr
+"""demonstrative det""".
+dd0mp0_ilr := dd_ilr & masc_3pl_ilr
+"""demonstrative det""".
+dd0fs0_ilr := dd_ilr & fem_3sg_ilr
+"""demonstrative det""".
+dd0fp0_ilr := dd_ilr & fem_3pl_ilr
+"""demonstrative det""".
+dd0cs0_ilr := d_ilr & 3sg_ilr
+"""demonstrative det""".
+dd0cp0_ilr := d_ilr & 3pl_ilr
+"""demonstrative det""".
 
 ; -- possessive det.
-dp1css_ilr :=  dp_ilr & 3sg_ilr.
-dp1cps_ilr :=  dp_ilr & 3pl_ilr.
-ap0ms1p_ilr :=  dp_ilr & masc_3sg_ilr.
-ap0mp1p_ilr :=  dp_ilr & masc_3pl_ilr.
-ap0fs1p_ilr :=  dp_ilr & fem_3sg_ilr.
-ap0fp1p_ilr :=  dp_ilr & fem_3pl_ilr.
-dp2css_ilr :=  dp_ilr & 3sg_ilr.
-dp2cps_ilr :=  dp_ilr & 3pl_ilr.
-ap0ms2p_ilr :=  dp_ilr & masc_3sg_ilr.
-ap0mp2p_ilr :=  dp_ilr & masc_3pl_ilr.
-ap0fs2p_ilr :=  dp_ilr & fem_3sg_ilr.
-ap0fp2p_ilr :=  dp_ilr & fem_3pl_ilr.
-dp3csn_ilr :=  dp_ilr & 3sg_ilr.
-dp3cpn_ilr :=  dp_ilr & 3pl_ilr.
+
+dp1css_ilr :=  dp_ilr & 3sg_ilr
+"""possessive det""".
+dp1cps_ilr := dp_ilr & 3pl_ilr
+"""possessive det""".
+ap0ms1p_ilr := dp_ilr & masc_3sg_ilr
+"""possessive det""".
+ap0mp1p_ilr := dp_ilr & masc_3pl_ilr
+"""possessive det""".
+ap0fs1p_ilr := dp_ilr & fem_3sg_ilr
+"""possessive det""".
+ap0fp1p_ilr := dp_ilr & fem_3pl_ilr
+"""possessive det""".
+dp2css_ilr := dp_ilr & 3sg_ilr
+"""possessive det""".
+dp2cps_ilr := dp_ilr & 3pl_ilr
+"""possessive det""".
+ap0ms2p_ilr := dp_ilr & masc_3sg_ilr
+"""possessive det""".
+ap0mp2p_ilr := dp_ilr & masc_3pl_ilr
+"""possessive det""".
+ap0fs2p_ilr := dp_ilr & fem_3sg_ilr
+"""possessive det""".
+ap0fp2p_ilr := dp_ilr & fem_3pl_ilr
+"""possessive det""".
+dp3csn_ilr := dp_ilr & 3sg_ilr
+"""possessive det""".
+dp3cpn_ilr := dp_ilr & 3pl_ilr
+"""possessive det""".
 
 ; -- indefinite det. 
-di0ms0_ilr :=  d_ilr & masc_3sg_ilr.
-di0mp0_ilr :=  d_ilr & masc_3pl_ilr.
-di0fs0_ilr :=  d_ilr & fem_3sg_ilr.
-di0fp0_ilr :=  d_ilr & fem_3pl_ilr.
-di0cs0_ilr :=  d_ilr & 3sg_ilr.
-di0cp0_ilr :=  d_ilr & 3pl_ilr.
+
+di0ms0_ilr :=  d_ilr & masc_3sg_ilr
+"""indefinite det""".
+di0mp0_ilr :=  d_ilr & masc_3pl_ilr
+"""indefinite det""".
+di0fs0_ilr :=  d_ilr & fem_3sg_ilr
+"""indefinite det""".
+di0fp0_ilr :=  d_ilr & fem_3pl_ilr
+"""indefinite det""".
+di0cs0_ilr :=  d_ilr & 3sg_ilr
+"""indefinite det""".
+di0cp0_ilr :=  d_ilr & 3pl_ilr
+"""indefinite det""".
 
 ; -- interrogative det.
-dt0ms0_ilr :=  dt_ilr & masc_3sg_ilr.
-dt0mp0_ilr :=  dt_ilr & masc_3pl_ilr.
-dt0fs0_ilr :=  dt_ilr & fem_3sg_ilr.
-dt0fp0_ilr :=  dt_ilr & fem_3pl_ilr.
-dt0cs0_ilr :=  dt_ilr & 3sg_ilr.
-dt0cp0_ilr :=  dt_ilr & 3pl_ilr.
-dt0cn0_ilr :=  dt_ilr.
+
+dt0ms0_ilr :=  dt_ilr & masc_3sg_ilr
+"""interrogative det""".
+dt0mp0_ilr :=  dt_ilr & masc_3pl_ilr
+"""interrogative det""".
+dt0fs0_ilr :=  dt_ilr & fem_3sg_ilr
+"""interrogative det""".
+dt0fp0_ilr :=  dt_ilr & fem_3pl_ilr
+"""interrogative det""".
+dt0cs0_ilr :=  dt_ilr & 3sg_ilr
+"""interrogative det""".
+dt0cp0_ilr :=  dt_ilr & 3pl_ilr
+"""interrogative det""".
+dt0cn0_ilr :=  dt_ilr
+"""interrogative det""".
 
 ; -- exclamative det.
-de0ms0_ilr :=  de_ilr & masc_3sg_ilr.
-de0mp0_ilr :=  de_ilr & masc_3pl_ilr.
-de0fs0_ilr :=  de_ilr & fem_3sg_ilr.
-de0fp0_ilr :=  de_ilr & fem_3pl_ilr.
-de0cs0_ilr :=  de_ilr & 3sg_ilr.
-de0cp0_ilr :=  de_ilr & 3pl_ilr.
-de0cn0_ilr :=  de_ilr.
+
+de0ms0_ilr :=  de_ilr & masc_3sg_il
+"""exclamative det""".
+de0mp0_ilr :=  de_ilr & masc_3pl_ilr
+"""exclamative det""".
+de0fs0_ilr :=  de_ilr & fem_3sg_ilr
+"""exclamative det""".
+de0fp0_ilr :=  de_ilr & fem_3pl_ilr
+"""exclamative det""".
+de0cs0_ilr :=  de_ilr & 3sg_ilr
+"""exclamative det""".
+de0cp0_ilr :=  de_ilr & 3pl_ilr
+"""exclamative det""".
+de0cn0_ilr :=  de_ilr
+"""exclamative det""".
 
 ; -- relative det.
-dr0ms0_ilr :=  dr_ilr & masc_3sg_ilr.
-dr0mp0_ilr :=  dr_ilr & masc_3pl_ilr.
-dr0fs0_ilr :=  dr_ilr & fem_3sg_ilr.
-dr0fp0_ilr :=  dr_ilr & fem_3pl_ilr.
+dr0ms0_ilr :=  dr_ilr & masc_3sg_ilr
+"""relative det""".
+dr0mp0_ilr :=  dr_ilr & masc_3pl_ilr
+"""relative det""".
+dr0fs0_ilr :=  dr_ilr & fem_3sg_ilr
+"""relative det""".
+dr0fp0_ilr :=  dr_ilr & fem_3pl_ilr
+"""relative det""".
 
 ; --- pronouns
 
@@ -305,78 +379,134 @@ pd_ilr :=  pr_ilr &
 pp_ilr :=  infl-ltow-rule.
 
 ; -- indefinite pron.
-pi0ms00_ilr :=  pi_ilr & sg_ilr & masc_ilr. 
-pi0mp00_ilr :=  pi_ilr & pl_ilr & masc_ilr. 
-pi0fs00_ilr :=  pi_ilr & sg_ilr & fem_ilr. 
-pi0fp00_ilr :=  pi_ilr & pl_ilr & fem_ilr. 
-pi0cs00_ilr :=  pi_ilr & sg_ilr.
-pi0cp00_ilr :=  pi_ilr & pl_ilr.
-pi0cc000_ilr :=  pi_ilr.
+pi0ms00_ilr :=  pi_ilr & sg_ilr & masc_ilr
+"""indefinite pron""". 
+pi0mp00_ilr :=  pi_ilr & pl_ilr & masc_ilr
+"""indefinite pron""". 
+pi0fs00_ilr :=  pi_ilr & sg_ilr & fem_ilr
+"""indefinite pron""". 
+pi0fp00_ilr :=  pi_ilr & pl_ilr & fem_ilr
+"""indefinite pron""". 
+pi0cs00_ilr :=  pi_ilr & sg_ilr
+"""indefinite pron""".
+pi0cp00_ilr :=  pi_ilr & pl_il
+"""indefinite pron""".
+pi0cc000_ilr :=  pi_ilr
+"""indefinite pron""".
 
 ; -- interrogative pron.
-pt0ms00_ilr :=  pt_ilr & sg_ilr & masc_ilr. 
-pt0mp00_ilr :=  pt_ilr & pl_ilr & masc_ilr. 
-pt0fs00_ilr :=  pt_ilr & sg_ilr & fem_ilr. 
-pt0fp00_ilr :=  pt_ilr & pl_ilr & fem_ilr. 
-pt0cs00_ilr :=  pt_ilr & sg_ilr.
-pt0cp00_ilr :=  pt_ilr & pl_ilr.
-pt00000_ilr :=  pt_ilr.
+pt0ms00_ilr :=  pt_ilr & sg_ilr & masc_ilr
+"""interrogative pron""". 
+pt0mp00_ilr :=  pt_ilr & pl_ilr & masc_ilr
+"""interrogative pron""". 
+pt0fs00_ilr :=  pt_ilr & sg_ilr & fem_ilr
+"""interrogative pron""". 
+pt0fp00_ilr :=  pt_ilr & pl_ilr & fem_ilr
+"""interrogative pron""". 
+pt0cs00_ilr :=  pt_ilr & sg_ilr
+"""interrogative pron""".
+pt0cp00_ilr :=  pt_ilr & pl_ilr
+"""interrogative pron""".
+pt00000_ilr :=  pt_ilr
+"""interrogative pron""".
 
 ; -- exclamative pron.
-pe0ms00_ilr :=  pe_ilr & sg_ilr & masc_ilr. 
-pe0mp00_ilr :=  pe_ilr & pl_ilr & masc_ilr. 
-pe0fs00_ilr :=  pe_ilr & sg_ilr & fem_ilr. 
-pe0fp00_ilr :=  pe_ilr & pl_ilr & fem_ilr. 
-pe0cs00_ilr :=  pe_ilr & sg_ilr.
-pe0cp00_ilr :=  pe_ilr & pl_ilr.
-pe00000_ilr :=  pe_ilr.
+pe0ms00_ilr :=  pe_ilr & sg_ilr & masc_ilr
+"""exclamative pron""". 
+pe0mp00_ilr :=  pe_ilr & pl_ilr & masc_ilr
+"""exclamative pron""". 
+pe0fs00_ilr :=  pe_ilr & sg_ilr & fem_ilr
+"""exclamative pron""". 
+pe0fp00_ilr :=  pe_ilr & pl_ilr & fem_ilr
+"""exclamative pron""". 
+pe0cs00_ilr :=  pe_ilr & sg_ilr
+"""exclamative pron""".
+pe0cp00_ilr :=  pe_ilr & pl_ilr
+"""exclamative pron""".
+pe00000_ilr :=  pe_ilr
+"""exclamative pron""".
 
 ; -- demonstrative pron.
-pd0ms00_ilr :=  pd_ilr & sg_ilr & masc_ilr. 
-pd0mp00_ilr :=  pd_ilr & pl_ilr & masc_ilr. 
-pd0fs00_ilr :=  pd_ilr & sg_ilr & fem_ilr. 
-pd0fp00_ilr :=  pd_ilr & pl_ilr & fem_ilr. 
-pd00s00_ilr :=  pd_ilr & sg_ilr & neut_ilr. 
-pd0cs00_ilr :=  pd_ilr & sg_ilr.
-pd0cp00_ilr :=  pd_ilr & pl_ilr.
+pd0ms00_ilr :=  pd_ilr & sg_ilr & masc_ilr
+"""demonstrative pron""". 
+pd0mp00_ilr :=  pd_ilr & pl_ilr & masc_ilr
+"""demonstrative pron""". 
+pd0fs00_ilr :=  pd_ilr & sg_ilr & fem_ilr
+"""demonstrative pron""". 
+pd0fp00_ilr :=  pd_ilr & pl_ilr & fem_ilr
+"""demonstrative pron""". 
+pd00s00_ilr :=  pd_ilr & sg_ilr & neut_ilr
+"""demonstrative pron""". 
+pd0cs00_ilr :=  pd_ilr & sg_ilr
+"""demonstrative pron""".
+pd0cp00_ilr :=  pd_ilr & pl_ilr
+"""demonstrative pron""".
 
 ; -- relative pron.
-pr0cs00_ilr := pr_sg_ilr.
-pr0cp00_ilr := pr_pl_ilr.
-pr0cn00_ilr := pr_ilr.
-pr00000_ilr := pr_ilr.
+pr0cs00_ilr := pr_sg_ilr
+"""relative pron""".
+pr0cp00_ilr := pr_pl_ilr
+"""relative pron""".
+pr0cn00_ilr := pr_ilr
+"""relative pron""".
+pr00000_ilr := pr_ilr
+"""relative pron""".
 
 ; -- personal pron.
-pp1csn0_ilr :=  pp_ilr & 1sg_ilr.
-pp2csn0_ilr :=  pp_ilr & 2sg_ilr.
-pp3fs00_ilr :=  pp_ilr & 3sg_ilr & fem_ilr. 
-pp3ms00_ilr :=  pp_ilr & 3sg_ilr & masc_ilr. 
-pp3ns000_ilr :=  pp_ilr & 3sg_ilr & neut_ilr. 
-pp1fp00_ilr :=  pp_ilr & 1pl_ilr & fem_ilr. 
-pp1mp00_ilr :=  pp_ilr & 1pl_ilr & masc_ilr. 
-pp2fp00_ilr :=  pp_ilr & 2pl_ilr & fem_ilr. 
-pp2mp00_ilr :=  pp_ilr & 2pl_ilr & masc_ilr. 
-pp3fp00_ilr :=  pp_ilr & 3pl_ilr & fem_ilr. 
-pp3mp00_ilr :=  pp_ilr & 3pl_ilr & masc_ilr. 
-pp2cs0p_ilr :=  pp_ilr & 3sg_ilr. 
-pp2cp0p_ilr :=  pp_ilr & 3pl_ilr. 
-pp1cso0_ilr :=  pp_ilr & 1sg_ilr.
-pp2cso0_ilr :=  pp_ilr & 2sg_ilr.
+pp1csn0_ilr :=  pp_ilr & 1sg_ilr
+"""personal pron""".
+pp2csn0_ilr :=  pp_ilr & 2sg_ilr
+"""personal pron""".
+pp3fs00_ilr :=  pp_ilr & 3sg_ilr & fem_ilr
+"""personal pron""". 
+pp3ms00_ilr :=  pp_ilr & 3sg_ilr & masc_ilr
+"""personal pron""". 
+pp3ns000_ilr :=  pp_ilr & 3sg_ilr & neut_ilr
+"""personal pron""". 
+pp1fp00_ilr :=  pp_ilr & 1pl_ilr & fem_ilr
+"""personal pron""". 
+pp1mp00_ilr :=  pp_ilr & 1pl_ilr & masc_ilr
+"""personal pron""". 
+pp2fp00_ilr :=  pp_ilr & 2pl_ilr & fem_ilr
+"""personal pron""". 
+pp2mp00_ilr :=  pp_ilr & 2pl_ilr & masc_ilr
+"""personal pron""". 
+pp3fp00_ilr :=  pp_ilr & 3pl_ilr & fem_ilr
+"""personal pron""". 
+pp3mp00_ilr :=  pp_ilr & 3pl_ilr & masc_ilr
+"""personal pron""". 
+pp2cs0p_ilr :=  pp_ilr & 3sg_ilr
+"""personal pron""". 
+pp2cp0p_ilr :=  pp_ilr & 3pl_ilr
+"""personal pron""". 
+pp1cso0_ilr :=  pp_ilr & 1sg_ilr
+"""personal pron""".
+pp2cso0_ilr :=  pp_ilr & 2sg_ilr
+"""personal pron""".
 pp3cno0_ilr :=  pp_ilr & 3per_ilr & 
-  [ SYNSEM.LOCAL.CAT.HEAD.MOD < > ]. 
+  [ SYNSEM.LOCAL.CAT.HEAD.MOD < > ]
+  """personal pron""". 
 
 
 ; -- adjectives
+
 a_ilr :=  infl-ltow-rule & 
   [ SYNSEM.LOCAL.CAT.HEAD adj ].
 
-a_sg_ilr :=  a_ilr & 3sg_ilr.
-a_pl_ilr :=  a_ilr & 3pl_ilr.
-a_fem-sg_ilr :=  a_ilr & fem_3sg_ilr.
-a_fem-pl_ilr :=  a_ilr & fem_3pl_ilr.
-a_masc-sg_ilr :=  a_ilr & masc_3sg_ilr.
-a_masc-pl_ilr :=  a_ilr & masc_3pl_ilr.
-a_neut-sg_ilr :=  a_ilr & neut_3sg_ilr.
+a_sg_ilr :=  a_ilr & 3sg_ilr
+"""adjective""".
+a_pl_ilr :=  a_ilr & 3pl_ilr
+"""adjective""".
+a_fem-sg_ilr :=  a_ilr & fem_3sg_ilr
+"""adjective""".
+a_fem-pl_ilr :=  a_ilr & fem_3pl_ilr
+"""adjective""".
+a_masc-sg_ilr :=  a_ilr & masc_3sg_ilr
+"""adjective""".
+a_masc-pl_ilr :=  a_ilr & masc_3pl_ilr
+"""adjective""".
+a_neut-sg_ilr :=  a_ilr & neut_3sg_ilr
+"""adjective""".
 
 
 ; -- clitics
@@ -437,6 +567,7 @@ pp1cs00_ilr := affx_1sg_ilr.
 p01cs00_ilr := affx_1sg_ilr.
 
 ; --- Common Nouns
+
 n_ilr :=  tmt-lex-rule & phrase-or-lexrule & 
   [ NEEDS-AFFIX +,
     INFLECTED +,
@@ -717,6 +848,7 @@ vppart_ilr :=  inflecting-lex-rule &
 
 
 ; --- enclitics (with infinitives, imperatives and gerunds)
+
 enclt_ilr := lex-rule & 
   [ NEEDS-AFFIX +,
     INFLECTED +,

--- a/irtypes.tdl
+++ b/irtypes.tdl
@@ -326,7 +326,7 @@ dt0cn0_ilr :=  dt_ilr
 
 ; -- exclamative det.
 
-de0ms0_ilr :=  de_ilr & masc_3sg_il
+de0ms0_ilr :=  de_ilr & masc_3sg_ilr
 """exclamative det""".
 de0mp0_ilr :=  de_ilr & masc_3pl_ilr
 """exclamative det""".
@@ -389,7 +389,7 @@ pi0fp00_ilr :=  pi_ilr & pl_ilr & fem_ilr
 """indefinite pron""". 
 pi0cs00_ilr :=  pi_ilr & sg_ilr
 """indefinite pron""".
-pi0cp00_ilr :=  pi_ilr & pl_il
+pi0cp00_ilr :=  pi_ilr & pl_ilr
 """indefinite pron""".
 pi0cc000_ilr :=  pi_ilr
 """indefinite pron""".

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -3731,71 +3731,87 @@ v_ppa-vp_inf-oc_lex := v_ditrans_cp_prop_inf & main-verb & basic-three-arg &
                                      [ LOCAL.CONT.HOOK.XARG #ind1 ] > ] ] ].
 |#
 
-; --- 1.3.3.7.3. ditransitive verbs taking interrogative clauses and IO 
-; (see transitive verbs taking interrogative clauses)
-v_ditrans_cp_ques_synsem := v_ditrans_cp_prop-or-ques_fin_synsem & 
+
+v_ditrans_cp_ques_synsem := v_ditrans_cp_prop-or-ques_fin_synsem &
   [ LOCAL.CAT.VAL.COMPS < synsem,
-                          [ LOCAL s_or_cp_fin_local & 
-                                  [ CAT.HEAD [ TAM.MOOD ind,
-                                               KEYS.ALT2KEY ques ] ] ] > ].
+                          [ LOCAL s_or_cp_fin_local & [ CAT.HEAD [ TAM.MOOD ind,
+                                                                   KEYS.ALT2KEY ques ] ] ] > ]
+  """
+  --- 1.3.3.7.3. ditransitive verbs taking interrogative clauses and IO
+  (see transitive verbs taking interrogative clauses)
+  """.
+
 
 v_ditrans_ques := v_ditrans_cp_prop-or-ques_fin &
-  [ ALTS.VCALT + ].
-
-; e.g. (me) preguntó (que) cómo lo habían hecho
-v_ppa*-cp_q-optcm_lex := v_ditrans_ques & main-verb & basic-three-arg & 
-  [ SYNSEM v_ditrans_cp_ques_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_ques_synsem, 
-                         VAL.COMPS < [ OPT + ] , synsem > ] ] ].
-
-;v_ppa*-cp_q-optcm_lex := v_ditrans_ques & main-verb & basic-three-arg & 
-;  [ SYNSEM v_ditrans_cp_ques_synsem &
-;           [ LOCAL.CAT.VAL.COMPS < [ OPT + ],  
-;                                   [ LOCAL.CONT.HOOK.INDEX.SF ques ] > ] ].
-
-; e.g. (me) chillar que dónde lo podía
-v_ppa*-cp_q-cm_lex := v_ditrans_ques & main-verb & basic-three-arg & 
-  [ SYNSEM v_ditrans_cp_ques_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_ques_synsem, 
-                         VAL.COMPS < [ OPT + ],  
-                                     [ LOCAL.CAT.HEAD comp & [ KEYS.ALTKEY prop ] ] > ] ] ].
-
-; e.g. (me) declaró *que cómo lo había hecho
-v_ppa*-cp_q_lex := v_ditrans_ques & main-verb & basic-three-arg & 
-  [ SYNSEM v_ditrans_cp_ques_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_ques_synsem, 
-                         VAL.COMPS < [ OPT + ], 
-                                     [ LOCAL.CAT.HEAD.KEYS.ALTKEY ques ] > ] ] ].
+  [ ALTS.VCALT + ]
+  """
+  
+  """.
 
 
-; --- 1.3.3.8. Transitive verb object to subject raising verbs (verbos de percepción)
-v_perception_synsem := v_trans_synsem & 
+v_ppa*-cp_q-optcm_lex := v_ditrans_ques & main-verb & basic-three-arg &
+  [ SYNSEM v_ditrans_cp_ques_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_ques_synsem,
+                                                    VAL.COMPS < [ OPT + ],
+                                                                synsem > ] ] ]
+  """
+  e.g. (me) preguntó (que) cómo lo habían hecho
+  """.
+
+
+v_ppa*-cp_q-cm_lex := v_ditrans_ques & main-verb & basic-three-arg &
+  [ SYNSEM v_ditrans_cp_ques_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_ques_synsem,
+                                                    VAL.COMPS < [ OPT + ],
+                                                                [ LOCAL.CAT.HEAD comp & [ KEYS.ALTKEY prop ] ] > ] ] ]
+  """
+  v_ppa*-cp_q-optcm_lex := v_ditrans_ques & main-verb & basic-three-arg &
+    [ SYNSEM v_ditrans_cp_ques_synsem &
+             [ LOCAL.CAT.VAL.COMPS < [ OPT + ],
+                                     [ LOCAL.CONT.HOOK.INDEX.SF ques ] > ] ].
+   e.g. (me) chillar que dónde lo podía
+  """.
+
+
+v_ppa*-cp_q_lex := v_ditrans_ques & main-verb & basic-three-arg &
+  [ SYNSEM v_ditrans_cp_ques_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_ques_synsem,
+                                                    VAL.COMPS < [ OPT + ],
+                                                                [ LOCAL.CAT.HEAD.KEYS.ALTKEY ques ] > ] ] ]
+  """
+  e.g. (me) declaró *que cómo lo había hecho
+  """.
+
+
+v_perception_synsem := v_trans_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
-                  VAL [ COMPS < [ OPT -, 
-                                  LOCAL np_acc_local & 
-                                        [ CAT.HEAD.KEYS.KEY non_modable_rel,
-                                          CONT.HOOK.INDEX #ind2 ],
-                                  NON-LOCAL.REL 0-dlist & [ LIST < > ] ],
-                                [ OPT -, 
-                                  LOCAL vp_local &
-                                        [ CAT [ MC -, 
-                                                HEAD.KEYS.KEY #ockey ],
-                                          CONT.HOOK [ XARG #ind2,
-                                                      LTOP #larg,
-                                                      INDEX.SF prop ] ] ] > ] ],
+                  VAL.COMPS < [ OPT -,
+                                LOCAL np_acc_local & [ CAT.HEAD.KEYS.KEY non_modable_rel,
+                                                       CONT.HOOK.INDEX #ind2 ],
+                                NON-LOCAL.REL 0-dlist & [ LIST < > ] ],
+                              [ OPT -,
+                                LOCAL vp_local & [ CAT [ MC -,
+                                                         HEAD.KEYS.KEY #ockey ],
+                                                   CONT.HOOK [ XARG #ind2,
+                                                               LTOP #larg,
+                                                               INDEX.SF prop ] ] ] > ],
             CONT [ RELS <! arg12-ev-relation !>,
                    HCONS <! qeq & [ HARG #harg,
                                     LARG #larg ] !> ] ],
     LKEYS [ KEYREL.ARG2 #harg,
-            --OCOMPKEY #ockey ] ].
+            --OCOMPKEY #ockey ] ]
+  """
+  --- 1.3.3.8. Transitive verb object to subject raising verbs (verbos de percepción)
+  """.
 
-v_perception := basic-main-verb & 
+
+v_perception := basic-main-verb &
   [ ALTS [ RCP -,
-           RFX -,  
+           RFX -,
            PASS +,
-           IMPERS + ] ].
+           IMPERS + ] ]
+  """
+  
+  """.
 
-; e.g. ver (to see), oir (to hear) (e.g. casi te oí decir)
+
 v_np-vp_inf-osr_lex := v_perception & basic-four-arg & 
   [ SYNSEM v_perception_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_perception_synsem, 
@@ -3805,498 +3821,676 @@ v_np-vp_inf-osr_lex := v_perception & basic-four-arg &
                                                       LOCAL vp_inf_local & 
                                                             [ CAT.VAL.CLTS #clts ] ] > >,
                                CLTS < #clt . #clts > ] ] ],
-    ARG-ST < #subj . < #comp1. < #comp2 . < #clt . #clts > > > > ].
-
-; e.g. sorprender  (to take by surprise) (e.g. la sorprendí robando)
-v_np-vp_ger-osr_lex := v_perception & basic-three-arg & 
-  [ SYNSEM v_perception_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_perception_synsem, 
-                         VAL.COMPS < [ OPT - ], 
-                                     [ OPT -, LOCAL vp_ger_local ] > ] ] ].
+    ARG-ST < #subj . < #comp1. < #comp2 . < #clt . #clts > > > > ]
+"""; e.g. ver (to see), oir (to hear) (e.g. casi te oí decir)
+""".
 
 
+v_np-vp_ger-osr_lex := v_perception & basic-three-arg &
+  [ SYNSEM v_perception_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_perception_synsem,
+                                               VAL.COMPS < [ OPT - ],
+                                                           [ OPT -,
+                                                             LOCAL vp_ger_local ] > ] ] ]
+  """
+  e.g. sorprender  (to take by surprise) (e.g. la sorprendí robando)
+  """.
 
-; --- 1.3.3.4. Symmetric verbs
 
-v_sym_synsem := arg1_lt & 
+v_sym_synsem := arg1_lt &
   [ LOCAL.CAT [ HEAD.INV -,
-                VAL.COMPS < [ LOCAL mrkd_np_local &
-                                    [ CAT.HEAD.KEYS [ KEY #ckey,
-                                                      ALTKEY non_modable_rel ] ] ],... > ],
-    LKEYS.--COMPKEY #ckey ].
+                VAL.COMPS < [ LOCAL mrkd_np_local & [ CAT.HEAD.KEYS [ KEY #ckey,
+                                                                      ALTKEY non_modable_rel ] ] ], ... > ],
+    LKEYS.--COMPKEY #ckey ]
+  """
+  --- 1.3.3.4. Symmetric verbs
+  """.
 
-v_sym := basic-main-verb & 
+
+v_sym := basic-main-verb &
   [ ALTS [ RCP -,
-           RFX - ] ].
+           RFX - ] ]
+  """
+  
+  """.
 
 
-; --- 1.3.3.4.1. Intransitive symmetric verbs taking marked NP / plural (or coord.) subject 
-v_sym_intr_mrkd_np_synsem := v_sym_synsem & 
+v_sym_intr_mrkd_np_synsem := v_sym_synsem &
   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #ind2 & ref-ind ] >,
             CONT [ RELS <! arg12-ev-relation !>,
                    HCONS <! !> ] ],
-    LKEYS.KEYREL.ARG2 #ind2 ].
+    LKEYS.KEYREL.ARG2 #ind2 ]
+  """
+  --- 1.3.3.4.1. Intransitive symmetric verbs taking marked NP / plural (or coord.) subject
+  """.
+
 
 v_sym_intr_mrkd_np := v_sym &
   [ ALTS [ PASS -,
-           VCALT - ] ].
+           VCALT - ] ]
+  """
+  
+  """.
 
-; e.g. conversar (to chat) (A conversa con B/A y B conversan); luchar (to fight) (A luchó con/contra B) 
-v_pp_e-sym_lex := v_sym_intr_mrkd_np & main-verb & basic-two-arg & 
+
+v_pp_e-sym_lex := v_sym_intr_mrkd_np & main-verb & basic-two-arg &
   [ ALTS.IMPERS +,
-    SYNSEM v_sym_intr_mrkd_np_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_intr_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+    SYNSEM v_sym_intr_mrkd_np_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_intr_mrkd_np_synsem,
+                                                     VAL.COMPS < [ OPT - ] > ] ] ]
+  """
+  e.g. conversar (to chat) (A conversa con B/A y B conversan); luchar (to fight) (A luchó con/contra B)
+  """.
 
-; e.g. colaborar (to collaborate)
-v_pp*_e-sym_lex := v_sym_intr_mrkd_np & main-verb & basic-two-arg & 
+
+v_pp*_e-sym_lex := v_sym_intr_mrkd_np & main-verb & basic-two-arg &
   [ ALTS.IMPERS +,
-    SYNSEM v_sym_intr_mrkd_np_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_intr_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
+    SYNSEM v_sym_intr_mrkd_np_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_intr_mrkd_np_synsem,
+                                                     VAL.COMPS < [ OPT + ] > ] ] ]
+  """
+  e.g. colaborar (to collaborate)
+  """.
 
-; e.g. A se pelea con B -> A y B se pelean; tu propuesta se adapta muy bien a la mía, 
+
 v_pp_e-sym-prn_lex := v_sym_intr_mrkd_np & main-vprn & basic-three-arg &
   [ ALTS.IMPERS -,
-    SYNSEM v_sym_intr_mrkd_np_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_intr_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+    SYNSEM v_sym_intr_mrkd_np_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_intr_mrkd_np_synsem,
+                                                     VAL.COMPS < [ OPT - ] > ] ] ]
+  """
+  e.g. A se pelea con B -> A y B se pelean; tu propuesta se adapta muy bien a la mía,
+  """.
 
 
-; --- 1.3.3.4.2. Intransitive symmetric verbs taking marked NP and marked completive clause (inf/fin) 
-; (s_ctrl) / pl. subject and marked completive clause 
-v_sym_intr_mrkd_np_mrkd_cp_prop_synsem := v_sym_synsem & 
+v_sym_intr_mrkd_np_mrkd_cp_prop_synsem := v_sym_synsem &
   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #ind3 & ref-ind ],
-                            [ LOCAL mrkd_or_unmrkd_cp_prop_or_ques_local &
-                                    [ CAT.HEAD.KEYS.KEY #ockey,
-                                      CONT.HOOK [ INDEX.SF prop,
-                                                  LTOP #larg ] ] ] >,
+                            [ LOCAL mrkd_or_unmrkd_cp_prop_or_ques_local & [ CAT.HEAD.KEYS.KEY #ockey,
+                                                                             CONT.HOOK [ INDEX.SF prop,
+                                                                                         LTOP #larg ] ] ] >,
             CONT [ HCONS <! qeq & [ HARG #harg,
                                     LARG #larg ] !>,
                    RELS <! arg123-ev-relation !> ] ],
-    LKEYS [ KEYREL [ ARG2 #harg, 
+    LKEYS [ KEYREL [ ARG2 #harg,
                      ARG3 #ind3 ],
-            --OCOMPKEY #ockey ] ].
+            --OCOMPKEY #ockey ] ]
+  """
+  --- 1.3.3.4.2. Intransitive symmetric verbs taking marked NP and marked completive clause (inf/fin)
+  (s_ctrl) / pl. subject and marked completive clause
+  """.
+
 
 v_sym_intr_mrkd_np_mrkd_cp_prop_inf_synsem := v_sym_intr_mrkd_np_mrkd_cp_prop_synsem &
-  [ LOCAL.CAT.VAL.COMPS < synsem,
-                          [ LOCAL mrkd_cp_prop_inf_local ] > ].
+  [ LOCAL.CAT.VAL.COMPS < synsem, [ LOCAL mrkd_cp_prop_inf_local ] > ]
+  """
+  
+  """.
+
 
 v_sym_intr_mrkd_np_mrkd_cp_prop_fin_synsem := v_sym_intr_mrkd_np_mrkd_cp_prop_synsem &
-  [ LOCAL.CAT.VAL.COMPS < synsem,
-                          [ LOCAL mrkd_cp_prop_fin_local ] > ]. 
+  [ LOCAL.CAT.VAL.COMPS < synsem, [ LOCAL mrkd_cp_prop_fin_local ] > ]
+  """
+  
+  """.
 
-v_sym_intr_mrkd_np_mrkd_cp_prop_fin := basic-main-verb & 
+
+v_sym_intr_mrkd_np_mrkd_cp_prop_fin := basic-main-verb &
   [ ALTS [ PASS -,
            IMPERS -,
-           VCALT + ] ].
-
-; e.g. quedé con ella en ir al cine / quedamos en ir al cine
-v_pp-pp_e-e-cp-p-sym_lex := v_sym_intr_mrkd_np_mrkd_cp_prop_fin & main-verb & basic-three-arg & 
-  [ SYNSEM v_sym_intr_mrkd_np_mrkd_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_intr_mrkd_np_mrkd_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+           VCALT + ] ]
+  """
+  
+  """.
 
 
-; --- 1.3.3.4.3. Transitive symmetric verbs taking marked NP and completive clause (inf/fin) (s_ctrl) / 
-;     pl. subject and completive clause 
-v_sym_trans_cp_prop_mrkd_np_synsem := v_sym_synsem & 
+v_pp-pp_e-e-cp-p-sym_lex := v_sym_intr_mrkd_np_mrkd_cp_prop_fin & main-verb & basic-three-arg &
+  [ SYNSEM v_sym_intr_mrkd_np_mrkd_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_intr_mrkd_np_mrkd_cp_prop_fin_synsem,
+                                                                      VAL.COMPS < [ OPT - ],
+                                                                                  [ OPT - ] > ] ] ]
+  """
+  e.g. quedé con ella en ir al cine / quedamos en ir al cine
+  """.
+
+
+v_sym_trans_cp_prop_mrkd_np_synsem := v_sym_synsem &
   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #ind3 & ref-ind ],
-                            [ LOCAL v_local &  
-                                    [ CAT.MC -,
-                                      CONT.HOOK [ INDEX.SF prop,
-                                                  LTOP #larg ] ] ] >,
+                            [ LOCAL v_local & [ CAT.MC -,
+                                                CONT.HOOK [ INDEX.SF prop,
+                                                            LTOP #larg ] ] ] >,
             CONT [ RELS <! arg123-ev-relation !>,
                    HCONS <! [ HARG #harg,
                               LARG #larg ] !> ] ],
-    LKEYS.KEYREL [ ARG2 #harg, 
-                   ARG3 #ind3 ] ].
+    LKEYS.KEYREL [ ARG2 #harg,
+                   ARG3 #ind3 ] ]
+  """
+  --- 1.3.3.4.3. Transitive symmetric verbs taking marked NP and completive clause (inf/fin) (s_ctrl) /
+      pl. subject and completive clause
+  """.
+
 
 v_sym_trans_cp_prop_inf_mrkd_np_synsem := v_sym_trans_cp_prop_mrkd_np_synsem &
   [ LOCAL.CAT.VAL.COMPS < synsem,
-                          [ LOCAL vp_inf_local & 
-                                  [ CAT.VAL.SUBJ < [ NON-LOCAL [ SLASH 0-dlist,
-                                                                 REL 0-dlist,
-                                                                 QUE 0-dlist ] ] > ] ] > ].
+                          [ LOCAL vp_inf_local & [ CAT.VAL.SUBJ < [ NON-LOCAL [ SLASH 0-dlist,
+                                                                                REL 0-dlist,
+                                                                                QUE 0-dlist ] ] > ] ] > ]
+  """
+  
+  """.
+
 
 v_sym_trans_cp_prop_fin_mrkd_np_synsem := v_sym_trans_cp_prop_mrkd_np_synsem &
-  [ LOCAL.CAT.VAL.COMPS < synsem,
-                          [ LOCAL s_or_cp_fin_local ] > ].
+  [ LOCAL.CAT.VAL.COMPS < synsem, [ LOCAL s_or_cp_fin_local ] > ]
+  """
+  
+  """.
+
 
 v_sym_trans_cp_prop_fin_mrkd_np := v_sym &
   [ ALTS [ PASS -,
            IMPERS -,
-           VCALT + ] ].
+           VCALT + ] ]
+  """
+  
+  """.
 
 
-; e.g. acordar (to agree) (A acordó con B no hablar/que no hablarían -> A y B acordaron no hablar/que no hablarían)
-v_pp-cp_e-p-sym_lex := v_sym_trans_cp_prop_fin_mrkd_np & main-verb & basic-three-arg & 
-  [ SYNSEM v_sym_trans_cp_prop_fin_mrkd_np_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_trans_cp_prop_fin_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+v_pp-cp_e-p-sym_lex := v_sym_trans_cp_prop_fin_mrkd_np & main-verb & basic-three-arg &
+  [ SYNSEM v_sym_trans_cp_prop_fin_mrkd_np_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_trans_cp_prop_fin_mrkd_np_synsem,
+                                                                  VAL.COMPS < [ OPT - ],
+                                                                              [ OPT - ] > ] ] ]
+  """
+  e.g. acordar (to agree) (A acordó con B no hablar/que no hablarían -> A y B acordaron no hablar/que no hablarían)
+  """.
 
 
-; --- 1.3.3.4.4. Transitive symmetric verbs taking DO and marked NP / plural (or coord.) DO
-v_sym_trans_np_mrkd_np_synsem := v_trans_np_synsem & 
+v_sym_trans_np_mrkd_np_synsem := v_trans_np_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
                   VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY non_modable_rel ],
-                              [ LOCAL mrkd_np_local &
-                                      [ CAT.HEAD.KEYS [ KEY #ockey,
-                                                        ALTKEY non_modable_rel ],
-                                        CONT.HOOK.INDEX ref-ind & #ind3 ] ] > ],
+                              [ LOCAL mrkd_np_local & [ CAT.HEAD.KEYS [ KEY #ockey,
+                                                                        ALTKEY non_modable_rel ],
+                                                        CONT.HOOK.INDEX ref-ind & #ind3 ] ] > ],
             CONT [ RELS <! arg123-ev-relation !>,
                    HCONS <! !> ] ],
     LKEYS [ KEYREL.ARG3 #ind3,
-            --OCOMPKEY #ockey ] ].
+            --OCOMPKEY #ockey ] ]
+  """
+  --- 1.3.3.4.4. Transitive symmetric verbs taking DO and marked NP / plural (or coord.) DO
+  """.
 
-v_sym_trans_np_mrkd_np_pl_do_synsem := v_sym_trans_np_mrkd_np_synsem.
-v_sym_trans_np_mrkd_np_pl_subj_synsem := v_sym_trans_np_mrkd_np_synsem.
+
+v_sym_trans_np_mrkd_np_pl_do_synsem := v_sym_trans_np_mrkd_np_synsem
+  """
+  
+  """.
+
+
+v_sym_trans_np_mrkd_np_pl_subj_synsem := v_sym_trans_np_mrkd_np_synsem
+  """
+  
+  """.
+
 
 v_sym_trans_np_mrkd_np := v_sym &
   [ ALTS [ PASS +,
            IMPERS +,
-           VCALT - ] ].
-
-; e.g. Ambos grupos comparten un fondo genético común.
-v_np-pp*_e-sym-sbj-pl_lex := v_sym_trans_np_mrkd_np & main-verb & basic-three-arg & 
-  [ SYNSEM v_sym_trans_np_mrkd_np_pl_subj_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_trans_np_mrkd_np_pl_subj_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
-
-; e.g. polarización que confrontará (la docencia a/con la investigación/la docencia y la investigación)
-v_np-pp_e-sym_lex := v_sym_trans_np_mrkd_np & main-verb & basic-three-arg & 
-  [ SYNSEM v_sym_trans_np_mrkd_np_pl_do_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_trans_np_mrkd_np_pl_do_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
-
-; e.g. compatibilizar
-v_np-pp*_e-sym_lex := v_sym_trans_np_mrkd_np & main-verb & basic-three-arg & 
-  [ SYNSEM v_sym_trans_np_mrkd_np_pl_do_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_trans_np_mrkd_np_pl_do_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
+           VCALT - ] ]
+  """
+  
+  """.
 
 
+v_np-pp*_e-sym-sbj-pl_lex := v_sym_trans_np_mrkd_np & main-verb & basic-three-arg &
+  [ SYNSEM v_sym_trans_np_mrkd_np_pl_subj_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_trans_np_mrkd_np_pl_subj_synsem,
+                                                                 VAL.COMPS < [ OPT - ],
+                                                                             [ OPT + ] > ] ] ]
+  """
+  e.g. Ambos grupos comparten un fondo genético común.
+  """.
 
-; --- 1.3.3.5. Verbs taking predicative complements
 
-v_prd-comp_synsem := arg1_lt & 
+v_np-pp_e-sym_lex := v_sym_trans_np_mrkd_np & main-verb & basic-three-arg &
+  [ SYNSEM v_sym_trans_np_mrkd_np_pl_do_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_trans_np_mrkd_np_pl_do_synsem,
+                                                               VAL.COMPS < [ OPT - ],
+                                                                           [ OPT - ] > ] ] ]
+  """
+  e.g. polarización que confrontará (la docencia a/con la investigación/la docencia y la investigación)
+  """.
+
+
+v_np-pp*_e-sym_lex := v_sym_trans_np_mrkd_np & main-verb & basic-three-arg &
+  [ SYNSEM v_sym_trans_np_mrkd_np_pl_do_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_sym_trans_np_mrkd_np_pl_do_synsem,
+                                                               VAL.COMPS < [ OPT - ],
+                                                                           [ OPT + ] > ] ] ]
+  """
+  e.g. compatibilizar
+  """.
+
+
+v_prd-comp_synsem := arg1_lt &
   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY #ckey ], ... >,
             CONT [ RELS <! arg12-ev-relation !>,
-		   HCONS <! qeq !> ] ],
-    LKEYS.--COMPKEY #ckey ].
+                   HCONS <! qeq !> ] ],
+    LKEYS.--COMPKEY #ckey ]
+  """
+  --- 1.3.3.5. Verbs taking predicative complements
+  """.
 
 
-; --- 1.3.3.5.1. verbs taking a predicative complement
-
-v_seq_synsem := v_prd-comp_synsem & 
+v_seq_synsem := v_prd-comp_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
-                  VAL.COMPS < [ LOCAL prd_local & 
-                                      [ CONT.HOOK [ LTOP #larg,
-                                                    XARG #xarg ] ],
+                  VAL.COMPS < [ LOCAL prd_local & [ CONT.HOOK [ LTOP #larg,
+                                                                XARG #xarg ] ],
                                 NON-LOCAL [ REL 0-dlist,
                                             QUE 0-dlist ] ] > ],
-            CONT [ HCONS <! [ HARG #harg,
-                              LARG #larg ] !> ] ], 
-    LKEYS.KEYREL arg12-ev-relation & 
-                 [ ARG1 #xarg,
-                   ARG2 #harg ] ].
+            CONT.HCONS <! [ HARG #harg,
+                            LARG #larg ] !> ],
+    LKEYS.KEYREL arg12-ev-relation & [ ARG1 #xarg,
+                                       ARG2 #harg ] ]
+  """
+  --- 1.3.3.5.1. verbs taking a predicative complement
+  """.
+
 
 v_ap_seq_synsem := v_seq_synsem &
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD adj,
-                            NON-LOCAL.SLASH 0-dlist ] > ].
+                            NON-LOCAL.SLASH 0-dlist ] > ]
+  """
+  
+  """.
+
 
 v_pp_seq_synsem := v_seq_synsem &
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD adp & [ KEYS.ALTKEY non_modable_rel ],
-                            NON-LOCAL.SLASH 0-dlist ] > ].
+                            NON-LOCAL.SLASH 0-dlist ] > ]
+  """
+  
+  """.
+
 
 v_pp_aj-seq_synsem := v_seq_synsem &
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD adp & [ KEYS.ALTKEY basic_adj_rel ],
-                            NON-LOCAL.SLASH 0-dlist ] > ].
+                            NON-LOCAL.SLASH 0-dlist ] > ]
+  """
+  
+  """.
+
 
 v_pp_vp-inf-seq_synsem := v_seq_synsem &
-  [ LOCAL.CAT.VAL.COMPS < [  LOCAL [ CAT.HEAD adp & 
-                                              [ KEYS.ALTKEY v_event_rel,
-                                                MOD < [ LOCAL.CAT.HEAD noun ] > ],
-                                     CONT.HOOK.INDEX.SF prop ] ] > ].
+  [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.HEAD adp & [ KEYS.ALTKEY v_event_rel,
+                                                     MOD < [ LOCAL.CAT.HEAD noun ] > ],
+                                    CONT.HOOK.INDEX.SF prop ] ] > ]
+  """
+  
+  """.
 
-v_xp_seq := basic-main-verb & 
-  [ ALTS [ RCP -, 
+
+v_xp_seq := basic-main-verb &
+  [ ALTS [ RCP -,
            RFX -,
            PASS -,
            IMPERS -,
-           VCALT - ], 
-    SYNSEM v_seq_synsem ].
+           VCALT - ],
+    SYNSEM v_seq_synsem ]
+  """
+  
+  """.
 
 
-; e.g. acabar, caer, permanecer, quedar, seguir, terminar (el anciano acabó/cayó/terminó enfermo)
-v_ap_seq_lex := v_xp_seq & main-verb & basic-two-arg & 
-  [ SYNSEM v_ap_seq_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ap_seq_synsem,
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+v_ap_seq_lex := v_xp_seq & main-verb & basic-two-arg &
+  [ SYNSEM v_ap_seq_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ap_seq_synsem,
+                                           VAL.COMPS < [ OPT - ] > ] ] ]
+  """
+  e.g. acabar, caer, permanecer, quedar, seguir, terminar (el anciano acabó/cayó/terminó enfermo)
+  """.
 
-; e.g. ejercer, pasar, trabajar (trabaja de/como camarera)
+
 v_pp_seq_lex := v_xp_seq & main-verb & basic-two-arg &
-  [ SYNSEM v_pp_seq_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_pp_seq_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+  [ SYNSEM v_pp_seq_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_pp_seq_synsem,
+                                           VAL.COMPS < [ OPT - ] > ] ] ]
+  """
+  e.g. ejercer, pasar, trabajar (trabaja de/como camarera)
+  """.
 
-; e.g. alardear, chulear, fardar, presumir (alardea de listo, presumía muy orgulloso de seductor con las mujeres) 
+
 v_pp_aj-seq_lex := v_xp_seq & main-verb & basic-two-arg &
-  [ SYNSEM v_pp_aj-seq_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_pp_aj-seq_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+  [ SYNSEM v_pp_aj-seq_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_pp_aj-seq_synsem,
+                                              VAL.COMPS < [ OPT - ] > ] ] ]
+  """
+  e.g. alardear, chulear, fardar, presumir (alardea de listo, presumía muy orgulloso de seductor con las mujeres)
+  """.
 
-; e.g. queda mucho por hacer
-v_pp_vp-inf-seq_lex := v_xp_seq & main-verb & basic-two-arg & 
-  [ SYNSEM v_pp_vp-inf-seq_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_pp_vp-inf-seq_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
 
-; e.g. creerse, encontrarse,... (se cree muy listo)
-v_ap_seq-prn_lex := v_xp_seq & main-vprn & basic-three-arg & 
-  [ SYNSEM v_ap_seq_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ap_seq_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+v_pp_vp-inf-seq_lex := v_xp_seq & main-verb & basic-two-arg &
+  [ SYNSEM v_pp_vp-inf-seq_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_pp_vp-inf-seq_synsem,
+                                                  VAL.COMPS < [ OPT - ] > ] ] ]
+  """
+  e.g. queda mucho por hacer
+  """.
 
-; e.g. se mostró muy crítico
-v_ap*_seq-prn_lex := v_xp_seq & main-vprn & basic-three-arg & 
-  [ SYNSEM v_ap_seq_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ap_seq_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
 
-; e.g. perfilarse,... (se perfila como campeón)
-v_pp_seq-prn_lex := v_xp_seq & main-vprn & basic-three-arg & 
-  [ SYNSEM v_pp_seq_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_pp_seq_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
- 
+v_ap_seq-prn_lex := v_xp_seq & main-vprn & basic-three-arg &
+  [ SYNSEM v_ap_seq_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ap_seq_synsem,
+                                           VAL.COMPS < [ OPT - ] > ] ] ]
+  """
+  e.g. creerse, encontrarse,... (se cree muy listo)
+  """.
 
-; --- 1.3.3.5.2. verbs taking a predicative complement and IO
 
-v_seq-ppa_synsem := v_prd-comp_synsem & 
-   [ LOCAL.CAT [ HEAD.INV -,
-                 VAL.COMPS < [ ],
-                             [ LOCAL dative_local & 
-                                     [ CAT.HEAD.KEYS.KEY #ockey,
-                                       CONT.HOOK.INDEX #arg3 ],
-                               NON-LOCAL.REL 0-dlist & [ LIST < > ] ] > ], 
-     LKEYS [ KEYREL arg123-ev-relation & 
-                    [ ARG3 #arg3 ],
-             --OCOMPKEY #ockey ] ].
+v_ap*_seq-prn_lex := v_xp_seq & main-vprn & basic-three-arg &
+  [ SYNSEM v_ap_seq_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ap_seq_synsem,
+                                           VAL.COMPS < [ OPT + ] > ] ] ]
+  """
+  e.g. se mostró muy crítico
+  """.
+
+
+v_pp_seq-prn_lex := v_xp_seq & main-vprn & basic-three-arg &
+  [ SYNSEM v_pp_seq_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_pp_seq_synsem,
+                                           VAL.COMPS < [ OPT - ] > ] ] ]
+  """
+  e.g. perfilarse,... (se perfila como campeón)
+  """.
+
+
+v_seq-ppa_synsem := v_prd-comp_synsem &
+  [ LOCAL.CAT [ HEAD.INV -,
+                VAL.COMPS < [ ],
+                            [ LOCAL dative_local & [ CAT.HEAD.KEYS.KEY #ockey,
+                                                     CONT.HOOK.INDEX #arg3 ],
+                              NON-LOCAL.REL 0-dlist & [ LIST < > ] ] > ],
+    LKEYS [ KEYREL arg123-ev-relation & [ ARG3 #arg3 ],
+            --OCOMPKEY #ockey ] ]
+  """
+  --- 1.3.3.5.2. verbs taking a predicative complement and IO
+  """.
+
 
 v_ap-ppa_synsem := v_seq-ppa_synsem &
-   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL prd_local & 
-                                     [ CAT.HEAD adj, 
-                                       CONT.HOOK [ LTOP #larg,
-                                                   XARG #xarg ] ] ],
-                               [ ] >,
-             CONT.HCONS <! [ HARG #harg,
-                             LARG #larg ] !> ], 
-     LKEYS.KEYREL arg123-ev-relation & 
-                  [ ARG1 #xarg,
-                    ARG2 #harg ] ].
+  [ LOCAL [ CAT.VAL.COMPS < [ LOCAL prd_local & [ CAT.HEAD adj,
+                                                  CONT.HOOK [ LTOP #larg,
+                                                              XARG #xarg ] ] ],
+                            [ ] >,
+            CONT.HCONS <! [ HARG #harg,
+                            LARG #larg ] !> ],
+    LKEYS.KEYREL arg123-ev-relation & [ ARG1 #xarg,
+                                        ARG2 #harg ] ]
+  """
+  
+  """.
+
 
 v_np-ppa_synsem := v_seq-ppa_synsem &
-   [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_unmrkd_local & 
-                                   [ CAT.HEAD.KEYS.KEY non_modable_rel,
-                                     CONT.HOOK.INDEX #arg2 & ref-ind ] ],
-                           [ ] >, 
-     LKEYS.KEYREL arg123-ev-relation & 
-                  [ ARG2 #arg2 ] ].
+  [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_unmrkd_local & [ CAT.HEAD.KEYS.KEY non_modable_rel,
+                                                          CONT.HOOK.INDEX #arg2 & ref-ind ] ],
+                          [ ] >,
+    LKEYS.KEYREL arg123-ev-relation & [ ARG2 #arg2 ] ]
+  """
+  
+  """.
 
-v_xp-ppa_seq := basic-main-verb & 
-  [ ALTS [ RCP -, 
+
+v_xp-ppa_seq := basic-main-verb &
+  [ ALTS [ RCP -,
            RFX -,
            PASS -,
            IMPERS -,
-           VCALT - ] ].
-
-; e.g. resultar ((le) resultaba incómodo)
-v_ap-ppa*_seq_lex := v_xp-ppa_seq & main-verb & basic-three-arg & 
-  [ SYNSEM v_ap-ppa_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ap-ppa_synsem,
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
-
-; e.g. me parece un bombazo
-v_np-ppa*_seq_lex := v_xp-ppa_seq & main-verb & basic-three-arg & 
-  [ SYNSEM v_np-ppa_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_np-ppa_synsem,
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
+           VCALT - ] ]
+  """
+  
+  """.
 
 
-; --- 1.3.3.5.3. verbs taking a predicative complement and DO
-; Including verbs taking ´cláusulas mínimas' (in fact they form just one constituent)
-; e.g. eligieron [a Tomás director del departamento]/eligieron [director a Tomás]/eligieron [de director 
-; a Tomás] Tomás fue elegido director del departamento/a Tomás lo eligieron director del departamento.
-; Faltan verbos como considerar, percibir (v_cp_prop_ap) y esgrimir  (v_cp_prop_pp*)!!!
+v_ap-ppa*_seq_lex := v_xp-ppa_seq & main-verb & basic-three-arg &
+  [ SYNSEM v_ap-ppa_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ap-ppa_synsem,
+                                           VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+  """
+  e.g. resultar ((le) resultaba incómodo)
+  """.
 
-v_np-predxp_synsem := arg1_lt & 
+
+v_np-ppa*_seq_lex := v_xp-ppa_seq & main-verb & basic-three-arg &
+  [ SYNSEM v_np-ppa_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_np-ppa_synsem,
+                                           VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+  """
+  e.g. me parece un bombazo
+  """.
+
+
+v_np-predxp_synsem := arg1_lt &
   [ LOCAL [ CAT [ HEAD.INV -,
-                  VAL.COMPS < [ LOCAL np_acc_local & 
-                                      [ CAT.HEAD.KEYS.KEY #ckey & non_modable_rel ],
+                  VAL.COMPS < [ LOCAL np_acc_local & [ CAT.HEAD.KEYS.KEY #ckey & non_modable_rel ],
                                 NON-LOCAL.REL 0-dlist & [ LIST < > ] ],
                               [ LOCAL.CAT.HEAD.KEYS.KEY #ockey ] > ],
-            CONT.RELS <! arg12-ev-relation !> ], 
+            CONT.RELS <! arg12-ev-relation !> ],
     LKEYS [ --COMPKEY #ckey,
-            --OCOMPKEY #ockey ] ].
+            --OCOMPKEY #ockey ] ]
+  """
+  --- 1.3.3.5.3. verbs taking a predicative complement and DO
+  Including verbs taking ´cláusulas mínimas' (in fact they form just one constituent)
+  e.g. eligieron [a Tomás director del departamento]/eligieron [director a Tomás]/eligieron [de director
+  a Tomás] Tomás fue elegido director del departamento/a Tomás lo eligieron director del departamento.
+  Faltan verbos como considerar, percibir (v_cp_prop_ap) y esgrimir  (v_cp_prop_pp*)!!!
+  """.
+
 
 v_np-np_synsem := v_np-predxp_synsem &
   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #ind2 ],
-                            [ LOCAL np_acc_unmrkd_local & 
-                                   [ CAT.HEAD.KEYS.KEY non_modable_rel,
-                                     CONT.HOOK.INDEX #arg3 & ref-ind ] ] >,
-            CONT.HCONS <! qeq !> ], 
-     LKEYS.KEYREL arg123-ev-relation & 
-                  [ ARG2 #ind2,
-                    ARG3 #arg3 ] ].
+                            [ LOCAL np_acc_unmrkd_local & [ CAT.HEAD.KEYS.KEY non_modable_rel,
+                                                            CONT.HOOK.INDEX #arg3 & ref-ind ] ] >,
+            CONT.HCONS <! qeq !> ],
+    LKEYS.KEYREL arg123-ev-relation & [ ARG2 #ind2,
+                                        ARG3 #arg3 ] ]
+  """
+  
+  """.
+
 
 v_np-xp_synsem := v_np-predxp_synsem &
   [ LOCAL [ CAT.VAL.COMPS < [ ],
-                            [ LOCAL prd_local & 
-                                    [ CONT.HOOK.LTOP #larg ] ] >,
-            CONT.HCONS <! [ LARG #larg ] !> ] ].
+                            [ LOCAL prd_local & [ CONT.HOOK.LTOP #larg ] ] >,
+            CONT.HCONS <! [ LARG #larg ] !> ] ]
+  """
+  
+  """.
 
 
-v_np-xp_oeq_synsem := v_np-xp_synsem & 
-   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #ind2 ],
-                             [ LOCAL.CONT.HOOK.XARG #ind2 ] >,
-             CONT.HCONS <! [ HARG #harg ] !> ], 
-     LKEYS.KEYREL arg123-ev-relation & 
-                  [ ARG2 #ind2,
-                    ARG3 #harg ] ].
+v_np-xp_oeq_synsem := v_np-xp_synsem &
+  [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #ind2 ],
+                            [ LOCAL.CONT.HOOK.XARG #ind2 ] >,
+            CONT.HCONS <! [ HARG #harg ] !> ],
+    LKEYS.KEYREL arg123-ev-relation & [ ARG2 #ind2,
+                                        ARG3 #harg ] ]
+  """
+  
+  """.
 
-v_np-xp_sor_synsem := v_np-xp_synsem & 
+
+v_np-xp_sor_synsem := v_np-xp_synsem &
   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #ind ],
                             [ LOCAL.CONT.HOOK.XARG #ind ] >,
             CONT.HCONS <! [ HARG #harg ] !> ],
-    LKEYS.KEYREL.ARG2 #harg ].
+    LKEYS.KEYREL.ARG2 #harg ]
+  """
+  
+  """.
 
 
-v_np-ap_oeq_synsem := v_np-xp_oeq_synsem & 
-  [ LOCAL.CAT.VAL.COMPS < [ ], [ LOCAL.CAT.HEAD adj ] > ]. 
+v_np-ap_oeq_synsem := v_np-xp_oeq_synsem &
+  [ LOCAL.CAT.VAL.COMPS < [ ], [ LOCAL.CAT.HEAD adj ] > ]
+  """
+  
+  """.
 
-v_np-pp_oeq_synsem := v_np-xp_oeq_synsem & 
-  [ LOCAL.CAT.VAL.COMPS < [ ], [ LOCAL.CAT.HEAD adp & [ KEYS.ALTKEY non_modable_rel ] ] > ].
 
-v_np-pp_aj-oeq_synsem := v_np-xp_oeq_synsem & 
-  [ LOCAL.CAT.VAL.COMPS < [ ], [ LOCAL.CAT.HEAD adp & [ KEYS.ALTKEY basic_adj_rel ] ] > ].
+v_np-pp_oeq_synsem := v_np-xp_oeq_synsem &
+  [ LOCAL.CAT.VAL.COMPS < [ ],
+                          [ LOCAL.CAT.HEAD adp & [ KEYS.ALTKEY non_modable_rel ] ] > ]
+  """
+  
+  """.
+
+
+v_np-pp_aj-oeq_synsem := v_np-xp_oeq_synsem &
+  [ LOCAL.CAT.VAL.COMPS < [ ],
+                          [ LOCAL.CAT.HEAD adp & [ KEYS.ALTKEY basic_adj_rel ] ] > ]
+  """
+  
+  """.
 
 
 v_np-ap_sor_synsem := v_np-xp_sor_synsem &
-  [ LOCAL.CAT.VAL.COMPS < [ ], [ LOCAL.CAT.HEAD adj ] > ]. 
+  [ LOCAL.CAT.VAL.COMPS < [ ], [ LOCAL.CAT.HEAD adj ] > ]
+  """
+  
+  """.
+
 
 v_np-pp_sor_synsem := v_np-xp_sor_synsem &
-  [ LOCAL.CAT.VAL.COMPS < [ ], [ LOCAL.CAT.HEAD adp & [ KEYS.ALTKEY non_modable_rel ] ] > ].
+  [ LOCAL.CAT.VAL.COMPS < [ ],
+                          [ LOCAL.CAT.HEAD adp & [ KEYS.ALTKEY non_modable_rel ] ] > ]
+  """
+  
+  """.
+
 
 v_np-pp_aj-sor_synsem := v_np-xp_sor_synsem &
-  [ LOCAL.CAT.VAL.COMPS < [ ], [ LOCAL.CAT.HEAD adp & [ KEYS.ALTKEY basic_adj_rel ] ] > ].
+  [ LOCAL.CAT.VAL.COMPS < [ ],
+                          [ LOCAL.CAT.HEAD adp & [ KEYS.ALTKEY basic_adj_rel ] ] > ]
+  """
+  
+  """.
 
 
-v_np-xp := basic-main-verb & 
+v_np-xp := basic-main-verb &
   [ ALTS [ PASS +,
            IMPERS +,
            RCP -,
-           VCALT - ] ].
+           VCALT - ] ]
+  """
+  
+  """.
 
 
-; e.g. eso se considera plagio
-v_np-np_sor-rfx_lex := v_np-xp & main-verb & basic-three-arg & 
+v_np-np_sor-rfx_lex := v_np-xp & main-verb & basic-three-arg &
   [ ALTS.RFX -,
-    SYNSEM v_np-np_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_np-np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+    SYNSEM v_np-np_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_np-np_synsem,
+                                          VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]
+  """
+  e.g. eso se considera plagio
+  """.
 
-; e.g. dejar (lo dejaron KO)
-v_np-ap_sor_lex := v_np-xp & main-verb & basic-three-arg & 
+
+v_np-ap_sor_lex := v_np-xp & main-verb & basic-three-arg &
   [ ALTS.RFX -,
-    SYNSEM v_np-ap_sor_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_np-ap_sor_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+    SYNSEM v_np-ap_sor_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_np-ap_sor_synsem,
+                                              VAL.COMPS < [ OPT - ],
+                                                          [ OPT - ] > ] ] ]
+  """
+  e.g. dejar (lo dejaron KO)
+  """.
 
-; e.g. declarar, proclamar (lo declararon culpable)
-v_np-ap_sor-rfx_lex := v_np-xp & main-verb & basic-three-arg & 
+
+v_np-ap_sor-rfx_lex := v_np-xp & main-verb & basic-three-arg &
   [ ALTS.RFX +,
-    SYNSEM v_np-ap_sor_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_np-ap_sor_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+    SYNSEM v_np-ap_sor_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_np-ap_sor_synsem,
+                                              VAL.COMPS < [ OPT - ],
+                                                          [ OPT - ] > ] ] ]
+  """
+  e.g. declarar, proclamar (lo declararon culpable)
+  """.
 
-; e.g. dar, calificar, tomar,... (e.g. me tomas por tonto?)
-v_np-pp_sor_lex := v_np-xp & main-verb & basic-three-arg & 
+
+v_np-pp_sor_lex := v_np-xp & main-verb & basic-three-arg &
   [ ALTS.RFX -,
-    SYNSEM v_np-pp_sor_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_np-pp_sor_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+    SYNSEM v_np-pp_sor_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_np-pp_sor_synsem,
+                                              VAL.COMPS < [ OPT - ],
+                                                          [ OPT - ] > ] ] ]
+  """
+  e.g. dar, calificar, tomar,... (e.g. me tomas por tonto?)
+  """.
 
-; e.g. proclamar (lo proclamaron como...)
-v_np-pp_sor-rfx_lex := v_np-xp & main-verb & basic-three-arg & 
+
+v_np-pp_sor-rfx_lex := v_np-xp & main-verb & basic-three-arg &
   [ ALTS.RFX +,
-    SYNSEM v_np-pp_sor_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_np-pp_sor_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+    SYNSEM v_np-pp_sor_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_np-pp_sor_synsem,
+                                              VAL.COMPS < [ OPT - ],
+                                                          [ OPT - ] > ] ] ]
+  """
+  e.g. proclamar (lo proclamaron como...)
+  """.
 
 
-; e.g. distrazar de
-v_np-pp*_oeq-rfx_lex := v_np-xp & main-verb & basic-three-arg & 
+v_np-pp*_oeq-rfx_lex := v_np-xp & main-verb & basic-three-arg &
   [ ALTS.RFX +,
-    SYNSEM v_np-pp_oeq_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_np-pp_oeq_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
+    SYNSEM v_np-pp_oeq_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_np-pp_oeq_synsem,
+                                              VAL.COMPS < [ OPT - ],
+                                                          [ OPT + ] > ] ] ]
+  """
+  e.g. distrazar de
+  """.
 
-; e.g. la combinación se evalúa como ineficiente.
-v_np-pp_aj-oeq_lex := v_np-xp & main-verb & basic-three-arg & 
+
+v_np-pp_aj-oeq_lex := v_np-xp & main-verb & basic-three-arg &
   [ ALTS.RFX -,
-    SYNSEM v_np-pp_aj-oeq_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_np-pp_aj-oeq_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+    SYNSEM v_np-pp_aj-oeq_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_np-pp_aj-oeq_synsem,
+                                                 VAL.COMPS < [ OPT - ],
+                                                             [ OPT - ] > ] ] ]
+  """
+  e.g. la combinación se evalúa como ineficiente.
+  """.
 
-; e.g. un libro que no vaciló en calificar de importante
-v_np-pp_aj-oeq-rfx_lex := v_np-xp & main-verb & basic-three-arg & 
+
+v_np-pp_aj-oeq-rfx_lex := v_np-xp & main-verb & basic-three-arg &
   [ ALTS.RFX +,
-    SYNSEM v_np-pp_aj-oeq_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_np-pp_aj-oeq_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+    SYNSEM v_np-pp_aj-oeq_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_np-pp_aj-oeq_synsem,
+                                                 VAL.COMPS < [ OPT - ],
+                                                             [ OPT - ] > ] ] ]
+  """
+  e.g. un libro que no vaciló en calificar de importante
+  """.
 
-
-
-
-; --- 1.5. Copula verbs
 
 v_copula_basic_synsem := lex-synsem &
   [ MODIFIED notmod,
-    LOCAL local &
-	  [ CAT [ MC -,
-                  HC-LIGHT -,
-                  HEAD verb & [ INV -,
-                                AUX -,
-                                KEYS.KEY _be_v_prd_rel ],
-		  VAL.COMPS < synsem & 
-                              [ LOCAL [ COORD -,
-                                        CAT [ HEAD.KEYS.KEY #ckey,
-                                              VAL.COMPS < > ] ],
-                                NON-LOCAL.REL 0-dlist ] > ] ],
+    LOCAL local & [ CAT [ MC -,
+                          HC-LIGHT -,
+                          HEAD verb & [ INV -,
+                                        AUX -,
+                                        KEYS.KEY _be_v_prd_rel ],
+                          VAL.COMPS < synsem & [ LOCAL [ COORD -,
+                                                         CAT [ HEAD.KEYS.KEY #ckey,
+                                                               VAL.COMPS < > ] ],
+                                                 NON-LOCAL.REL 0-dlist ] > ] ],
     LKEYS [ KEYREL.PRED _be_v_prd_rel,
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+  """
+  --- 1.5. Copula verbs
+  """.
+
 
 v_copula_synsem := v_copula_basic_synsem &
   [ LOCAL [ CAT [ HEAD.TAM #tam,
-		  VAL [ SUBJ < [ OPT + ] >,
+                  VAL [ SUBJ < [ OPT + ] >,
                         COMPS < [ OPT -,
                                   LOCAL [ CAT.HEAD.TAM #tam,
                                           CONT.HOOK.INDEX #index ],
                                   NON-LOCAL.REL 0-dlist ] > ] ],
-	    CONT.HOOK.INDEX #index ] ].
+            CONT.HOOK.INDEX #index ] ]
+  """
+  
+  """.
+
 
 v_copula := basic-verb-lex &
-  [ ALTS [ RCP -, 
-           RFX -, 
+  [ ALTS [ RCP -,
+           RFX -,
            PASS -,
            IMPERS -,
-           VCALT - ] ].
+           VCALT - ] ]
+  """
+  
+  """.
+
 
 v_cop := v_copula &
   [ SYNSEM [ LOCAL.CAT.VAL [ SUBJ < #subj >,
-                             COMPS < #comps & 
-                                     [ LOCAL.CAT.VAL.CLTS #clts ] >,
+                             COMPS < #comps & [ LOCAL.CAT.VAL.CLTS #clts ] >,
                              CLTS #clts ],
              NON-LOCAL [ SLASH [ LIST #sfirst,
                                  LAST #slast ],
@@ -4307,232 +4501,307 @@ v_cop := v_copula &
                                            LAST #slast ],
                                    REL #rel & 0-dlist,
                                    QUE [ LIST #qmiddle,
-                                         LAST #qlast ] ] ].
-             < #comps & [ NON-LOCAL [ SLASH [ LIST #sfirst,
+                                         LAST #qlast ] ] ],
+             #comps & [ NON-LOCAL [ SLASH [ LIST #sfirst,
+                                            LAST #smiddle ],
+                                    QUE [ LIST #qfirst,
+                                          LAST #qmiddle ] ] ] . < #comps & [ NON-LOCAL [ SLASH [ LIST #sfirst,
                                               LAST #smiddle ],
                                       QUE [ LIST #qfirst,
-                                            LAST #qmiddle ] ] ]. #clts > > ].
+                                            LAST #qmiddle ] ] ] . #clts > > ]
+  """
+  
+  """.
+
 
 v_cop-np_sbj := v_cop &
   [ SYNSEM.LOCAL [ AGR.PNG #png,
-                   CAT [ VAL [ SUBJ < [ LOCAL np_nom_local & 
-                                              [ AGR.PNG #png ] ] >,
-                               COMPS < [ LOCAL.CONT.HOOK.LTOP #ltop ] > ] ],
-	           CONT [ HOOK.LTOP #ltop,
+                   CAT.VAL [ SUBJ < [ LOCAL np_nom_local & [ AGR.PNG #png ] ] >,
+                             COMPS < [ LOCAL.CONT.HOOK.LTOP #ltop ] > ],
+                   CONT [ HOOK.LTOP #ltop,
                           RELS <! !>,
-		          HCONS <! !> ] ] ].
+                          HCONS <! !> ] ] ]
+  """
+  
+  """.
+
 
 v_cop-nsbj := v_copula &
   [ SYNSEM [ LOCAL [ CAT [ HEAD.INV -,
                            VAL [ SUBJ < >,
-                                 COMPS #comps &
-                                       < [ LOCAL [ CAT.VAL.SUBJ < >,
-                                                   CONT.HOOK.LTOP #ltop ],
-                                           NON-LOCAL #nonlocal ] > ] ],
-	             CONT [ HOOK.LTOP #ltop,
+                                 COMPS #comps & < [ LOCAL [ CAT.VAL.SUBJ < >,
+                                                            CONT.HOOK.LTOP #ltop ],
+                                                    NON-LOCAL #nonlocal ] > ] ],
+                     CONT [ HOOK.LTOP #ltop,
                             RELS <! !>,
-		            HCONS <! !> ] ],
+                            HCONS <! !> ] ],
              NON-LOCAL #nonlocal ],
-    ARG-ST #comps ].
+    ARG-ST #comps ]
+  """
+  
+  """.
 
-; e.g. Juan es feo
-; removed LOCAL [ CAT.VAL COMPS < [ LOCAL [ CAT.HEAD [ KEYS.KEY basic_adj_rel ], to cover "será complicado"
-v_ap_ser_synsem :=  v_copula_synsem & 
+
+v_ap_ser_synsem := v_copula_synsem &
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
-                      COMPS < [ LOCAL [ CAT.HEAD adj &
-                                                [ MOD < [ LOCAL.CAT.HEAD noun ] >,
-                                                  PRD.COPV ser ],
+                      COMPS < [ LOCAL [ CAT.HEAD adj & [ MOD < [ LOCAL.CAT.HEAD noun ] >,
+                                                         PRD.COPV ser ],
                                         CONT.HOOK.XARG #sind ] ] > ],
-            CONT.HOOK.XARG #sind ] ].
+            CONT.HOOK.XARG #sind ] ]
+  """
+  e.g. Juan es feo
+  removed LOCAL [ CAT.VAL COMPS < [ LOCAL [ CAT.HEAD [ KEYS.KEY basic_adj_rel ], to cover "será complicado"
+  """.
+
 
 v_ap_ser_lex := v_cop-np_sbj &
-  [ SYNSEM v_ap_ser_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_ap_ser_synsem ] ].
+  [ SYNSEM v_ap_ser_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_ap_ser_synsem ] ]
+  """
+  
+  """.
 
 
-; e.g. Juan es de esta ciudad
 v_pp_ser_synsem := v_copula_synsem &
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
-                      COMPS < [ LOCAL [ CAT.HEAD adp &
-                                                 [ KEYS.ALT2KEY quant_or_deg_rel, 
-                                                   MOD < [ LOCAL.CAT.HEAD noun ] >,
-                                                   PRD.COPV ser ],
+                      COMPS < [ LOCAL [ CAT.HEAD adp & [ KEYS.ALT2KEY quant_or_deg_rel,
+                                                         MOD < [ LOCAL.CAT.HEAD noun ] >,
+                                                         PRD.COPV ser ],
                                         CONT.HOOK.XARG #sind ] ] > ],
-            CONT.HOOK.XARG #sind ] ].
+            CONT.HOOK.XARG #sind ] ]
+  """
+  e.g. Juan es de esta ciudad
+  """.
+
 
 v_pp_ser_lex := v_cop-np_sbj &
-  [ SYNSEM v_pp_ser_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_pp_ser_synsem ] ].
+  [ SYNSEM v_pp_ser_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_pp_ser_synsem ] ]
+  """
+  
+  """.
 
 
-; e.g. fue la semana pasada
-;; abans : COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY prep_mod_rel ] >, but "Esto es al contado"... )
 v_modnp_ser_synsem := v_copula_synsem &
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
                       COMPS < [ LOCAL [ CAT.HEAD modnp & [ MOD < [ LOCAL.CAT.HEAD noun ] > ],
                                         CONT.HOOK.XARG #sind ] ] > ],
-            CONT.HOOK.XARG #sind ] ].
+            CONT.HOOK.XARG #sind ] ]
+  """
+   e.g. fue la semana pasada
+  ; abans : COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY prep_mod_rel ] >, but "Esto es al contado"... )
+  """.
+
 
 v_modnp_ser_lex := v_cop-np_sbj &
-  [ SYNSEM v_modnp_ser_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_modnp_ser_synsem ] ].
+  [ SYNSEM v_modnp_ser_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_modnp_ser_synsem ] ]
+  """
+  
+  """.
 
 
-; e.g. Es como pulsar una tecla de un simple vistazo.
 v_pp_e-vp-inf_ser_synsem := v_copula_basic_synsem &
   [ LOCAL [ CAT [ HEAD.PRD non-prd,
                   VAL [ SUBJ < [ OPT +,
                                  LOCAL.CONT.HOOK.INDEX #sind ] >,
                         COMPS < [ OPT -,
-                                  LOCAL [ CAT.HEAD adp & 
-                                                   [ KEYS.ALT2KEY v_event_rel,
-                                                     MOD < [ LOCAL.CAT.HEAD noun ] >,
-                                                             PRD.COPV ser ],
+                                  LOCAL [ CAT.HEAD adp & [ KEYS.ALT2KEY v_event_rel,
+                                                           MOD < [ LOCAL.CAT.HEAD noun ] >,
+                                                           PRD.COPV ser ],
                                           CONT.HOOK [ INDEX.SF prop,
                                                       XARG #sind ] ],
                                   NON-LOCAL.REL 0-dlist ] > ] ],
-            CONT.HOOK.XARG #sind ] ].
+            CONT.HOOK.XARG #sind ] ]
+  """
+  e.g. Es como pulsar una tecla de un simple vistazo.
+  """.
+
 
 v_pp_e-vp-inf-ser_lex := v_cop-np_sbj &
-  [ SYNSEM v_pp_e-vp-inf_ser_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_pp_e-vp-inf_ser_synsem ] ]. 
+  [ SYNSEM v_pp_e-vp-inf_ser_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_pp_e-vp-inf_ser_synsem ] ]
+  """
+  
+  """.
 
 
-; e.g. Juan fue atacado
 v_vp_ppart_ser_synsem := v_copula_synsem &
   [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #arg2 ] >,
                     COMPS < [ LOCAL [ CAT.HEAD verb & [ PRD.COPV ser ],
-                                      CONT.RELS.LIST < [ ARG2 #arg2 ],... > ] ] > ] ].
+                                      CONT.RELS.LIST < [ ARG2 #arg2 ], ... > ] ] > ] ]
+  """
+  e.g. Juan fue atacado
+  """.
+
+
 v_vp_ppart-ser_lex := v_cop-np_sbj &
-  [ SYNSEM v_vp_ppart_ser_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_vp_ppart_ser_synsem ] ].
+  [ SYNSEM v_vp_ppart_ser_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_vp_ppart_ser_synsem ] ]
+  """
+  
+  """.
 
 
-; e.g. Juan está muerto
 v_vp_ppart_estar_synsem := v_copula_synsem &
   [ LOCAL.CAT [ HEAD.PRD non-prd,
                 VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #arg2 ] >,
-                      COMPS < [ LOCAL [ CAT.HEAD adj & 
-                                                 [ MOD < [ LOCAL [ AGR #arg2, CAT.HEAD noun ] ] >,
-                                                   PRD.COPV estar,
-                                                   KEYS.KEY v_event_rel ] ] ] > ] ] ].
-v_vp_ppart-estar_lex := v_cop-np_sbj &
-  [ SYNSEM v_vp_ppart_estar_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_vp_ppart_estar_synsem ] ].
+                      COMPS < [ LOCAL.CAT.HEAD adj & [ MOD < [ LOCAL [ AGR #arg2,
+                                                                       CAT.HEAD noun ] ] >,
+                                                       PRD.COPV estar,
+                                                       KEYS.KEY v_event_rel ] ] > ] ] ]
+  """
+  e.g. Juan está muerto
+  """.
 
-; e.g. Juan está feo
+
+v_vp_ppart-estar_lex := v_cop-np_sbj &
+  [ SYNSEM v_vp_ppart_estar_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_vp_ppart_estar_synsem ] ]
+  """
+  
+  """.
+
+
 v_ap_estar_synsem := v_copula_synsem &
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
-                      COMPS < [ LOCAL [ CAT.HEAD adj &
-                                                 [ MOD < [ LOCAL.CAT.HEAD noun ] >,
-                                                           PRD.COPV estar,
-                                                           KEYS.KEY adj_rel ],
+                      COMPS < [ LOCAL [ CAT.HEAD adj & [ MOD < [ LOCAL.CAT.HEAD noun ] >,
+                                                         PRD.COPV estar,
+                                                         KEYS.KEY adj_rel ],
                                         CONT.HOOK.XARG #sind ] ] > ],
-            CONT.HOOK.XARG #sind ] ].
+            CONT.HOOK.XARG #sind ] ]
+  """
+  e.g. Juan está feo
+  """.
+
 
 v_ap_estar_lex := v_cop-np_sbj &
-  [ SYNSEM v_ap_estar_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_ap_estar_synsem ] ].
+  [ SYNSEM v_ap_estar_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_ap_estar_synsem ] ]
+  """
+  
+  """.
 
-; e.g. Juan está en la ciudad
+
 v_pp_estar_synsem := v_copula_synsem &
   [ LOCAL [ CAT [ HEAD.PRD non-prd,
                   VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
-                        COMPS < [ LOCAL [ CAT.HEAD adp & 
-                                                   [ PRD predicative,
-                                                     KEYS.ALT2KEY quant_or_deg_rel, 
-                                                     MOD < [ LOCAL.CAT.HEAD noun ] > ],
+                        COMPS < [ LOCAL [ CAT.HEAD adp & [ PRD predicative,
+                                                           KEYS.ALT2KEY quant_or_deg_rel,
+                                                           MOD < [ LOCAL.CAT.HEAD noun ] > ],
                                           CONT.HOOK.XARG #sind ] ] > ] ],
-            CONT.HOOK.XARG #sind ] ].
+            CONT.HOOK.XARG #sind ] ]
+  """
+  e.g. Juan está en la ciudad
+  """.
+
 
 v_pp_estar_lex := v_cop-np_sbj &
-  [ SYNSEM v_pp_estar_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_pp_estar_synsem ] ].
+  [ SYNSEM v_pp_estar_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_pp_estar_synsem ] ]
+  """
+  
+  """.
 
-; e.g. está muy bien
+
 v_adv_estar_synsem := v_copula_basic_synsem &
-           [ LOCAL [ CAT [ HEAD.PRD non-prd,
-                           VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
-                                 COMPS < [ OPT -,
-                                           LOCAL [ CAT.HEAD adv &
-                                                 [ MOD < [ LOCAL.CAT.HEAD verb ] > ],
-                                                   CONT.HOOK.XARG #sind ] ] > ] ],
-                     CONT.HOOK.XARG #sind ] ].
+  [ LOCAL [ CAT [ HEAD.PRD non-prd,
+                  VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
+                        COMPS < [ OPT -,
+                                  LOCAL [ CAT.HEAD adv & [ MOD < [ LOCAL.CAT.HEAD verb ] > ],
+                                          CONT.HOOK.XARG #sind ] ] > ] ],
+            CONT.HOOK.XARG #sind ] ]
+  """
+  e.g. está muy bien
+  """.
+
 
 v_adv_estar_lex := v_cop-np_sbj &
-  [ SYNSEM v_adv_estar_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_adv_estar_synsem ] ].
+  [ SYNSEM v_adv_estar_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_adv_estar_synsem ] ]
+  """
+  
+  """.
 
 
-; e.g. ahí estamos; ¿Dónde/cómo está Juan?
 v_modnp_estar_synsem := v_copula_synsem &
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
-                      COMPS < [ LOCAL [ CAT.HEAD modnp &
-                                                 [ MOD < [ LOCAL.CAT.HEAD noun ] > ],
+                      COMPS < [ LOCAL [ CAT.HEAD modnp & [ MOD < [ LOCAL.CAT.HEAD noun ] > ],
                                         CONT.HOOK.XARG #sind ] ] > ],
-            CONT.HOOK.XARG #sind ] ].
+            CONT.HOOK.XARG #sind ] ]
+  """
+  e.g. ahí estamos; ¿Dónde/cómo está Juan?
+  """.
+
 
 v_modnp_estar_lex := v_cop-np_sbj &
-  [ SYNSEM v_modnp_estar_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_modnp_estar_synsem ] ].
+  [ SYNSEM v_modnp_estar_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_modnp_estar_synsem ] ]
+  """
+  
+  """.
 
-; e.g. todo está por organizar
+
 v_pp_e-vp-inf-estar_synsem := v_copula_basic_synsem &
-           [ LOCAL [ CAT [ HEAD.PRD non-prd,
-                           VAL [ SUBJ < [ OPT +,
-                                          LOCAL.CONT.HOOK.INDEX #sind ] >,
-                                 COMPS < [ OPT -,
-                                           LOCAL [ CAT.HEAD adp & 
-                                                            [ KEYS.ALTKEY v_event_rel,
-                                                              MOD < [ LOCAL.CAT.HEAD noun ] >,
-                                                              PRD.COPV estar ],
-                                                   CONT.HOOK [ INDEX.SF prop,
-                                                               XARG #sind ] ],
-                                           NON-LOCAL.REL 0-dlist ] > ] ],
-                     CONT.HOOK.XARG #sind ] ].
+  [ LOCAL [ CAT [ HEAD.PRD non-prd,
+                  VAL [ SUBJ < [ OPT +,
+                                 LOCAL.CONT.HOOK.INDEX #sind ] >,
+                        COMPS < [ OPT -,
+                                  LOCAL [ CAT.HEAD adp & [ KEYS.ALTKEY v_event_rel,
+                                                           MOD < [ LOCAL.CAT.HEAD noun ] >,
+                                                           PRD.COPV estar ],
+                                          CONT.HOOK [ INDEX.SF prop,
+                                                      XARG #sind ] ],
+                                  NON-LOCAL.REL 0-dlist ] > ] ],
+            CONT.HOOK.XARG #sind ] ]
+  """
+  e.g. todo está por organizar
+  """.
+
 
 v_pp_e-vp-inf-estar_lex := v_cop-np_sbj &
-  [ SYNSEM v_pp_e-vp-inf-estar_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_pp_e-vp-inf-estar_synsem ] ].
+  [ SYNSEM v_pp_e-vp-inf-estar_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_pp_e-vp-inf-estar_synsem ] ]
+  """
+  
+  """.
 
 
-; e.g. Juan está cantando
 v_vp_ger-estar_synsem := v_copula_synsem &
-           [ LOCAL [ CAT [ HEAD.PRD non-prd,
-                           VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
-                                 COMPS < [ LOCAL [ CAT [ HEAD verb & 
-                                                              [ PRD.COPV estar,
-                                                                VOICE active,
-                                                                VFORM ger,
-                                                                MOD < > ],
-                                                         VAL.SUBJ < [ OPT + ] > ],
-                                                    CONT.HOOK.XARG #sind ] ] > ] ],
-                     CONT.HOOK.XARG #sind ] ].
+  [ LOCAL [ CAT [ HEAD.PRD non-prd,
+                  VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
+                        COMPS < [ LOCAL [ CAT [ HEAD verb & [ PRD.COPV estar,
+                                                              VOICE active,
+                                                              VFORM ger,
+                                                              MOD < > ],
+                                                VAL.SUBJ < [ OPT + ] > ],
+                                          CONT.HOOK.XARG #sind ] ] > ] ],
+            CONT.HOOK.XARG #sind ] ]
+  """
+  e.g. Juan está cantando
+  """.
+
 
 v_vp_ger-estar_lex := v_cop-np_sbj &
-  [ SYNSEM v_vp_ger-estar_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_vp_ger-estar_synsem ] ].
+  [ SYNSEM v_vp_ger-estar_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_vp_ger-estar_synsem ] ]
+  """
+  
+  """.
 
 
-; e.g. está lloviendo
 v_vp_ger-nsbj-estar_synsem := v_copula_basic_synsem &
-           [ LOCAL [ AGR.PNG.PN 3sg, 
-                     CAT [ HEAD [ PRD non-prd,
-                                  TAM #tam ],
-                           VAL [ COMPS < [ OPT -,
-                                           LOCAL [ CAT [ HEAD verb & 
-                                                              [ PRD.COPV estar,
-                                                                VOICE active,
-                                                                VFORM ger,
-                                                                TAM #tam ],
-                                                         VAL.CLTS < > ],
-                                                   CONT.HOOK.INDEX #index ] ] >,
-                                 CLTS < > ] ],
-	             CONT.HOOK.INDEX #index ] ].
+  [ LOCAL [ AGR.PNG.PN 3sg,
+            CAT [ HEAD [ PRD non-prd,
+                         TAM #tam ],
+                  VAL [ COMPS < [ OPT -,
+                                  LOCAL [ CAT [ HEAD verb & [ PRD.COPV estar,
+                                                              VOICE active,
+                                                              VFORM ger,
+                                                              TAM #tam ],
+                                                VAL.CLTS < > ],
+                                          CONT.HOOK.INDEX #index ] ] >,
+                        CLTS < > ] ],
+            CONT.HOOK.INDEX #index ] ]
+  """
+  e.g. está lloviendo
+  """.
+
 
 v_vp_ger-nsbj-estar_lex := v_cop-nsbj &
-  [ SYNSEM v_vp_ger-nsbj-estar_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_vp_ger-nsbj-estar_synsem ] ].
+  [ SYNSEM v_vp_ger-nsbj-estar_synsem & [ LOCAL.CAT.HEAD.LSYNSEM v_vp_ger-nsbj-estar_synsem ] ]
+  """
+  
+  """.
+
  
 
 
@@ -4560,9 +4829,14 @@ v_aux_haber_synsem := lex-synsem &
                           INDEX #index ],
 	       	   RELS <! !>,
 		   HCONS <! !> ] ],
-    LKEYS.--COMPKEY #ckey ].
-
+    LKEYS.--COMPKEY #ckey ]
+"""
+; --- Auxiliary verbs
+; the VOICE of the COMPS element used to be active, but in order to deal with 
+; passives such as "se ha resuelto el caso"
 ;   SYNSEM [ LOCAL.CAT [ HEAD [ TAM.ASPECT perf,
+""".
+
 
 v_aux_vp-part_synsem := v_aux_haber_synsem &
   [ LOCAL [ AGR #sind, 
@@ -4735,7 +5009,10 @@ n_intrans := basic-noun-lex & basic-one-arg & norm-hook-lex &
                          VAL [ SPR < [ OPT -] >,
                                COMPS < > ] ],
                    CONT [ RELS <! noun-arg0-relation !>,
-                          HCONS <! !> ] ] ]. 
+                          HCONS <! !> ] ] ]
+"""
+; -- subcategorization types
+""". 
 
 n_trans := basic-noun-lex & 
   [ SYNSEM [ LOCAL.CAT [ HEAD.KEYS.KEY non_temp_nonpro_rel & non_elliptical_n_rel,
@@ -4838,11 +5115,13 @@ n_quant := quant-common-noun-lex & basic-two-arg & norm-hook-lex &
                             HCONS <! !> ] ],
              LKEYS.--COMPKEY #ckey ] ].
 
-; fot LRs
 n_prop-or-ques_fin_synsem := basic-common-noun-synsem &
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL mrkd_or_unmrkd_cp_prop_or_ques_local &
                                   [ CONT.HOOK.INDEX.E [ TENSE tense,
-                                                        MOOD ind_or_sub_mood ] ] ] > ].
+                                                        MOOD ind_or_sub_mood ] ] ] > ]
+"""
+; fot LRs
+""".
 
 n_prop-or-ques_inf_synsem := basic-common-noun-synsem &
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL mrkd_or_unmrkd_cp_prop_or_ques_local &
@@ -4865,56 +5144,81 @@ n_ppde_prop-inf_synsem := basic-common-noun-synsem &
 
 ; --- 2.1. Common nouns
 
-; --- 2.1.1. Intrans common nouns
 
-; e.g. los/cualquier niños
-n_-_c_lex := n_intrans & 
-  [ SYNSEM.LOCAL.AGR.DIVISIBLE - ].
- 
-; e.g. las/*la arras
-n_-_c-pl_lex := n_intrans & 
+n_-_c_lex := n_intrans &
+  [ SYNSEM.LOCAL.AGR.DIVISIBLE - ]
+  """
+  --- 2.1.1. Intrans common nouns
+  e.g. los/cualquier niños
+  """.
+
+
+n_-_c-pl_lex := n_intrans &
   [ SYNSEM.LOCAL.AGR [ PNG.PN plur,
-                       DIVISIBLE + ] ].
+                       DIVISIBLE + ] ]
+  """
+  e.g. las/*la arras
+  """.
 
-; e.g. (bastante/un poco de/*cualquier) acidez
-n_-_m_lex := n_intrans & 
+
+n_-_m_lex := n_intrans &
   [ SYNSEM.LOCAL.AGR [ PNG.PN sing,
-                       DIVISIBLE + ] ].
+                       DIVISIBLE + ] ]
+  """
+  e.g. (bastante/un poco de/*cualquier) acidez
+  """.
 
-; e.g. e.g. tiene *tres/un poco de celos, *entre comestibles 
-n_-_m-pl_lex := n_intrans & 
+
+n_-_m-pl_lex := n_intrans &
   [ SYNSEM.LOCAL.AGR [ PNG.PN plur,
-                       DIVISIBLE + ] ].
+                       DIVISIBLE + ] ]
+  """
+  e.g. e.g. tiene *tres/un poco de celos, *entre comestibles
+  """.
 
-; e.g. bebió (cualquier/un/un poco de/una copa de) vino
-n_-_mc_lex := n_intrans.
 
-; e.g. *un poco de/bastante abogacía
-n_-_nc_lex := n_intrans.
+n_-_mc_lex := n_intrans
+  """
+  e.g. bebió (cualquier/un/un poco de/una copa de) vino
+  """.
 
-; e.g. ejército, manada,...
-n_-_col_lex := n_intrans.
 
-; e.g. lo vieron ese lunes/día/mes/año/...; iremos de vacaciones en enero, comeremos a las dos
-n_-_c-tmp_lex := basic-noun-lex & norm-sem-lex-item & basic-one-arg & 
+n_-_nc_lex := n_intrans
+  """
+  e.g. *un poco de/bastante abogacía
+  """.
+
+
+n_-_col_lex := n_intrans
+  """
+  e.g. ejército, manada,...
+  """.
+
+
+n_-_c-tmp_lex := basic-noun-lex & norm-sem-lex-item & basic-one-arg &
   [ SYNSEM.LOCAL [ CAT [ POSTHEAD +,
                          HEAD.KEYS.KEY time_n_rel,
                          VAL [ SPR < [ OPT + ] >,
                                COMPS < > ] ],
                    CONT [ HOOK.INDEX.SORT tmp,
-                          RELS <! date-relation & 
-                                  [ PRED time_n_rel ] !> ] ] ].
+                          RELS <! date-relation & [ PRED time_n_rel ] !> ] ] ]
+  """
+  e.g. lo vieron ese lunes/día/mes/año/...; iremos de vacaciones en enero, comeremos a las dos
+  """.
+
 
 n_-_c-qnt_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ AGR #agr,
-                     CAT.VAL.SPR < [ OPT -,
-                                     LOCAL local-min &
-                                           [ AGR #agr,
-                                             CAT [ HEAD.KEYS.KEY quant_or_deg_rel, 
-                                                   VAL.SUBJ < > ] ],
-                                     NON-LOCAL [ REL 0-dlist,
-                                                 SLASH 0-dlist ] ] >  ] ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ AGR #agr,
+                                                CAT.VAL.SPR < [ OPT -,
+                                                                LOCAL local-min & [ AGR #agr,
+                                                                                    CAT [ HEAD.KEYS.KEY quant_or_deg_rel,
+                                                                                          VAL.SUBJ < > ] ],
+                                                                NON-LOCAL [ REL 0-dlist,
+                                                                            SLASH 0-dlist ] ] > ] ] ]
+  """
+  
+  """.
+
 
 ; --- appositional nouns (see ERG's tittle nouns)
 ; e.g. propuesta número 1234
@@ -4923,6 +5227,10 @@ n_-_c-qnt_lex := pronominal-lex & norm-zero-arg &
 
 ; --- 2.1.2. Argumental common nouns
 
+n_pp_c_lex := n_pp-de & 
+  [ SYNSEM basic-common-noun-synsem &
+           [ LOCAL.CONT.HOOK.INDEX.DIVISIBLE - ] ]
+"""
 ; --- Nouns taking a PPde (which may be replaced by the poss.)
 ; (i) non-derived nouns: relational nouns (e.g. el padre de la novia), los amigos de Peter), 
 ; body part nouns (e.g. brazo, pierna,...), constitutive (abstract) nouns (e.g. el color del dinero); 
@@ -4930,10 +5238,7 @@ n_-_c-qnt_lex := pronominal-lex & norm-zero-arg &
 ; measure verbs (e.g. el peso de la paja); (3) nouns derived from unaccusative verbs (e.g. la 
 ; muerte de Mikel); (4) nouns derived from unergative verbs (e.g. el silbido del tren); (5) subject 
 ; nominalizations (e.g. el traductor del Tractatus)
-
-n_pp_c_lex := n_pp-de & 
-  [ SYNSEM basic-common-noun-synsem &
-           [ LOCAL.CONT.HOOK.INDEX.DIVISIBLE - ] ].
+""".
 
 n_pp_m_lex := n_pp-de & 
   [ SYNSEM basic-common-noun-synsem &
@@ -4946,15 +5251,17 @@ n_pp_nc_lex := n_pp-de &
   [ SYNSEM basic-common-noun-synsem ]. 
 
 
+n_pp-pp_de-mc_lex := n_ppde_pp & 
+  [ SYNSEM basic-common-noun-synsem &
+           [ LOCAL.CONT.HOOK.INDEX.SORT abs ] ]
+"""
 ; --- Nouns taking two PPcomps (being the first one a PPde)
 ; (1) de-adjectival nouns (e.g. la adicción de Juan a los caramelos de menta); (2) deverbal 
 ; nouns from psicological, inchoative and perception verbs (e.g. el temor de Juan a las 
 ; enfermedades infecciosas, la preocupación de María por sus hijos); (3) deverbal nouns 
 ; derived by intrans verbs (e.g. la lucha de los kurdos contra el estado turco); (4) deverbal 
 ; nouns derived by trans verbs (e.g. el descubrimiento de) 
-n_pp-pp_de-mc_lex := n_ppde_pp & 
-  [ SYNSEM basic-common-noun-synsem &
-           [ LOCAL.CONT.HOOK.INDEX.SORT abs ] ].
+""".
 
 n_pp-pp_de-de-mc_lex := n_ppde_pp & 
   [ SYNSEM basic-common-noun-synsem &
@@ -4975,119 +5282,147 @@ n_pp-pp_de-de-mc_lex := n_ppde_pp &
 
 
 ; --- Nouns taking verbal complements
-; e.g. una ventaja ((de) que no llueva es que no hay ocasión de perder el paraguas)
+
 n_cp*_p-c_lex := n_cp_prop_fin & 
   [ SYNSEM n_prop-or-ques_fin_synsem & 
            [ LOCAL [ CAT.VAL.COMPS < [ OPT + ] >,
-                     CONT.HOOK.INDEX.DIVISIBLE - ] ] ]. 
+                     CONT.HOOK.INDEX.DIVISIBLE - ] ] ]
+"""
+; --- Nouns taking verbal complements
+; e.g. una ventaja ((de) que no llueva es que no hay ocasión de perder el paraguas)
+""". 
 
-n_cp_p-c_lex := n_cp_prop_fin & 
-  [ SYNSEM n_prop-or-ques_fin_synsem & 
-           [ LOCAL [ CAT.VAL.COMPS < [ OPT - ] >,
-                     CONT.HOOK.INDEX.DIVISIBLE - ] ] ]. 
 
-; e.g. no hay duda de que vendrá
-n_cp_p-mc_lex := n_cp_prop_fin & 
-  [ SYNSEM n_prop-or-ques_fin_synsem & 
-           [ LOCAL.CAT.VAL.COMPS < [ OPT - ] > ] ]. 
+n_cp_p-c_lex := n_cp_prop_fin &
+  [ SYNSEM n_prop-or-ques_fin_synsem & [ LOCAL [ CAT.VAL.COMPS < [ OPT - ] >,
+                                                 CONT.HOOK.INDEX.DIVISIBLE - ] ] ]
+  """
+  
+  """.
 
-; e.g. la incógnita (de si/cómo se ha utilizado el dinero público)
-n_cp_q-c_lex := n_cp_question & 
-  [ SYNSEM n_prop-or-ques_fin_synsem & 
-           [ LOCAL [ CAT.VAL.COMPS < [ OPT + ] >,
-                     CONT.HOOK.INDEX.DIVISIBLE - ] ] ].
 
-; e.g. el interés (de la empresa) (en/por que lleguen a un acuerdo/llegar a un acuerdo)
-n_pp-cp_p-mc_lex := n_ppde_cp_prop_fin & 
-  [ SYNSEM n_ppde_prop-fin_synsem & 
-           [ LOCAL.CAT.VAL.COMPS < [ OPT + ], [ OPT + ] > ] ]. 
+n_cp_p-mc_lex := n_cp_prop_fin &
+  [ SYNSEM n_prop-or-ques_fin_synsem & [ LOCAL.CAT.VAL.COMPS < [ OPT - ] > ] ]
+  """
+  e.g. no hay duda de que vendrá
+  """.
 
-; e.g. la estupidez (de Juan) (de votar a Ernesto)
+
+n_cp_q-c_lex := n_cp_question &
+  [ SYNSEM n_prop-or-ques_fin_synsem & [ LOCAL [ CAT.VAL.COMPS < [ OPT + ] >,
+                                                 CONT.HOOK.INDEX.DIVISIBLE - ] ] ]
+  """
+  e.g. la incógnita (de si/cómo se ha utilizado el dinero público)
+  """.
+
+
+n_pp-cp_p-mc_lex := n_ppde_cp_prop_fin &
+  [ SYNSEM n_ppde_prop-fin_synsem & [ LOCAL.CAT.VAL.COMPS < [ OPT + ],
+                                                            [ OPT + ] > ] ]
+  """
+  e.g. el interés (de la empresa) (en/por que lleguen a un acuerdo/llegar a un acuerdo)
+  """.
+
+
 n_pp-vp_mc_lex := n_ppde_cp_prop_inf &
-  [ SYNSEM.LOCAL.CAT.VAL.COMPS < [ OPT + ], [ OPT + ] > ]. 
-
+  [ SYNSEM.LOCAL.CAT.VAL.COMPS < [ OPT + ], [ OPT + ] > ]
+  """
+  e.g. la estupidez (de Juan) (de votar a Ernesto)
+  """.
 
 ; --- Quantifying nouns (we distinguish three classes)
 ; --- Partitive nouns
-; - may show "ad sensum" agreement; i.e. the verb agrees with either the head or its complement  
-; (e.g. la mayoría de senadores votaron/votó en contra). 
-; - If their complement is indefinite, they build pseudo-partitive constructions; i.e. the complement 
-; doesn't have referential properties, nor can it be topicalized (e.g. *de senadores, una mayoría 
-; votó en contra); if their complement is a definite NP, they build partitive constructions; i.e. 
-; both the complement and the whole NP are referential, and the complement may be topicalized 
-; (e.g. de los senadores, una mayoría votó en contra).
-; !!! NOTE that this distinction is not implemented yet.
-; --- Group nouns
-; - some of them are ambiguous with collective nouns, e.g. manada de cerdos
-; - ambiguous: descriptive vs pseudo-partitive reading, but they only have a pseudo-partitive reading 
-; when they do not co-occur with the definite article (e.g. *el/un grupo de senadores votaron en contra).
-; - If their complement is indefinite, they build pseudo-partitive constructions (see above) 
-; (e.g. ((un grupo minoritario) (de senadores)) votaron en contra), if their complement is a definite 
-; NP, they build partitive constructions (e.g. ((un grupo minoritario) (de los senadores)))
-; !!! NOTE that this distinction is not implemented yet.
-; - Some take plural/mass nouns (e.g. un haz (de luz/protones), un grupo (de gente/caminantes)) and 
-; some only plural nouns (e.g. racimo (de uvas), fajo (de billetes), hatajo (de idiotas))
-; --- Pseudo-partitive nouns
-; - This type includes: counter ('acotadores') nouns (e.g. tableta (de mantequilla/turrón), 
-; terrón (de azúcar), hilo (de azafrán), hoja (de papel), rebanada (de pan), grano (de 
-; uva/café/arena/trigo),...) and measure nouns (e.g. un montón (de libros), un puñado (de 
-; dólares), un manojo (de perejil), una pila (de libros), un kilo (de peras/harina), 
-; un litro (de leche), una libra (de azúcar/clavos)).
-; - ambiguous: descriptive vs pseudo-partitive reading, but they only have a pseudo-partitive reading 
-; when they do not co-occur with the definite article (e.g. *el/un montón (de libros)).
-n_pp_part_lex := n_quant & 
-  [ ALTS.PASS -,
-    SYNSEM basic-quantifying-nom-synsem & 
-           [ LOCAL.CAT.VAL.COMPS < [ OPT + ] > ] ].
 
-n_pp_grp_lex := n_quant & 
+n_pp_part_lex := n_quant &
   [ ALTS.PASS -,
-    SYNSEM n_group-or-pseudopart_synsem & 
-           [ LOCAL.CAT.VAL.COMPS < [ OPT + ] > ] ].
+    SYNSEM basic-quantifying-nom-synsem & [ LOCAL.CAT.VAL.COMPS < [ OPT + ] > ] ]
+  """
+  --- Quantifying nouns (we distinguish three classes)
+  --- Partitive nouns
+  - may show "ad sensum" agreement; i.e. the verb agrees with either the head or its complement
+  (e.g. la mayoría de senadores votaron/votó en contra).
+  - If their complement is indefinite, they build pseudo-partitive constructions; i.e. the complement
+  doesn't have referential properties, nor can it be topicalized (e.g. *de senadores, una mayoría
+  votó en contra); if their complement is a definite NP, they build partitive constructions; i.e.
+  both the complement and the whole NP are referential, and the complement may be topicalized
+  (e.g. de los senadores, una mayoría votó en contra).
+  !!! NOTE that this distinction is not implemented yet.
+  --- Group nouns
+  - some of them are ambiguous with collective nouns, e.g. manada de cerdos
+  - ambiguous: descriptive vs pseudo-partitive reading, but they only have a pseudo-partitive reading
+  when they do not co-occur with the definite article (e.g. *el/un grupo de senadores votaron en contra).
+  - If their complement is indefinite, they build pseudo-partitive constructions (see above)
+  (e.g. ((un grupo minoritario) (de senadores)) votaron en contra), if their complement is a definite
+  NP, they build partitive constructions (e.g. ((un grupo minoritario) (de los senadores)))
+  !!! NOTE that this distinction is not implemented yet.
+  - Some take plural/mass nouns (e.g. un haz (de luz/protones), un grupo (de gente/caminantes)) and
+  some only plural nouns (e.g. racimo (de uvas), fajo (de billetes), hatajo (de idiotas))
+  --- Pseudo-partitive nouns
+  - This type includes: counter ('acotadores') nouns (e.g. tableta (de mantequilla/turrón),
+  terrón (de azúcar), hilo (de azafrán), hoja (de papel), rebanada (de pan), grano (de
+  uva/café/arena/trigo),...) and measure nouns (e.g. un montón (de libros), un puñado (de
+  dólares), un manojo (de perejil), una pila (de libros), un kilo (de peras/harina),
+  un litro (de leche), una libra (de azúcar/clavos)).
+  - ambiguous: descriptive vs pseudo-partitive reading, but they only have a pseudo-partitive reading
+  when they do not co-occur with the definite article (e.g. *el/un montón (de libros)).
+  """.
 
-n_pp_psd-part_lex := n_quant & 
+
+n_pp_grp_lex := n_quant &
   [ ALTS.PASS -,
-    SYNSEM n_group-or-pseudopart_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ OPT + ] > ] ].
+    SYNSEM n_group-or-pseudopart_synsem & [ LOCAL.CAT.VAL.COMPS < [ OPT + ] > ] ]
+  """
+  
+  """.
 
-; --- temporal measure nouns (e.g. despues de años (de espera/disgustos) se divorciaron)
+
+n_pp_psd-part_lex := n_quant &
+  [ ALTS.PASS -,
+    SYNSEM n_group-or-pseudopart_synsem & [ LOCAL.CAT.VAL.COMPS < [ OPT + ] > ] ]
+  """
+  
+  """.
+
+
 n_pp_c-tmp_lex := n_ppcomp &
-  [ SYNSEM basic-common-noun-synsem &
-           [ LOCAL [ CAT [ HEAD.KEYS.KEY part_nom_rel,
-                           VAL.COMPS < [ OPT -, 
-                                         LOCAL [ CAT.HEAD.KEYS [ KEY _de_p_sel_rel,
-                                                                 ALT2KEY implicit_q_rel ],
-                                                 CONT.HOOK.INDEX.SORT non-temp ] ] > ],
-                     CONT.HOOK.INDEX [ DIVISIBLE -, 
-                                       SORT tmp ] ] ] ]. 
-
-
+  [ SYNSEM basic-common-noun-synsem & [ LOCAL [ CAT [ HEAD.KEYS.KEY part_nom_rel,
+                                                      VAL.COMPS < [ OPT -,
+                                                                    LOCAL [ CAT.HEAD.KEYS [ KEY _de_p_sel_rel,
+                                                                                            ALT2KEY implicit_q_rel ],
+                                                                            CONT.HOOK.INDEX.SORT non-temp ] ] > ],
+                                                CONT.HOOK.INDEX [ DIVISIBLE -,
+                                                                  SORT tmp ] ] ] ]
+  """
+  --- temporal measure nouns (e.g. despues de años (de espera/disgustos) se divorciaron)
+  """.
 
 ; --- 2.2. Proper names
-; If the proper name is modified, then it requires a def. article (e.g. (*el) manolo del otro día, 
-; la Rocío de la que te hablé). Some proper names may take the article (e.g. la Pantoja)
 
-n_-_pn_lex := basic-noun-lex & basic-one-arg & norm-sem-lex-item & 
+n_-_pn_lex := basic-noun-lex & basic-one-arg & norm-sem-lex-item &
   [ SYNSEM [ LOCAL [ AGR #agr & [ PNG.GEN #gen ],
                      CAT [ POSTHEAD +,
                            HEAD.KEYS [ KEY named_rel,
-                                       ALTKEY non_free_relative_q_rel ], 
-                           VAL [ SPR < [ LOCAL [ AGR.PNG.GEN #gen & masc_or_fem, 
-                                                 CAT.HEAD.KEYS.KEY quant_rel ], 
-                                         NON-LOCAL.QUE #que ] >, 
+                                       ALTKEY non_free_relative_q_rel ],
+                           VAL [ SPR < [ LOCAL [ AGR.PNG.GEN #gen & masc_or_fem,
+                                                 CAT.HEAD.KEYS.KEY quant_rel ],
+                                         NON-LOCAL.QUE #que ] >,
                                  COMPS < > ] ],
-                     CONT.HOOK [ INDEX #agr & 
-                                       [ DIVISIBLE -, 
-                                         PNG.PN 3per,
-                                         SORT non-temp,
-                                         PRONTYPE not_pron ],
+                     CONT.HOOK [ INDEX #agr & [ DIVISIBLE -,
+                                                PNG.PN 3per,
+                                                SORT non-temp,
+                                                PRONTYPE not_pron ],
                                  XARG #arg1 ] ],
              NON-LOCAL [ SLASH 0-dlist,
                          REL 0-dlist,
                          QUE #que ],
-             LKEYS [ KEYREL named-relation & 
-                            [ PRED named_rel, ARG1 #arg1 ],
-                     ALTKEYREL.PRED implicit_q_rel ] ] ].
+             LKEYS [ KEYREL named-relation & [ PRED named_rel,
+                                               ARG1 #arg1 ],
+                     ALTKEYREL.PRED implicit_q_rel ] ] ]
+  """
+  If the proper name is modified, then it requires a def. article (e.g. (*el) manolo del otro día,
+  la Rocío de la que te hablé). Some proper names may take the article (e.g. la Pantoja)
+  """.
+
 
 
 ; --- 2.3. Pronouns
@@ -5146,44 +5481,49 @@ personal_pron_synsem := norm-pronominal-synsem &
 
 ; --- 2.3.1.1. Personal pronouns
 
-; -- yo, tú
+
 n_-_pr-pers-n_lex := personal-pron-lex & basic-zero-arg &
-  [ SYNSEM personal_pron_synsem &
-           [ LOCAL.CAT [ HEAD.CASE nom,
-                         VAL.SPR < > ] ] ].
+  [ SYNSEM personal_pron_synsem & [ LOCAL.CAT [ HEAD.CASE nom,
+                                                VAL.SPR < > ] ] ]
+  """
+  -- yo, tú
+  """.
 
-; -- (todo) él, ella, vos
+
 n_-_pr-pers-no-sg_lex := personal-pron-lex & basic-one-arg &
-  [ SYNSEM personal_pron_synsem &
-           [ LOCAL [ AGR.PNG.PN sing,
-                     CAT [ HEAD.CASE nom_or_obl,
-                           VAL.SPR < [ OPT +,
-                                       LOCAL.CAT.HEAD.KEYS.KEY todo_def_q_rel,
-                                       NON-LOCAL [ QUE 0-dlist,
-                                                    REL 0-dlist ] ] > ] ] ] ].
+  [ SYNSEM personal_pron_synsem & [ LOCAL [ AGR.PNG.PN sing,
+                                            CAT [ HEAD.CASE nom_or_obl,
+                                                  VAL.SPR < [ OPT +,
+                                                              LOCAL.CAT.HEAD.KEYS.KEY todo_def_q_rel,
+                                                              NON-LOCAL [ QUE 0-dlist,
+                                                                          REL 0-dlist ] ] > ] ] ] ]
+  """
+  -- (todo) él, ella, vos
+  """.
 
-; -- (todos) nosotros, vosotros, ellos/as, usted/es
+
 n_-_pr-pers-no-pl_lex := personal-pron-lex & basic-one-arg &
-  [ SYNSEM personal_pron_synsem &
-           [ LOCAL [ AGR.PNG.PN plur,
-                     CAT [ HEAD.CASE nom_or_obl,
-                           VAL.SPR < [ OPT +,
-                                       LOCAL.CAT.HEAD.KEYS.KEY todo_def_q_rel,
-                                       NON-LOCAL [ QUE 0-dlist,
-                                                    REL 0-dlist ] ] > ] ] ] ].
+  [ SYNSEM personal_pron_synsem & [ LOCAL [ AGR.PNG.PN plur,
+                                            CAT [ HEAD.CASE nom_or_obl,
+                                                  VAL.SPR < [ OPT +,
+                                                              LOCAL.CAT.HEAD.KEYS.KEY todo_def_q_rel,
+                                                              NON-LOCAL [ QUE 0-dlist,
+                                                                          REL 0-dlist ] ] > ] ] ] ]
+  """
+  -- (todos) nosotros, vosotros, ellos/as, usted/es
+  """.
 
-; -- mí, tí, sí, conmigo, contigo, consigo
+
 n_-_pr-pers-o_lex := personal-pron-lex & basic-zero-arg &
-  [ SYNSEM personal_pron_synsem &
-           [ LOCAL.CAT [ HEAD.CASE obl,
-                         VAL.SPR < > ] ] ].
+  [ SYNSEM personal_pron_synsem & [ LOCAL.CAT [ HEAD.CASE obl,
+                                                VAL.SPR < > ] ] ]
+  """
+  -- mí, tí, sí, conmigo, contigo, consigo
+  """.
+
 
 
 ; --- 2.3.1.2. Clitics
-; - depend phonologically on the verb and can't appear alone; can't appear in a coordination nor be 
-; selected by identity (e.g. *Juan lo y la trajo; *Juan la lavó y regaló); may produce phonological 
-; processes in the verb (e.g. sentad+os => sentaos); when appear in a sequence, this can't be interrupted 
-; (e.g. *lo puede darme)
 
 clitic-lex := norm-zero-arg &
   [ INFLECTED -,
@@ -5191,7 +5531,14 @@ clitic-lex := norm-zero-arg &
                      RPUNCT no_punct ],
              LOCAL [ COORD -,
                      COORD-STRAT zero,
-                     CAT.HEAD noun ] ] ].
+                     CAT.HEAD noun ] ] ]
+"""
+; --- 2.3.1.2. Clitics
+; - depend phonologically on the verb and can't appear alone; can't appear in a coordination nor be 
+; selected by identity (e.g. *Juan lo y la trajo; *Juan la lavó y regaló); may produce phonological 
+; processes in the verb (e.g. sentad+os => sentaos); when appear in a sequence, this can't be interrupted 
+; (e.g. *lo puede darme)
+""".
 
 ; clitic-synsem := lex-synsem &
 clitic-synsem := non-canonical &
@@ -5350,143 +5697,181 @@ spec_norm_indefinite_pron_synsem := norm_indefinite_pron_synsem &
              ALT2KEYREL.LBL #khand ] ].
 
 
-; e.g. (*casi) alguien llamó
+
 n_-_pr-idf-alguien_lex := indefinite-pron-lex & norm-zero-arg &
-  [ SYNSEM norm_indefinite_pron_synsem & 
-           [ LOCAL [ AGR.PNG.PN 3per,
-                     CAT.VAL.SPR < >,
-                     CONT [ HOOK.INDEX.SORT hum,
-                            RELS.LIST < [ PRED person_rel ],... > ] ],
-             LKEYS.ALTKEYREL.PRED undef_quant_q_rel & _alguno_q_rel ] ].
+  [ SYNSEM norm_indefinite_pron_synsem & [ LOCAL [ AGR.PNG.PN 3per,
+                                                   CAT.VAL.SPR < >,
+                                                   CONT [ HOOK.INDEX.SORT hum,
+                                                          RELS.LIST < [ PRED person_rel ], ... > ] ],
+                                           LKEYS.ALTKEYREL.PRED undef_quant_q_rel & _alguno_q_rel ] ]
+  """
+  e.g. (*casi) alguien llamó
+  """.
 
-; e.g. (casi) nadie vino
+
 n_-_pr-idf-nadie_lex := spec-indefinite-pron-lex &
-  [ SYNSEM spec_norm_indefinite_pron_synsem & 
-           [ LOCAL [ AGR.PNG.PN 3per,
-                     CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY _casi_x_deg_rel ] >,
-                     CONT [ HOOK.INDEX.SORT hum,
-                            RELS <! [ PRED person_rel ], relation !> ] ],
-             LKEYS.ALTKEYREL.PRED _ninguno_q_rel ] ].
+  [ SYNSEM spec_norm_indefinite_pron_synsem & [ LOCAL [ AGR.PNG.PN 3per,
+                                                        CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY _casi_x_deg_rel ] >,
+                                                        CONT [ HOOK.INDEX.SORT hum,
+                                                               RELS <! [ PRED person_rel ],
+                                                                       relation !> ] ],
+                                                LKEYS.ALTKEYREL.PRED _ninguno_q_rel ] ]
+  """
+  e.g. (casi) nadie vino
+  """.
 
-; e.g. (casi) todos fueron
+
 n_-_pr-idf-todo_lex := spec-indefinite-pron-lex &
-  [ SYNSEM spec_norm_indefinite_pron_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY _casi_x_deg_rel ] >,
-                     CONT.RELS <! [ PRED generic_entity_rel ], relation !> ],
-             LKEYS.ALTKEYREL.PRED undef_quant_q_rel & _todo_q_rel ] ].
+  [ SYNSEM spec_norm_indefinite_pron_synsem & [ LOCAL [ CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY _casi_x_deg_rel ] >,
+                                                        CONT.RELS <! [ PRED generic_entity_rel ],
+                                                                     relation !> ],
+                                                LKEYS.ALTKEYREL.PRED undef_quant_q_rel & _todo_q_rel ] ]
+  """
+  e.g. (casi) todos fueron
+  """.
 
-; e.g. vinieron Pedro, Juan y (los) demás
+
 n_-_pr-idf-demas_lex := spec-indefinite-pron-lex &
-  [ SYNSEM indefinite_pron_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY _el_q_rel ] >,
-                     CONT.RELS <! [ PRED generic_entity_rel ] !> ] ] ].
+  [ SYNSEM indefinite_pron_synsem & [ LOCAL [ CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY _el_q_rel ] >,
+                                              CONT.RELS <! [ PRED generic_entity_rel ] !> ] ] ]
+  """
+  e.g. vinieron Pedro, Juan y (los) demás
+  """.
 
-; e.g. cada cual mantuvo su posición
+
 n_-_pr-idf-cual_lex := spec-indefinite-pron-lex &
-  [ SYNSEM indefinite_pron_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < [ OPT -, 
-                                     LOCAL.CAT.HEAD.KEYS.KEY _cada_q_rel ] >,
-                     CONT.RELS <! [ PRED generic_entity_rel ] !> ] ] ].
+  [ SYNSEM indefinite_pron_synsem & [ LOCAL [ CAT.VAL.SPR < [ OPT -,
+                                                              LOCAL.CAT.HEAD.KEYS.KEY _cada_q_rel ] >,
+                                              CONT.RELS <! [ PRED generic_entity_rel ] !> ] ] ]
+  """
+  e.g. cada cual mantuvo su posición
+  """.
 
 
-; --- 2.3.4. (Pseudo)partitive pronouns
-basic-partitive-pron-synsem := lex-synsem & 
+basic-partitive-pron-synsem := lex-synsem &
   [ LOCAL [ CAT [ MC na,
-                  HEAD partn & 
-                       [ MOD < >,
-                         KEYS [ KEY #key & non_modable_rel,
-                                ALTKEY non_free_relative_q_rel ] ], 
-                  VAL [ SUBJ < >, 
-                        SPEC < >, 
-                        COMPS < [ LOCAL mrkd_np_local & 
-                                        [ CAT.HEAD.KEYS [ KEY #ckey, 
-                                                          ALTKEY #key ],
-                                          CONT.HOOK [ INDEX #arg & [ SORT #sort ] ] ],
+                  HEAD partn & [ MOD < >,
+                                 KEYS [ KEY #key & non_modable_rel,
+                                        ALTKEY non_free_relative_q_rel ] ],
+                  VAL [ SUBJ < >,
+                        SPEC < >,
+                        COMPS < [ LOCAL mrkd_np_local & [ CAT.HEAD.KEYS [ KEY #ckey,
+                                                                          ALTKEY #key ],
+                                                          CONT.HOOK.INDEX #arg & [ SORT #sort ] ],
                                   NON-LOCAL [ REL #rel,
                                               QUE 0-dlist,
-                                              SLASH 0-dlist ] ] > ] ], 
+                                              SLASH 0-dlist ] ] > ] ],
             CONT [ RELS.LIST < #keyrel, ... >,
                    HOOK [ LTOP #nhand,
-                          INDEX #index & 
-                                [ SORT non-temp, 
-                                  PRONTYPE real_pron ] ] ] ], 
-    NON-LOCAL [ REL #rel,
-                REL 0-dlist ],
-    LKEYS [ KEYREL #keyrel & 
-                   [ PRED part_of_rel,
-                     LBL #nhand,
-                     ARG0 #index & ref-ind & [ SORT #sort ], 
-                     ARG1 #arg & ref-ind ],
-            --COMPKEY #ckey & _de_p_sel_rel ] ]. 
+                          INDEX #index & [ SORT non-temp,
+                                           PRONTYPE real_pron ] ] ] ],
+    NON-LOCAL.REL 0-dlist,
+    LKEYS [ KEYREL #keyrel & [ PRED part_of_rel,
+                               LBL #nhand,
+                               ARG0 #index & ref-ind & [ SORT #sort ],
+                               ARG1 #arg & ref-ind ],
+            --COMPKEY #ckey & _de_p_sel_rel ] ]
+  """
+  --- 2.3.4. (Pseudo)partitive pronouns
+  """.
+
 
 norm-basic-partitive-pron-synsem := basic-partitive-pron-synsem &
   [ LOCAL [ CAT.HEAD.KEYS.ALTKEY #altkeypred,
             CONT [ HOOK [ LTOP #nhand,
                           INDEX #index,
                           XARG #nhand ],
-                   RELS <! #keyrel & noun-relation & 
-                           [ ARG0 #index,
-                             LBL #nhand ],
-                           #altkey & 
-                           [ PRED #altkeypred,
-                             ARG0 #index,
-                             RSTR #phand ] !>,
+                   RELS <! #keyrel & noun-relation & [ ARG0 #index,
+                                                       LBL #nhand ],
+                           #altkey & [ PRED #altkeypred,
+                                       ARG0 #index,
+                                       RSTR #phand ] !>,
                    HCONS <! qeq & [ HARG #phand,
-                                    LARG #nhand ] !> ] ], 
+                                    LARG #nhand ] !> ] ],
     NON-LOCAL.SLASH 0-dlist,
-    LKEYS [ KEYREL #keyrel, 
-            ALTKEYREL #altkey ] ]. 
+    LKEYS [ KEYREL #keyrel,
+            ALTKEYREL #altkey ] ]
+  """
+  
+  """.
 
-partitive-pron-lex := basic-nominal-lex & 
+
+partitive-pron-lex := basic-nominal-lex &
   [ SYNSEM.LOCAL.CAT.VAL [ SPR < >,
                            COMPS #comps ],
-    ARG-ST #comps ].
+    ARG-ST #comps ]
+  """
+  
+  """.
 
-spec-partitive-pron-lex := basic-nominal-lex & 
+
+spec-partitive-pron-lex := basic-nominal-lex &
   [ SYNSEM.LOCAL.CAT.VAL [ SPR #spr & < [ NON-LOCAL [ QUE 0-dlist,
                                                       REL 0-dlist ] ] >,
-                          COMPS #comps ],
-    ARG-ST < #spr. #comps > ].
+                           COMPS #comps ],
+    ARG-ST < #spr . #comps > ]
+  """
+  
+  """.
 
-; --- 2.3.4.1. pseudo-partitive pronouns (i.e. un poco/algo/nada + de Mass_N)
-; e.g. no he comido algo/nada/un poco + de sopa
-basic-pseudo-part-pron-synsem := lex-synsem & 
-  [ LOCAL [ AGR #agr & [ PNG.PN 3sg, 
+
+basic-pseudo-part-pron-synsem := lex-synsem &
+  [ LOCAL [ AGR #agr & [ PNG.PN 3sg,
                          DIVISIBLE + ],
             CAT.VAL.COMPS < [ OPT +,
                               LOCAL [ CAT.HEAD.KEYS.ALT2KEY udef_q_rel,
                                       CONT.HOOK.INDEX [ PNG.PN sing,
                                                         DIVISIBLE + ] ] ] >,
-            CONT.HOOK.INDEX #agr ], 
-    NON-LOCAL.QUE 0-dlist ].
+            CONT.HOOK.INDEX #agr ],
+    NON-LOCAL.QUE 0-dlist ]
+  """
+  --- 2.3.4.1. pseudo-partitive pronouns (i.e. un poco/algo/nada + de Mass_N)
+  e.g. no he comido algo/nada/un poco + de sopa
+  """.
 
-norm_pseudo-partitive_synsem := basic-pseudo-part-pron-synsem & norm-basic-partitive-pron-synsem.
-basic_pseudo-partitive_synsem := basic-pseudo-part-pron-synsem & basic-partitive-pron-synsem.
 
-; e.g. he comido (*casi) algo (de sopa)
+norm_pseudo-partitive_synsem := basic-pseudo-part-pron-synsem & norm-basic-partitive-pron-synsem
+  """
+  
+  """.
+
+
+basic_pseudo-partitive_synsem := basic-pseudo-part-pron-synsem & basic-partitive-pron-synsem
+  """
+  
+  """.
+
+
 n_pp_pr-part-algo_lex := partitive-pron-lex &
-  [ SYNSEM norm-basic-partitive-pron-synsem &
-           [ LOCAL.CONT.RELS <! relation, 
-                                [ PRED _alguno_q_rel ] !> ] ].
+  [ SYNSEM norm-basic-partitive-pron-synsem & [ LOCAL.CONT.RELS <! relation,
+                                                                   [ PRED _alguno_q_rel ] !> ] ]
+  """
+  e.g. he comido (*casi) algo (de sopa)
+  """.
 
-; e.g. no he comido (casi) nada (de sopa)
+
 n_pp_pr-part-nada_lex := spec-partitive-pron-lex &
-  [ SYNSEM norm-basic-partitive-pron-synsem &
-           [ LOCAL [ CAT.VAL.SPR < [ OPT +,
-                                     LOCAL [ CAT.HEAD.KEYS.KEY _casi_x_deg_rel,
-                                             CONT.HOOK [ XARG #index,
-                                                         LTOP #alt2hand ] ] ] >,
-                     CONT [ HOOK.INDEX #index,
-                            RELS <! relation, 
-                                    [ LBL #alt2hand, 
-                                      PRED _ninguno_q_rel ] !> ] ],
-             LKEYS.ALT2KEYREL.LBL #alt2hand ] ].
+  [ SYNSEM norm-basic-partitive-pron-synsem & [ LOCAL [ CAT.VAL.SPR < [ OPT +,
+                                                                        LOCAL [ CAT.HEAD.KEYS.KEY _casi_x_deg_rel,
+                                                                                CONT.HOOK [ XARG #index,
+                                                                                            LTOP #alt2hand ] ] ] >,
+                                                        CONT [ HOOK.INDEX #index,
+                                                               RELS <! relation,
+                                                                       [ LBL #alt2hand,
+                                                                         PRED _ninguno_q_rel ] !> ] ],
+                                                LKEYS.ALT2KEYREL.LBL #alt2hand ] ]
+  """
+  e.g. no he comido (casi) nada (de sopa)
+  """.
 
-; e.g. he comido (un) poco de sopa, *(un) poco
+
 n_pp_pr-part-un-poco_lex := partitive-pron-lex &
-  [ SYNSEM basic_pseudo-partitive_synsem &
-           [ LOCAL.CONT.RELS <! relation, 
-                                [ PRED _un_poco_part_of_rel ] !>  ] ].
+  [ SYNSEM basic_pseudo-partitive_synsem & [ LOCAL.CONT.RELS <! relation,
+                                                                [ PRED _un_poco_part_of_rel ] !> ] ]
+  """
+  e.g. he comido (un) poco de sopa, *(un) poco
+  """.
+
 #|
 actually...
 n_pp_pr-part-poco_lex := spec-partitive-pron-lex &
@@ -5498,99 +5883,132 @@ n_pp_pr-part-poco_lex := spec-partitive-pron-lex &
 |#
 
 ; --- 2.3.4.2. partitive pronouns
+
 basic-part-pron-synsem := lex-synsem &
   [ LOCAL [ AGR.PNG.GEN #gender,
             CAT.VAL.COMPS < [ OPT -, 
                               LOCAL [ CAT.HEAD.KEYS.ALT2KEY def_quant_q_rel,
                                       CONT.HOOK.INDEX.PNG [ PN plur, 
                                                             GEN #gender ] ] ] > ], 
-    NON-LOCAL.QUE 0-dlist ].
+    NON-LOCAL.QUE 0-dlist ]
+"""
+; --- 2.3.4.2. partitive pronouns
+""".
 
 norm_partitive_synsem := basic-part-pron-synsem & norm-basic-partitive-pron-synsem.
 basic_partitive_synsem := basic-part-pron-synsem & basic-partitive-pron-synsem.
 
-; e.g. (*casi) alguno/bastantes/muchos/demasiados... de *(los) chicos
+
 n_pp_pr-part-alguno_lex := partitive-pron-lex &
-  [ SYNSEM norm_partitive_synsem &
-           [ LKEYS.ALTKEYREL.PRED _alguno_q_rel ] ].
+  [ SYNSEM norm_partitive_synsem & [ LKEYS.ALTKEYREL.PRED _alguno_q_rel ] ]
+  """
+  e.g. (*casi) alguno/bastantes/muchos/demasiados... de *(los) chicos
+  """.
+
 
 n_pp_pr-part-bastante_lex := partitive-pron-lex &
-  [ SYNSEM norm_partitive_synsem &
-           [ LKEYS.ALTKEYREL.PRED _bastante_q_rel ] ].
+  [ SYNSEM norm_partitive_synsem & [ LKEYS.ALTKEYREL.PRED _bastante_q_rel ] ]
+  """
+  
+  """.
+
 
 n_pp_pr-part-cualquiera_lex := partitive-pron-lex &
-  [ SYNSEM norm_partitive_synsem &
-           [ LKEYS.ALTKEYREL.PRED _cualquiera_q_rel ] ].
+  [ SYNSEM norm_partitive_synsem & [ LKEYS.ALTKEYREL.PRED _cualquiera_q_rel ] ]
+  """
+  
+  """.
+
 
 n_pp_pr-part-demasiado_lex := partitive-pron-lex &
-  [ SYNSEM norm_partitive_synsem &
-           [ LKEYS.ALTKEYREL.PRED _demasiado_q_rel ] ].
+  [ SYNSEM norm_partitive_synsem & [ LKEYS.ALTKEYREL.PRED _demasiado_q_rel ] ]
+  """
+  
+  """.
+
 
 n_pp_pr-part-quienquiera_lex := partitive-pron-lex &
-  [ SYNSEM norm_partitive_synsem &
-           [ LKEYS.ALTKEYREL.PRED _quienquiera_q_rel ] ].
+  [ SYNSEM norm_partitive_synsem & [ LKEYS.ALTKEYREL.PRED _quienquiera_q_rel ] ]
+  """
+  
+  """.
+
 
 n_pp_pr-part-varios_lex := partitive-pron-lex &
-  [ SYNSEM norm_partitive_synsem &
-           [ LKEYS.ALTKEYREL.PRED _varios_q_rel ] ].
+  [ SYNSEM norm_partitive_synsem & [ LKEYS.ALTKEYREL.PRED _varios_q_rel ] ]
+  """
+  
+  """.
 
-; e.g. otras muchas/pocos volvieron a su lugar de origen
+
 n_pp_pr-part-mucho_lex := spec-partitive-pron-lex &
-  [ SYNSEM basic_partitive_synsem &
-           [ LOCAL [ CAT.VAL.SPR < [ OPT +,
-                                     LOCAL.CAT.HEAD.KEYS.KEY #altkey ] >,
-                     CONT.RELS <! relation & [ PRED _mucho_part_of_rel ] !> ],
-             LKEYS.ALTKEYREL.PRED #altkey ] ].
+  [ SYNSEM basic_partitive_synsem & [ LOCAL [ CAT.VAL.SPR < [ OPT +,
+                                                              LOCAL.CAT.HEAD.KEYS.KEY #altkey ] >,
+                                              CONT.RELS <! relation & [ PRED _mucho_part_of_rel ] !> ],
+                                      LKEYS.ALTKEYREL.PRED #altkey ] ]
+  """
+  e.g. otras muchas/pocos volvieron a su lugar de origen
+  """.
+
 
 n_pp_pr-part-poco_lex := spec-partitive-pron-lex &
-  [ SYNSEM basic_partitive_synsem &
-           [ LOCAL [ CAT.VAL.SPR < [ OPT +,
-                                     LOCAL.CAT.HEAD.KEYS.KEY #altkey ] >,
-                     CONT.RELS <! relation & [ PRED _poco_part_of_rel ] !> ],
-             LKEYS.ALTKEYREL.PRED #altkey ] ].
+  [ SYNSEM basic_partitive_synsem & [ LOCAL [ CAT.VAL.SPR < [ OPT +,
+                                                              LOCAL.CAT.HEAD.KEYS.KEY #altkey ] >,
+                                              CONT.RELS <! relation & [ PRED _poco_part_of_rel ] !> ],
+                                      LKEYS.ALTKEYREL.PRED #altkey ] ]
+  """
+  
+  """.
 
-; e.g. esta no es una guerra diferente a las otras
+
 n_pp_pr-part-otro_lex := spec-partitive-pron-lex &
-  [ SYNSEM basic_partitive_synsem &
-           [ LOCAL [ CAT.VAL.SPR < [ OPT +,
-                                     LOCAL.CAT.HEAD.KEYS.KEY #altkey ] >,
-                     CONT.RELS <! relation & [ PRED _otro_part_of_rel ] !> ],
-             LKEYS.ALTKEYREL.PRED #altkey ] ].
+  [ SYNSEM basic_partitive_synsem & [ LOCAL [ CAT.VAL.SPR < [ OPT +,
+                                                              LOCAL.CAT.HEAD.KEYS.KEY #altkey ] >,
+                                              CONT.RELS <! relation & [ PRED _otro_part_of_rel ] !> ],
+                                      LKEYS.ALTKEYREL.PRED #altkey ] ]
+  """
+  e.g. esta no es una guerra diferente a las otras
+  """.
 
-; e.g. (casi) ninguno (de los chicos)
+
 n_pp_pr-part-ninguno_lex := spec-partitive-pron-lex &
-  [ SYNSEM basic_partitive_synsem &
-           [ LOCAL [ CAT.VAL.SPR < [ OPT +,
-                                     LOCAL [ CAT.HEAD.KEYS.KEY _casi_x_deg_rel,
-                                             CONT.HOOK [ LTOP #alt2hand,
-                                                         XARG #index ] ],
-                                     NON-LOCAL [ QUE 0-dlist,
-                                                 REL 0-dlist ] ] >,
-                     CONT [ HOOK.INDEX #index,
-                            RELS <! relation, [ LBL #alt2hand ] !> ] ],
-             LKEYS.ALT2KEYREL.LBL #alt2hand ] ].
+  [ SYNSEM basic_partitive_synsem & [ LOCAL [ CAT.VAL.SPR < [ OPT +,
+                                                              LOCAL [ CAT.HEAD.KEYS.KEY _casi_x_deg_rel,
+                                                                      CONT.HOOK [ LTOP #alt2hand,
+                                                                                  XARG #index ] ],
+                                                              NON-LOCAL [ QUE 0-dlist,
+                                                                          REL 0-dlist ] ] >,
+                                              CONT [ HOOK.INDEX #index,
+                                                     RELS <! relation,
+                                                             [ LBL #alt2hand ] !> ] ],
+                                      LKEYS.ALT2KEYREL.LBL #alt2hand ] ]
+  """
+  e.g. (casi) ninguno (de los chicos)
+  """.
 
-; e.g. (cada) uno (de los chicos)
+
 n_pp_pr-part-uno_lex := spec-partitive-pron-lex &
-  [ SYNSEM basic_partitive_synsem &
-           [ LOCAL [ CAT.VAL.SPR < [ OPT +, 
-                                     LOCAL.CAT.HEAD.KEYS.KEY cada_q_rel ] >,  
-                     CONT.RELS <! relation & [ PRED card_rel ] !> ],
-             LKEYS.ALTKEYREL.PRED cada_q_rel ] ].
+  [ SYNSEM basic_partitive_synsem & [ LOCAL [ CAT.VAL.SPR < [ OPT +,
+                                                              LOCAL.CAT.HEAD.KEYS.KEY cada_q_rel ] >,
+                                              CONT.RELS <! relation & [ PRED card_rel ] !> ],
+                                      LKEYS.ALTKEYREL.PRED cada_q_rel ] ]
+  """
+  e.g. (cada) uno (de los chicos)
+  """.
 
-; e.g. *(unos) cuantos (de los chicos)
+
 n_pp_pr-part-cuantos_lex := spec-partitive-pron-lex &
-  [ SYNSEM basic_partitive_synsem &
-           [ LOCAL [ CAT.VAL.SPR < [ OPT -, 
-                                     LOCAL.CAT.HEAD.KEYS.KEY art_indef_q_rel ] >,
-                     CONT.RELS <! relation !> ],
-             LKEYS.ALTKEYREL.PRED art_indef_q_rel ] ].
+  [ SYNSEM basic_partitive_synsem & [ LOCAL [ CAT.VAL.SPR < [ OPT -,
+                                                              LOCAL.CAT.HEAD.KEYS.KEY art_indef_q_rel ] >,
+                                              CONT.RELS <! relation !> ],
+                                      LKEYS.ALTKEYREL.PRED art_indef_q_rel ] ]
+  """
+  e.g. *(unos) cuantos (de los chicos)
+  """.
 
 
 ; --- 2.3.5. Relative pronouns
-; - they don't inflect when they function as subjects, so its predicate agrees with its antecedent  
-; (e.g. yo, que me porté bien, pude salir temprano). 
-; NOTE: more in Bosque pp. 458-463
+
 rel_pronominal_synsem := lex-synsem &
   [ LOCAL [ AGR #index,
             CAT [ MC na,
@@ -5610,143 +6028,156 @@ rel_pronominal_synsem := lex-synsem &
                                XARG #xarg ] > ] ],
     LKEYS [ KEYREL [ PRED non_free_relative_nom_rel, 
                      LBL #hand ], 
-            ALTKEYREL relation ] ].
-;LKEYS [ KEYREL [ PRED non_temp_nom_rel,
+            ALTKEYREL relation ] ]
+"""
+; --- 2.3.5. Relative pronouns
+; - they don't inflect when they function as subjects, so its predicate agrees with its antecedent  
+; (e.g. yo, que me porté bien, pude salir temprano). 
+; NOTE: more in Bosque pp. 458-463
 
-; Free relatives have a non-empty QUE value whose single list element is an index 
-; (rather than the handle which is employed for ordinary question WH-words).
-; They encode the constraints for their S/XP sister in the free-relative construction, 
-; in their SLASH attribute.
-;free_rel_pro_lex := pronominal-lex &
+;LKEYS [ KEYREL [ PRED non_temp_nom_rel,
+""".
+
+
+
 free_rel_pro_lex := basic-nominal-lex &
   [ SYNSEM [ LOCAL [ AGR #ind,
-		     CAT [ HC-LIGHT -,
+                     CAT [ HC-LIGHT -,
                            MC na,
                            VAL [ SUBJ < >,
-			         COMPS < > ] ],
-		     CONT [ HOOK [ INDEX ref-ind & #ind,
+                                 COMPS < > ] ],
+                     CONT [ HOOK [ INDEX ref-ind & #ind,
                                    XARG #nhand ],
-			    RELS.LIST < [ ARG0 #ind,
-                                          RSTR #rhand ], 
+                            RELS.LIST < [ ARG0 #ind,
+                                          RSTR #rhand ],
                                         [ LBL #nhand,
                                           ARG0 #ind ], ... >,
-			    HCONS <! qeq &
-				    [ HARG #rhand,
-				      LARG #nhand ] !> ]],
-	     NON-LOCAL [ REL 0-dlist,
+                            HCONS <! qeq & [ HARG #rhand,
+                                             LARG #nhand ] !> ] ],
+             NON-LOCAL [ REL 0-dlist,
                          QUE 1-dlist & <! #ind !>,
-                         SLASH 1-dlist &
-                               <! [ CAT.VAL.COMPS < > ] !> ] ],
-    ARG-ST < > ].
+                         SLASH 1-dlist & <! [ CAT.VAL.COMPS < > ] !> ] ],
+    ARG-ST < > ]
+  """
+   Free relatives have a non-empty QUE value whose single list element is an index
+   (rather than the handle which is employed for ordinary question WH-words).
+   They encode the constraints for their S/XP sister in the free-relative construction,
+   in their SLASH attribute.
+  free_rel_pro_lex := pronominal-lex &
+  """.
 
-; a)- The pronoun "que":
-; - May occur in non-restrictive and restrictive RC, taking any syntactic funcion. It also   
-; occur in predicative and semi-free relatives (together with the quantifier), but they never occur 
-; in free relatvs.
-; - Must be preceeded by the article when functioning as a preposition's complement (and, obviously, when 
-; they occur in a semi-free relative, where we find other quantifiers (e.g. los estudiantes que faltaron 
-; fueron más que los/aquellos que asistieron))
-; e.g. el escritor al que premiaron anoche vendrá a nuestra tertulia.
-; - Never co-occur with the article in a non-oblique rel. explicativa
-;   - may function as DO without the prep. "a"
-;   e.g. el escritor que premiaron anoche vendrá a nuestra tertulia.
-;   - In oblique relatives the determiner may be absent when the antecedent has a 'caracter predicativo', and: 
-;     - the phrase including the relative is definite
-;     e.g. le regalé *una/la pluma con que había escrito mis novelas
-;     - the polarity of the subordinate clause can't be negative 
-;     e.g. me prestó el dinero *de/del que yo no disponía
-;     - only with the propositions "con", "de", "en", "por" and "a" (if it is not accusative nor dative)
-;     - que no sea explicativa (la empresa, *en que/en la que trabajo hace años, se dedica a ...)
-n_-_pr-rel-que_lex := pron_relat & 
-  [ SYNSEM rel_pronominal_synsem &
-           [ LOCAL [ CAT [ HEAD.KEYS [ KEY que_pron_rel, 
-                                     ALTKEY def_q_rel ],
-                           VAL.SPR #spr & 
-                                   < [ OPT -,
-                                       LOCAL [ CAT.HEAD det & [ KEYS.KEY def_q_rel ],
-                                               CONT.RELS <! relation !> ] ] > ] ] ],
-    ARG-ST #spr ]. 
 
-n_-_pr-free-rel-que_lex := free_rel_pro_lex & 
-  [ SYNSEM [ LOCAL [ CAT [ HEAD noun &
-                                [ MOD < >,
-                                  PRD non-prd,
-                                  KEYS [ KEY #pred,
-                                         ALTKEY semi-free_relative_q_rel ] ],
+n_-_pr-rel-que_lex := pron_relat &
+  [ SYNSEM rel_pronominal_synsem & [ LOCAL.CAT [ HEAD.KEYS [ KEY que_pron_rel,
+                                                             ALTKEY def_q_rel ],
+                                                 VAL.SPR #spr & < [ OPT -,
+                                                                    LOCAL [ CAT.HEAD det & [ KEYS.KEY def_q_rel ],
+                                                                            CONT.RELS <! relation !> ] ] > ] ],
+    ARG-ST #spr ]
+  """
+  a)- The pronoun "que":
+  - May occur in non-restrictive and restrictive RC, taking any syntactic funcion. It also
+  occur in predicative and semi-free relatives (together with the quantifier), but they never occur
+  in free relatvs.
+  - Must be preceeded by the article when functioning as a preposition's complement (and, obviously, when
+  they occur in a semi-free relative, where we find other quantifiers (e.g. los estudiantes que faltaron
+  fueron más que los/aquellos que asistieron))
+  e.g. el escritor al que premiaron anoche vendrá a nuestra tertulia.
+  - Never co-occur with the article in a non-oblique rel. explicativa
+    - may function as DO without the prep. "a"
+    e.g. el escritor que premiaron anoche vendrá a nuestra tertulia.
+    - In oblique relatives the determiner may be absent when the antecedent has a 'caracter predicativo', and:
+      - the phrase including the relative is definite
+      e.g. le regalé *una/la pluma con que había escrito mis novelas
+      - the polarity of the subordinate clause can't be negative
+      e.g. me prestó el dinero *de/del que yo no disponía
+      - only with the propositions "con", "de", "en", "por" and "a" (if it is not accusative nor dative)
+      - que no sea explicativa (la empresa, *en que/en la que trabajo hace años, se dedica a ...)
+  """.
+
+
+n_-_pr-free-rel-que_lex := free_rel_pro_lex &
+  [ SYNSEM [ LOCAL [ CAT [ HEAD noun & [ MOD < >,
+                                         PRD non-prd,
+                                         KEYS [ KEY #pred,
+                                                ALTKEY semi-free_relative_q_rel ] ],
                            VAL.SPR < [ OPT -,
-                                       LOCAL.CAT.HEAD det & [ KEYS.KEY art_def_q_rel ] ]> ],
+                                       LOCAL.CAT.HEAD det & [ KEYS.KEY art_def_q_rel ] ] > ],
                      CONT [ HOOK.INDEX #ind,
                             RELS <! #altkey, #key !> ] ],
-	     NON-LOCAL [ SLASH 1-dlist &
-                               <! [ AGR ref-ind,
-                                    CAT.HEAD [ MOD < >,
-                                               PRD non-prd ],
-                                    CONT.HOOK.INDEX #ind ] !> ],
+             NON-LOCAL.SLASH 1-dlist & <! [ AGR ref-ind,
+                                            CAT.HEAD [ MOD < >,
+                                                       PRD non-prd ],
+                                            CONT.HOOK.INDEX #ind ] !>,
              LKEYS [ KEYREL #key & [ PRED #pred & free_que_pron_rel ],
-                     ALTKEYREL #altkey & [ PRED semi-free_relative_q_rel ] ] ] ].
-;            LKEYS [ KEYREL #key & [ PRED #pred & nom_rel ],
+                     ALTKEYREL #altkey & [ PRED semi-free_relative_q_rel ] ] ] ]
+  """
+  
+  """.
 
-; b)- La forma "quien"
-; - puede aparecer en rel. especificativas, explicativas, predicativas y libres.
-; - sólo puede aparecer en las especificativas cuando actúa como término de preposición, 
-; i.e. no puede desempeñar la función de sujeto (*los congresistas quienes llegaron anoche 
-; fueron alojados provisionalmente)
-; - en las explicativas puede aparecer sin restricción alguna (los congresistas, quienes 
-; llegaron anoche, fueron alojados provisionalmente)
-; - cuando actúa de OD debe llevar la prep."a" (*el hombre quien vimos ayer...)
-n_-_pr-rel-quien_lex := pron_relat & 
-  [ SYNSEM rel_pronominal_synsem &
-           [ LOCAL [ CAT [ HEAD [ MOD < >,
-                                  KEYS [ KEY non_que_pron_rel, 
-                                         ALTKEY def_q_rel ] ],
-                           VAL.SPR < > ], 
-                     CONT.HOOK.INDEX.SORT hum ] ] ]. 
 
-n_-_pr-free-rel-quien_lex := free_rel_pro_lex & 
-  [ SYNSEM [ LOCAL [ CAT [ HEAD noun &
-                                [ MOD < >,
-                                  PRD non-prd,
-                                  KEYS [ KEY nom_rel & #pred,
-                                         ALTKEY free_relative_q_rel ] ],
+n_-_pr-rel-quien_lex := pron_relat &
+  [ SYNSEM rel_pronominal_synsem & [ LOCAL [ CAT [ HEAD [ MOD < >,
+                                                          KEYS [ KEY non_que_pron_rel,
+                                                                 ALTKEY def_q_rel ] ],
+                                                   VAL.SPR < > ],
+                                             CONT.HOOK.INDEX.SORT hum ] ] ]
+  """
+             LKEYS [ KEYREL #key & [ PRED #pred & nom_rel ],
+  b)- La forma "quien"
+  - puede aparecer en rel. especificativas, explicativas, predicativas y libres.
+  - sólo puede aparecer en las especificativas cuando actúa como término de preposición,
+  i.e. no puede desempeñar la función de sujeto (*los congresistas quienes llegaron anoche
+  fueron alojados provisionalmente)
+  - en las explicativas puede aparecer sin restricción alguna (los congresistas, quienes
+  llegaron anoche, fueron alojados provisionalmente)
+  - cuando actúa de OD debe llevar la prep."a" (*el hombre quien vimos ayer...)
+  """.
+
+
+n_-_pr-free-rel-quien_lex := free_rel_pro_lex &
+  [ SYNSEM [ LOCAL [ CAT [ HEAD noun & [ MOD < >,
+                                         PRD non-prd,
+                                         KEYS [ KEY nom_rel & #pred,
+                                                ALTKEY free_relative_q_rel ] ],
                            VAL.SPR < > ],
                      CONT [ HOOK.INDEX #ind & [ SORT hum ],
-                            RELS <! #altkey,  #key !> ] ],
-	     NON-LOCAL [ SLASH 1-dlist &
-                               <! [ AGR ref-ind,
-                                    CAT.HEAD [ MOD < >,
-                                               PRD non-prd ],
-                                    CONT.HOOK.INDEX #ind ] !> ],
+                            RELS <! #altkey, #key !> ] ],
+             NON-LOCAL.SLASH 1-dlist & <! [ AGR ref-ind,
+                                            CAT.HEAD [ MOD < >,
+                                                       PRD non-prd ],
+                                            CONT.HOOK.INDEX #ind ] !>,
              LKEYS [ KEYREL #key & [ PRED #pred ],
-                     ALTKEYREL #altkey & [ PRED free_relative_q_rel ] ] ] ].
-
-; c)- La forma "el cual"
-; - no puede aparecer en rel. libres o semilibres
-; - sólo puede aparecer en las especificativas cuando actúa como término de preposición, 
-; e.g. *ese es un tema el cual ha estudiado a fondo/sobre el cual tiene varios artículos
-; - es el único rel. que puede aparecer al final de un grupo fónico: 
-;   - c. genitivo no extrapuesto de sintagmas partitivos
-;   e.g. los estudiantes, la mayoría de los cuales apoyó la propuesta, se manifestaron.
-;   - suj. de cláusulas absolutas , e.g. dicho lo cual
-;   - término de locuciones prepositivas( a consecuencia de, en torno a,...) 
-; - aparece con frecuencia al frente de la rel. yustapuestas, o cuando el antecedentes es
-; un SN complejo de cuyo núcleo queda distanciado el rel.
-; e.g. la columna de humo que causó la explosión, el cual se propagó a otros edificios
-n_-_pr-rel-cual_lex := pron_relat & 
-  [ SYNSEM rel_pronominal_synsem &
-           [ LOCAL.CAT [ HEAD [ MOD < >,
-                                KEYS [ KEY non_que_pron_rel, 
-                                     ALTKEY def_q_rel ] ],
-                         VAL.SPR #spr & < [ OPT -,
-                                            LOCAL.CAT.HEAD det & [ KEYS.KEY art_def_q_rel ] ] > ] ], 
-    ARG-ST #spr ]. 
+                     ALTKEYREL #altkey & [ PRED free_relative_q_rel ] ] ] ]
+  """
+  
+  """.
 
 
-; d)- cuantos le oían le admiraban
+n_-_pr-rel-cual_lex := pron_relat &
+  [ SYNSEM rel_pronominal_synsem & [ LOCAL.CAT [ HEAD [ MOD < >,
+                                                        KEYS [ KEY non_que_pron_rel,
+                                                               ALTKEY def_q_rel ] ],
+                                                 VAL.SPR #spr & < [ OPT -,
+                                                                    LOCAL.CAT.HEAD det & [ KEYS.KEY art_def_q_rel ] ] > ] ],
+    ARG-ST #spr ]
+  """
+  c)- La forma "el cual"
+  - no puede aparecer en rel. libres o semilibres
+  - sólo puede aparecer en las especificativas cuando actúa como término de preposición,
+  e.g. *ese es un tema el cual ha estudiado a fondo/sobre el cual tiene varios artículos
+  - es el único rel. que puede aparecer al final de un grupo fónico:
+    - c. genitivo no extrapuesto de sintagmas partitivos
+    e.g. los estudiantes, la mayoría de los cuales apoyó la propuesta, se manifestaron.
+    - suj. de cláusulas absolutas , e.g. dicho lo cual
+    - término de locuciones prepositivas( a consecuencia de, en torno a,...)
+  - aparece con frecuencia al frente de la rel. yustapuestas, o cuando el antecedentes es
+  un SN complejo de cuyo núcleo queda distanciado el rel.
+  e.g. la columna de humo que causó la explosión, el cual se propagó a otros edificios
+  """.
 
-; --- 2.3.6. Interrogative pronouns (qué, quién/es, cuál/es, cuánto/s)
-; - quién, cuál y cuánto pueden tomar un PP_de partitivo
-; e.g. ¿Quién/cuál/cuántos de tus amigos es diputado?
-basic_wh_pron_lex := pronominal-lex & 
+
+basic_wh_pron_lex := pronominal-lex &
   [ SYNSEM [ LOCAL [ AGR #index,
                      CAT [ MC na,
                            HC-LIGHT -,
@@ -5757,46 +6188,71 @@ basic_wh_pron_lex := pronominal-lex &
                                       ARG0 #index ],
                                     [ ARG0 #index,
                                       RSTR #rhand ] !>,
-			    HCONS <! qeq &
-				     [ HARG #rhand,
-				       LARG #nhand ] !> ] ],
-	     NON-LOCAL [ REL 0-dlist,
-                         QUE 1-dlist & [ LIST < param > ] ] ] ].
+                            HCONS <! qeq & [ HARG #rhand,
+                                             LARG #nhand ] !> ] ],
+             NON-LOCAL [ REL 0-dlist,
+                         QUE 1-dlist & [ LIST < param > ] ] ] ]
+  """
+  d)- cuantos le oían le admiraban
+  --- 2.3.6. Interrogative pronouns (qué, quién/es, cuál/es, cuánto/s)
+  - quién, cuál y cuánto pueden tomar un PP_de partitivo
+  e.g. ¿Quién/cuál/cuántos de tus amigos es diputado?
+  """.
 
-pron_wh_lex := basic_wh_pron_lex & 
+
+pron_wh_lex := basic_wh_pron_lex &
   [ SYNSEM.LOCAL [ AGR #index,
-                   CAT.VAL.COMPS < >, 
+                   CAT.VAL.COMPS < >,
                    CONT.HOOK.INDEX #index ],
-    ARG-ST < > ].
+    ARG-ST < > ]
+  """
+  
+  """.
+
 
 pron_wh_part_lex := basic_wh_pron_lex &
-  [ SYNSEM basic-partitive-pron-synsem & 
-           [ LOCAL [ AGR.PNG.GEN #gender,
-                     CAT.VAL.COMPS #comps &  
-                                   < [ OPT +,
-                                       LOCAL.CONT.HOOK.INDEX.PNG [ PN plur, GEN #gender ] ] >,
-                     CONT.HOOK.INDEX.SORT non-temp ] ],
-    ARG-ST #comps ].
+  [ SYNSEM basic-partitive-pron-synsem & [ LOCAL [ AGR.PNG.GEN #gender,
+                                                   CAT.VAL.COMPS #comps & < [ OPT +,
+                                                                              LOCAL.CONT.HOOK.INDEX.PNG [ PN plur,
+                                                                                                          GEN #gender ] ] >,
+                                                   CONT.HOOK.INDEX.SORT non-temp ] ],
+    ARG-ST #comps ]
+  """
+  
+  """.
+
 
 n_-_pr-wh-que_lex := pron_wh_lex &
-  [ SYNSEM [ LOCAL [ CONT [ HOOK.INDEX.SORT non-hum_non-temp,
-                            RELS <! relation, 
-                                    [ PRED que_q_rel ] !> ] ],
-             LKEYS.KEYREL.PRED thing_rel ] ].
+  [ SYNSEM [ LOCAL.CONT [ HOOK.INDEX.SORT non-hum_non-temp,
+                          RELS <! relation, [ PRED que_q_rel ] !> ],
+             LKEYS.KEYREL.PRED thing_rel ] ]
+  """
+  
+  """.
 
-n_pp_pr-wh-quien_lex := pron_wh_part_lex & 
-  [ SYNSEM [ LOCAL [ CAT.HEAD.CASE nom,
-                     CONT [ HOOK.INDEX.SORT hum,
-                            RELS <! relation, 
-                                    [ PRED que_q_rel ] !> ] ] ] ].
 
-n_pp_pr-wh-cual_lex := pron_wh_part_lex & 
-  [ SYNSEM [ LOCAL.CONT.RELS <! relation, 
-                                [ PRED que_q_rel ] !> ] ].
+n_pp_pr-wh-quien_lex := pron_wh_part_lex &
+  [ SYNSEM.LOCAL [ CAT.HEAD.CASE nom,
+                   CONT [ HOOK.INDEX.SORT hum,
+                          RELS <! relation, [ PRED que_q_rel ] !> ] ] ]
+  """
+  
+  """.
 
-n_pp_pr-wh-cuanto_lex := pron_wh_part_lex & 
-  [ SYNSEM [ LOCAL.CONT.RELS <! relation, 
-                                [ PRED que_q_rel ] !> ] ].
+
+n_pp_pr-wh-cual_lex := pron_wh_part_lex &
+  [ SYNSEM.LOCAL.CONT.RELS <! relation, [ PRED que_q_rel ] !> ]
+  """
+  
+  """.
+
+
+n_pp_pr-wh-cuanto_lex := pron_wh_part_lex &
+  [ SYNSEM.LOCAL.CONT.RELS <! relation, [ PRED que_q_rel ] !> ]
+  """
+  
+  """.
+
 
 
 

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -8580,20 +8580,24 @@ basic_det_synsem := lex-synsem &
 ; with 'ad-sensum' agr. 
 """.
 
-; dets taking spr and building a DP
 specfd_det_synsem := basic_det_synsem &
   [ LOCAL [ AGR #agr,
             CAT.VAL.SPR < [ LIGHT +,
                             LOCAL.AGR #agr,
                             NON-LOCAL [ QUE 0-dlist,
-                                        REL 0-dlist ] ] > ] ].
+                                        REL 0-dlist ] ] > ] ]
+"""
+; dets taking spr and building a DP
+""".
 
-; sub-hierarchy of dets on the basis of non-local values
 det_que := basic-det-lex & 
   [ SYNSEM [ LOCAL.CAT [ POSTHEAD -,
                          VAL.COMPS < > ], 
              NON-LOCAL [ QUE 1-dlist & [ LIST < param > ],
-                         REL 0-dlist ] ] ]. 
+                         REL 0-dlist ] ] ]
+"""
+; sub-hierarchy of dets on the basis of non-local valuess
+""". 
 
 det_nonque := basic-det-lex & 
   [ SYNSEM.NON-LOCAL.QUE 0-dlist ]. 
@@ -8614,8 +8618,7 @@ det_nonque_nonrel_nonposs := det_nonque_nonrel &
 
 
 ; --- 6.1. Definite articles
-; - (todo) + DEF. ART + (adj. indef.)* + (adj. qual.)* + N'
-; e.g. (todos) los (otros) (muchos/pocos/tres) libros
+
 d_-_art-d := det_nonque_nonrel_nonposs & 
   [ SYNSEM basic_det_synsem & 
            [ LOCAL.CAT [ POSTHEAD -,
@@ -8625,16 +8628,18 @@ d_-_art-d := det_nonque_nonrel_nonposs &
                                COMPS < > ] ],
              LKEYS [ KEYREL [ PRED _el_q_rel,
                               LBL #lbl ],
-                     ALTKEYREL.LBL #lbl ] ] ].
+                     ALTKEYREL.LBL #lbl ] ] ]
+"""
+; --- 6.1. Definite articles
+; - (todo) + DEF. ART + (adj. indef.)* + (adj. qual.)* + N'
+; e.g. (todos) los (otros) (muchos/pocos/tres) libros
+""".
 
 d_-_art-d_lex := d_-_art-d &
   [ SYNSEM specfd_det_synsem ].
 
  
 ; --- 6.2. Indefinite article
-; - INDEF. ART + (cardinal) + Pl_N'
-; e.g. Necesito unas tres personas 
-; !!! yet not covered: ¡cayó una (cantidad) de agua...!
 d_-_art-i_lex := det_nonque_nonrel_nonposs &
   [ SYNSEM specfd_det_synsem &
            [ LOCAL.CAT [ POSTHEAD -,
@@ -8643,23 +8648,16 @@ d_-_art-i_lex := det_nonque_nonrel_nonposs &
                                        LOCAL.CAT.HEAD.KEYS.KEY pre_indef_art_rel ] > ] ],
              LKEYS [ KEYREL [ PRED art_indef_q_rel,
                               LBL #lbl ],
-                     ALTKEYREL.LBL #lbl ] ] ].
+                     ALTKEYREL.LBL #lbl ] ] ]
+"""
+; --- 6.2. Indefinite article
+; - INDEF. ART + (cardinal) + Pl_N'
+; e.g. Necesito unas tres personas 
+; !!! yet not covered: ¡cayó una (cantidad) de agua...!
+""".
 
 ; --- 6.3. Possessives 
-; - no puede aparecer con relativas especificativas, ni con SNs cuyo núcleu se relacione con
-; verbos impersonales meteorológicos (*su nevada nos dejó aislados). Tampoco en un SN con 
-; núcleo elíptico (*su coche pequeño y mi grande).No se puede interpretar de forma impersonal, 
-; a no ser que exista un antecedente impersonal sintácticamente explícito. Puede realizar las 
-; funciones de poseedor, agente o tema, pronominalizando complementos o adjuntos introducidos 
-; por la prep "de". Pero no pueden pronominalizar complementos locativos de procedencia, ni 
-; adjuntos que expresan materia, ni expresiones temporales, ni los complementos partitivos 
-; - Existe una jerarquía para la realización de los argumentos como posesivos: (POSEEDOR >) AGENTE > TEMA
-; - when they follow the noun, they are modifiers and they require the def. article or the 
-; demonstrative, e.g. la/esa canción tuya me gustó
-; - (todo) + POSS + (adj. indef.)* + (adj. qual.)* + N'
-;   e.g. (todos) tus (otros) (muchos/pocos/tres) libros
-; - dem + POSS + N'
-;   e.g. esos tus ojos
+
 det_poss := det_nonque_nonrel & 
   [ SYNSEM specfd_det_synsem &
            [ LOCAL [ CAT [ POSTHEAD -,
@@ -8686,7 +8684,24 @@ det_poss := det_nonque_nonrel &
                             HCONS <! qeq, qeq & [ HARG #rhand,
                                                   LARG #prohand ] !> ] ],
              LKEYS [ KEYREL.PRED poss_q_rel, 
-                     ALTKEYREL #altkey ] ] ]. 
+                     ALTKEYREL #altkey ] ] ]
+"""
+; --- 6.3. Possessives 
+; - no puede aparecer con relativas especificativas, ni con SNs cuyo núcleu se relacione con
+; verbos impersonales meteorológicos (*su nevada nos dejó aislados). Tampoco en un SN con 
+; núcleo elíptico (*su coche pequeño y mi grande).No se puede interpretar de forma impersonal, 
+; a no ser que exista un antecedente impersonal sintácticamente explícito. Puede realizar las 
+; funciones de poseedor, agente o tema, pronominalizando complementos o adjuntos introducidos 
+; por la prep "de". Pero no pueden pronominalizar complementos locativos de procedencia, ni 
+; adjuntos que expresan materia, ni expresiones temporales, ni los complementos partitivos 
+; - Existe una jerarquía para la realización de los argumentos como posesivos: (POSEEDOR >) AGENTE > TEMA
+; - when they follow the noun, they are modifiers and they require the def. article or the 
+; demonstrative, e.g. la/esa canción tuya me gustó
+; - (todo) + POSS + (adj. indef.)* + (adj. qual.)* + N'
+;   e.g. (todos) tus (otros) (muchos/pocos/tres) libros
+; - dem + POSS + N'
+;   e.g. esos tus ojos
+""". 
 
 d_-_poss-mi_lex := det_poss &
  [ SYNSEM.LKEYS.KEYREL.PRED _mi_q_rel ]. 
@@ -8704,12 +8719,7 @@ d_-_poss-vuestro_lex := det_poss &
  [ SYNSEM.LKEYS.KEYREL.PRED _vuestro_q_rel ].
 
 ; --- 6.4. Demonstratives
-; - when they follow the noun, they are modifiers and they require the definite article
-; e.g. la canción esa me gustó
-; - (todo) + DEM + (otro) (mucho/poco/cardinal) + N'
-;   e.g. (todos) estos (otros) (muchos/pocos/tres) libros
-; - DEM + poss + N'
-;   e.g. esos tus ojos
+
 det_dem := det_nonque_nonrel_nonposs & 
   [ SYNSEM specfd_det_synsem &
            [ LOCAL.CAT [ POSTHEAD -,
@@ -8718,7 +8728,16 @@ det_dem := det_nonque_nonrel_nonposs &
                                COMPS < > ] ],
              LKEYS [ KEYREL [ PRED dem_q_rel,
                               LBL #lbl ],
-                     ALTKEYREL.LBL #lbl ] ] ].
+                     ALTKEYREL.LBL #lbl ] ] ]
+"""
+; --- 6.4. Demonstratives
+; - when they follow the noun, they are modifiers and they require the definite article
+; e.g. la canción esa me gustó
+; - (todo) + DEM + (otro) (mucho/poco/cardinal) + N'
+;   e.g. (todos) estos (otros) (muchos/pocos/tres) libros
+; - DEM + poss + N'
+;   e.g. esos tus ojos
+""".
 
 d_-_dem-este_lex := det_dem &
  [ SYNSEM.LKEYS.KEYREL.PRED _este_q_rel ].
@@ -8729,8 +8748,6 @@ d_-_dem-ese_lex := det_dem &
 d_-_dem-aquel_lex := det_dem &
  [ SYNSEM.LKEYS.KEYREL.PRED _aquel_q_rel ].
 
-; --- the demonstrative "tal" 
-; e.g. en tal ocasión, en tales casos
 d_-_tal_lex := det_nonque_nonrel_nonposs & 
   [ SYNSEM basic_det_synsem &
            [ LOCAL.CAT [ POSTHEAD -,
@@ -8739,10 +8756,12 @@ d_-_tal_lex := det_nonque_nonrel_nonposs &
                                COMPS < > ] ],
              LKEYS [ KEYREL [ PRED _tal_q_rel,
                               LBL #lbl ],
-                     ALTKEYREL.LBL #lbl ] ] ].
+                     ALTKEYREL.LBL #lbl ] ] ]
+"""
+; --- the demonstrative "tal" 
+; e.g. en tal ocasión, en tales casos
+""".
 
-; --- The demonstrative "semejante" 
-; e.g. semenjante persona no puede estar aquí
 d_-_semejante_lex := det_nonque_nonrel_nonposs & 
   [ SYNSEM basic_det_synsem &
            [ LOCAL.CAT [ POSTHEAD -,
@@ -8751,102 +8770,141 @@ d_-_semejante_lex := det_nonque_nonrel_nonposs &
                                COMPS < > ] ],
              LKEYS [ KEYREL [ PRED _semejante_q_rel,
                               LBL #lbl ],
-                     ALTKEYREL.LBL #lbl ] ] ].
+                     ALTKEYREL.LBL #lbl ] ] ]
+"""
+; --- The demonstrative "semejante" 
+; e.g. semenjante persona no puede estar aquí
+""".
 
 ; --- 6.5. Quantifiers
+
 det_quant := det_nonque_nonrel_nonposs & 
   [ SYNSEM basic_det_synsem &
            [ LOCAL.CAT.VAL.COMPS < >,
              LKEYS [ KEYREL.LBL #lbl,
                      ALTKEYREL.LBL #lbl ] ] ].
 
+
 ; --- 6.5.1. Universal Def/Indef. Quantifier (cualquier)
-; - cualquier + (otro) + Count Sg_N'
+  
 d_-_q-cualquier_lex := det_quant &
   [ SYNSEM [ LOCAL [ AGR [ PNG.PN sing,
                            DIVISIBLE - ],
                      CAT [ POSTHEAD -,
                            VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
                                  SPR < > ] ] ],
-             LKEYS.KEYREL.PRED _cualquiera_q_rel ] ].
+             LKEYS.KEYREL.PRED _cualquiera_q_rel ] ]
+  """
+  --- 6.5.1. Universal Def/Indef. Quantifier (cualquier)
+  - cualquier + (otro) + Count Sg_N'
+  """.
 
-; - cualquiera: it may follow (modify) the noun, but then it needs an indef. article or a cardinal number
-; e.g. un hombre cualquiera, tres libros cualesquiera.
-aj_-_i-nprd-cualquiera_lex := aj_rel & a_intrans & norm-zero-arg & 
-  [ SYNSEM.LOCAL.CAT [ POSTHEAD +, 
+
+aj_-_i-nprd-cualquiera_lex := aj_rel & a_intrans & norm-zero-arg &
+  [ SYNSEM.LOCAL.CAT [ POSTHEAD +,
                        HEAD [ PRD non-prd,
                               MOD < [ LOCAL.CAT [ HEAD.KEYS.ALTKEY undef_quant_q_rel,
-                                                  VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY quant_rel ] > ] ] > ] ] ].
+                                                  VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY quant_rel ] > ] ] > ] ] ]
+  """
+  - cualquiera: it may follow (modify) the noun, but then it needs an indef. article or a cardinal number
+  e.g. un hombre cualquiera, tres libros cualesquiera.
+  """.
 
-; --- 6.5.2. Universal (or definite) Quantifiers 
-; !!! pueden cuantificar nombres contables, de sustancia o abstractos
-; - tienen caracter definido 
-; e.g. *hay [cada libro/ambos libros/todos los libros] en el estante
+; --- 6.5.2. Universal (or definite) Quantifiers  
+
 det_def_quant := det_quant &
   [ SYNSEM [ LOCAL.CAT.POSTHEAD -,
-             LKEYS.KEYREL.PRED univ_quant_q_rel ] ].
+             LKEYS.KEYREL.PRED univ_quant_q_rel ] ]
+  """
+  --- 6.5.2. Universal (or definite) Quantifiers
+  !!! pueden cuantificar nombres contables, de sustancia o abstractos
+  - tienen caracter definido
+  e.g. *hay [cada libro/ambos libros/todos los libros] en el estante
+  """.
 
-; - AMBOS + Pl_N'
+
 d_-_q-ambos_lex := det_nonque_nonrel &
-  [ SYNSEM basic_det_synsem &
-           [ LOCAL [ CAT [ POSTHEAD -,
-                           VAL.COMPS < > ],
-                     CONT [ HOOK.INDEX #index,
-                            HCONS <! [ LARG #larg ] !>,
-                            RELS <! relation, 
-                                    #altkey & 
-                                    [ LBL #larg,
-                                      PRED card_q_rel,
-                                      ARG1 #index,
-                                      CARG "2" ] !> ] ],
-             LKEYS [ KEYREL.PRED univ_quant_q_rel &_ambos_q_rel, 
-                     ALTKEYREL #altkey ] ] ].
+  [ SYNSEM basic_det_synsem & [ LOCAL [ CAT [ POSTHEAD -,
+                                              VAL.COMPS < > ],
+                                        CONT [ HOOK.INDEX #index,
+                                               HCONS <! [ LARG #larg ] !>,
+                                               RELS <! relation,
+                                                       #altkey & [ LBL #larg,
+                                                                   PRED card_q_rel,
+                                                                   ARG1 #index,
+                                                                   CARG "2" ] !> ] ],
+                                LKEYS [ KEYREL.PRED univ_quant_q_rel & _ambos_q_rel,
+                                        ALTKEYREL #altkey ] ] ]
+  """
+  - AMBOS + Pl_N'
+  """.
 
-; - SENDOS + Pl_N'
-d_-_q-sendos_lex := det_def_quant & 
+
+d_-_q-sendos_lex := det_def_quant &
   [ SYNSEM [ LOCAL [ AGR.PNG.PN plur,
                      CAT.VAL.SPEC < [ LOCAL.CAT.HEAD noun ] > ],
-             LKEYS.KEYREL.PRED _sendos_q_rel ] ].
+             LKEYS.KEYREL.PRED _sendos_q_rel ] ]
+  """
+  - SENDOS + Pl_N'
+  """.
 
-; - CADA + Sg_N'
-; e.g. íbamos al cine cada día
+
 d_-_q-cada_lex := det_def_quant &
   [ SYNSEM [ LOCAL [ AGR.PNG.PN sing,
                      CAT.VAL.SPEC < [ LOCAL.CAT.HEAD noun ] > ],
-             LKEYS.KEYREL.PRED _cada_q_rel ] ].
-
-; - (casi) + TODO + art_def;dem;poss + N'
-; e.g. (casi) todos los/estos/sus alumnos
-d_-_q-todo_lex := det_def_quant & 
-  [ SYNSEM specfd_det_synsem &
-           [ LOCAL.CAT.VAL [ SPR < [ OPT +,
-                                     LOCAL [ CAT.HEAD.KEYS.KEY _casi_x_deg_rel,
-                                             CONT.HOOK.LTOP #lbl ] ] >,
-                             SPEC < [ LOCAL.CAT.HEAD.KEYS.KEY post_todo_q_rel ] > ],
-             LKEYS [ KEYREL.PRED todo_def_q_rel,
-                     ALTKEYREL.LBL #lbl ] ] ].
-;                         SPEC < [ LOCAL.CAT.HEAD.KEYS.KEY def_q_rel ] > ],
-
-; e.g. (casi) todos estos/nosotros
-d_-_q-prn-todo_lex := det_def_quant & 
-  [ SYNSEM specfd_det_synsem &
-           [ LOCAL [ AGR.PNG.PN plur,
-                     CAT.VAL [ SPR < [ OPT +,
-                                       LOCAL [ CAT.HEAD.KEYS.KEY _casi_x_deg_rel,
-                                               CONT.HOOK.LTOP #lbl ] ] >,
-                               SPEC < [ LOCAL [ CAT.HEAD noun & [ KEYS.KEY non_modable_rel ],
-                                                CONT.HOOK.INDEX.PRONTYPE real_pron ] ] > ] ],
-             LKEYS [ KEYREL.PRED todo_def_q_rel,
-                     ALTKEYREL.LBL #lbl ] ] ]. 
+             LKEYS.KEYREL.PRED _cada_q_rel ] ]
+  """
+  - CADA + Sg_N'
+  e.g. íbamos al cine cada día
+  """.
 
 
-; --- 6.5.3. Non-universal (or indef.) Quantifiers
-; - forman SSNN indefinidos. e.g. había algunos/muchos/varios (otros) problemas
+d_-_q-todo_lex := det_def_quant &
+  [ SYNSEM specfd_det_synsem & [ LOCAL.CAT.VAL [ SPR < [ OPT +,
+                                                         LOCAL [ CAT.HEAD.KEYS.KEY _casi_x_deg_rel,
+                                                                 CONT.HOOK.LTOP #lbl ] ] >,
+                                                 SPEC < [ LOCAL.CAT.HEAD.KEYS.KEY post_todo_q_rel ] > ],
+                                 LKEYS [ KEYREL.PRED todo_def_q_rel,
+                                         ALTKEYREL.LBL #lbl ] ] ]
+  """
+  - (casi) + TODO + art_def;dem;poss + N'
+  e.g. (casi) todos los/estos/sus alumnos
+
+  ;                         SPEC < [ LOCAL.CAT.HEAD.KEYS.KEY def_q_rel ] > ],
+  
+  """.
+
+
+d_-_q-prn-todo_lex := det_def_quant &
+  [ SYNSEM specfd_det_synsem & [ LOCAL [ AGR.PNG.PN plur,
+                                         CAT.VAL [ SPR < [ OPT +,
+                                                           LOCAL [ CAT.HEAD.KEYS.KEY _casi_x_deg_rel,
+                                                                   CONT.HOOK.LTOP #lbl ] ] >,
+                                                   SPEC < [ LOCAL [ CAT.HEAD noun & [ KEYS.KEY non_modable_rel ],
+                                                                    CONT.HOOK.INDEX.PRONTYPE real_pron ] ] > ] ],
+                                 LKEYS [ KEYREL.PRED todo_def_q_rel,
+                                         ALTKEYREL.LBL #lbl ] ] ]
+  """
+  e.g. (casi) todos estos/nosotros
+  """.
+
+;--- 6.5.3. Non-universal (or indef.) Quantifiers
+  
 det_quant_indef := det_quant &
   [ SYNSEM [ LOCAL.CAT [ POSTHEAD -,
                          VAL.SPEC < [ LOCAL.CAT.HEAD noun ] > ],
-             LKEYS.KEYREL.PRED undef_quant_q_rel ] ].
+             LKEYS.KEYREL.PRED undef_quant_q_rel ] ]
+  """
+  --- 6.5.3. Non-universal (or indef.) Quantifiers
+  - forman SSNN indefinidos. e.g. había algunos/muchos/varios (otros) problemas
+  """.
 
+
+; --- 6.5.3.1. Cuantificadores de existencia
+
+d_qnt-indf_alg-ning := det_quant_indef &
+  [ SYNSEM.LOCAL.CAT.VAL.SPR < > ]
+"""
 ; --- 6.5.3.1. Cuantificadores de existencia
 ; - no pueden ser predicados, ni como atributos, ni como adjetivos pospuestos a otro 
 ; determinante. e.g. *sus problemas eran algunos/ningunos, *su alguna/ninguna compañera
@@ -8855,115 +8913,166 @@ det_quant_indef := det_quant &
 ; - alguno/ninguno always follow the noun (e.g. no tengo miedo alguno); 
 ; algún/ningún always precede the nouns; alguna/os/as, ninguna may precede 
 ; and follow the noun. 
-d_qnt-indf_alg-ning := det_quant_indef &
-  [ SYNSEM.LOCAL.CAT.VAL.SPR < > ]. 
+
+""". 
+
 
 d_-_q-algun_lex := d_qnt-indf_alg-ning &
-  [ SYNSEM.LKEYS.KEYREL.PRED _alguno_q_rel ]. 
+  [ SYNSEM.LKEYS.KEYREL.PRED _alguno_q_rel ]
+  """
+  
+  """.
+
 
 d_-_q-ningun_lex := d_qnt-indf_alg-ning &
-  [ SYNSEM.LKEYS.KEYREL.PRED _ninguno_q_rel ]. 
+  [ SYNSEM.LKEYS.KEYREL.PRED _ninguno_q_rel ]
+  """
+  
+  """.
 
-; b)- UNOS CUANTOS + (otro) Pl_N'
-; e.g. 
-d_-_q-cuantos_lex := det_quant_indef & 
-  [ SYNSEM specfd_det_synsem &
-           [ LOCAL [ AGR.PNG.PN plur,
-                     CAT.VAL.SPR < [ OPT -,
-                                     LOCAL.CAT.HEAD.KEYS.KEY art_indef_q_rel ] > ],
-             LKEYS.KEYREL.PRED _cuantos_q_rel ] ].
 
-; b)- TODO + (otro) Sg_N'
-; e.g. toda persona ajena a la empresa
-d_-_q-todo-sg_lex := det_quant & 
+d_-_q-cuantos_lex := det_quant_indef &
+  [ SYNSEM specfd_det_synsem & [ LOCAL [ AGR.PNG.PN plur,
+                                         CAT.VAL.SPR < [ OPT -,
+                                                         LOCAL.CAT.HEAD.KEYS.KEY art_indef_q_rel ] > ],
+                                 LKEYS.KEYREL.PRED _cuantos_q_rel ] ]
+  """
+  b)- UNOS CUANTOS + (otro) Pl_N'
+  e.g.
+  """.
+
+
+d_-_q-todo-sg_lex := det_quant &
   [ SYNSEM [ LOCAL [ AGR [ DIVISIBLE -,
                            PNG.PN sing ],
                      CAT [ POSTHEAD -,
                            VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
                                  SPR < > ] ] ],
-             LKEYS.KEYREL.PRED todo_undef_q_rel ] ].
+             LKEYS.KEYREL.PRED todo_undef_q_rel ] ]
+  """
+  b)- TODO + (otro) Sg_N'
+  e.g. toda persona ajena a la empresa
+  """.
 
-; --- 6.5.3.2. Cuantificadores evaluativos
-; pueden ser predicados, sea como atributo, sea como adjetivo pospuesto a otro 
-; determinante (i.e. se les aplicaran RLs que los convertiran en adj. indef.)
-; e.g. sus problemas eran muchos/demasiado, sus demasiados/muchos problemas.
-det_quant_eval := det_nonque_nonrel & 
-  [ SYNSEM basic_det_synsem &
-           [ LOCAL [ CAT [ POSTHEAD -,
-                           VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
-                                 COMPS < > ] ],
-                     CONT [ HOOK [ LTOP #ltop,
-                                   INDEX #index,
-                                   XARG #larg ], 
-                            HCONS <! qeq & [ HARG #harg,
-                                             LARG #larg ] !>,
-                            RELS <! [ LBL #ltop,
-                                      PRED undef_q_rel,
-                                      ARG0 #index,
-                                      RSTR #harg ],
-                                    #altkey & [ PRED card_or_undef_q_rel,
-                                                LBL #larg,
-                                                ARG1 #index ] !> ] ],
-             LKEYS.ALTKEYREL #altkey ] ].
+;--- 6.5.3.2. Cuantificadores evaluativos
 
-; a)- OTRO (mediante una regla léxica se convierte en adj. indef que modifica a un sust.
-; que tendrá un especificador con KEYS.KEY pre_otro_q_rel 
-; (el/este/su/algún/poco/bastante) + otro + N'
+det_quant_eval := det_nonque_nonrel &
+  [ SYNSEM basic_det_synsem & [ LOCAL [ CAT [ POSTHEAD -,
+                                              VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
+                                                    COMPS < > ] ],
+                                        CONT [ HOOK [ LTOP #ltop,
+                                                      INDEX #index,
+                                                      XARG #larg ],
+                                               HCONS <! qeq & [ HARG #harg,
+                                                                LARG #larg ] !>,
+                                               RELS <! [ LBL #ltop,
+                                                         PRED undef_q_rel,
+                                                         ARG0 #index,
+                                                         RSTR #harg ],
+                                                       #altkey & [ PRED card_or_undef_q_rel,
+                                                                   LBL #larg,
+                                                                   ARG1 #index ] !> ] ],
+                                LKEYS.ALTKEYREL #altkey ] ]
+  """
+  --- 6.5.3.2. Cuantificadores evaluativos
+  pueden ser predicados, sea como atributo, sea como adjetivo pospuesto a otro
+  determinante (i.e. se les aplicaran RLs que los convertiran en adj. indef.)
+  e.g. sus problemas eran muchos/demasiado, sus demasiados/muchos problemas.
+  """.
+
+
 d_-_q-otro_lex := det_quant_eval &
-   [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
-              LKEYS.ALTKEYREL.PRED _otro_q_rel ] ]. 
+  [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
+             LKEYS.ALTKEYREL.PRED _otro_q_rel ] ]
+  """
+  a)- OTRO (mediante una regla léxica se convierte en adj. indef que modifica a un sust.
+  que tendrá un especificador con KEYS.KEY pre_otro_q_rel
+  (el/este/su/algún/poco/bastante) + otro + N'
+  """.
 
-; b)- MUCHO/POCO (mediante una regla léxica se convierten en adj. indef que modifican a un 
-; sust. que tendrán un especificador con KEYS.KEY pre_much_or_poc_q_rel 
-; (el/este/su/otro) + poco/mucho + N'
-; lo mismo para los numerales cardinales
+
 d_-_q-mucho_lex := det_quant_eval &
-   [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
-              LKEYS.ALTKEYREL.PRED _mucho_q_rel ] ]. 
+  [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
+             LKEYS.ALTKEYREL.PRED _mucho_q_rel ] ]
+  """
+  b)- MUCHO/POCO (mediante una regla léxica se convierten en adj. indef que modifican a un
+  sust. que tendrán un especificador con KEYS.KEY pre_much_or_poc_q_rel
+  (el/este/su/otro) + poco/mucho + N'
+  lo mismo para los numerales cardinales
+  """.
 
-d_-_q-poco_lex := det_quant_eval & 
-   [ SYNSEM specfd_det_synsem &
-            [ LOCAL.CAT.VAL.SPR < [ OPT +,
-                                    LOCAL [ CAT.HEAD.KEYS.KEY _muy_x_deg_rel,
-                                            CONT.HOOK.LTOP #lbl ] ] >,
-              LKEYS [ ALTKEYREL.PRED _poco_q_rel,
-                      KEYREL.LBL #lbl ] ] ]. 
 
-; c)- Other
-; - mediante una regla léxica se convierten en adj. indef que modifican a un sust. que 
-; tendrán un especificador con KEYS.KEY def_q_rel
-; - co-ocurring with divisible nouns (plural/mass nouns)
-det_quant_eval_div := det_quant_eval & 
+d_-_q-poco_lex := det_quant_eval &
+  [ SYNSEM specfd_det_synsem & [ LOCAL.CAT.VAL.SPR < [ OPT +,
+                                                       LOCAL [ CAT.HEAD.KEYS.KEY _muy_x_deg_rel,
+                                                               CONT.HOOK.LTOP #lbl ] ] >,
+                                 LKEYS [ ALTKEYREL.PRED _poco_q_rel,
+                                         KEYREL.LBL #lbl ] ] ]
+  """
+  
+  """.
+
+
+det_quant_eval_div := det_quant_eval &
   [ SYNSEM [ LOCAL.AGR.DIVISIBLE +,
-             LKEYS.ALTKEYREL.PRED undef_q_rel ] ].
+             LKEYS.ALTKEYREL.PRED undef_q_rel ] ]
+  """
+  c)- Other
+  - mediante una regla léxica se convierten en adj. indef que modifican a un sust. que
+  tendrán un especificador con KEYS.KEY def_q_rel
+  - co-ocurring with divisible nouns (plural/mass nouns)
+  """.
 
-d_-_q-bastante_lex := det_quant_eval_div & 
-  [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
-             LKEYS.ALTKEYREL.PRED _bastante_q_rel ] ].
 
-d_-_q-demasiado_lex := det_quant_eval_div & 
+d_-_q-bastante_lex := det_quant_eval_div &
   [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
-             LKEYS.ALTKEYREL.PRED _demasiado_q_rel ] ].
+             LKEYS.ALTKEYREL.PRED _bastante_q_rel ] ]
+  """
+  
+  """.
 
-d_-_q-varios_lex := det_quant_eval_div & 
-  [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
-             LKEYS.ALTKEYREL.PRED _varios_q_rel ] ].
 
-d_-_q-multiples_lex := det_quant_eval_div & 
+d_-_q-demasiado_lex := det_quant_eval_div &
   [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
-             LKEYS.ALTKEYREL.PRED _multiples_q_rel ] ].
+             LKEYS.ALTKEYREL.PRED _demasiado_q_rel ] ]
+  """
+  
+  """.
 
-; DEMÁS puede aparecer sin artículo en el cierre de enumeración
-; e.g. vinieron mi padre, mi madre y demás familia.
-d_-_q-demas_lex := det_quant_eval_div & 
-  [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
-             LKEYS.ALTKEYREL.PRED _demás_q_rel ] ].
 
-; - the following ones are now encoded as adjectives
-; cierto, determinado, distinto, diverso, escaso, numeroso, raro, cuanto
-d_quant_eval := det_quant_eval & 
+d_-_q-varios_lex := det_quant_eval_div &
   [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
-             LKEYS.ALTKEYREL.PRED undef_q_rel ] ].
+             LKEYS.ALTKEYREL.PRED _varios_q_rel ] ]
+  """
+  
+  """.
+
+
+d_-_q-multiples_lex := det_quant_eval_div &
+  [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
+             LKEYS.ALTKEYREL.PRED _multiples_q_rel ] ]
+  """
+  
+  """.
+
+
+d_-_q-demas_lex := det_quant_eval_div &
+  [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
+             LKEYS.ALTKEYREL.PRED _demás_q_rel ] ]
+  """
+  DEMÁS puede aparecer sin artículo en el cierre de enumeración
+  e.g. vinieron mi padre, mi madre y demás familia.
+  """.
+
+
+d_quant_eval := det_quant_eval &
+  [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
+             LKEYS.ALTKEYREL.PRED undef_q_rel ] ]
+  """
+  - the following ones are now encoded as adjectives
+  cierto, determinado, distinto, diverso, escaso, numeroso, raro, cuanto
+  """.
+
 
 d_-_q-cierto_lex := det_quant_indef & 
   [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
@@ -9035,42 +9144,55 @@ basic_comp_det_synsem := basic_det_synsem &
     NON-LOCAL [ REL 0-dlist,
                 QUE 0-dlist ] ].
 
-; a)- (mucho/poco/bastante) + MÁS/MENOS + N' ( + que + N')
-; e.g. (muchos) más niños (que niñas)
+
 det_cmp_deg_spec := basic-comp-det-lex &
-  [ SYNSEM basic_comp_det_synsem &
-           [ LOCAL [ CAT [ HEAD adv & [ KEYS.KEY comp_degree_rel ],
-                           VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
-                                 SPR < [ LOCAL.CAT.HEAD.KEYS.KEY basic_quant_degree_rel ] >,
-                                 COMPS < [ LOCAL mrkd_np_local &
-                                                 [ CAT.HEAD.KEYS.KEY #ckey,  
-                                                   CONT.HOOK.INDEX #arg2 ] ] > ] ],
-                     CONT.RELS <! relation, 
-                                  relation, 
-                                  [ PRED compar, ARG2 #arg2 ] !> ],
-             LKEYS.--COMPKEY #ckey & _que_p_comp_rel ] ]. 
+  [ SYNSEM basic_comp_det_synsem & [ LOCAL [ CAT [ HEAD adv & [ KEYS.KEY comp_degree_rel ],
+                                                   VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
+                                                         SPR < [ LOCAL.CAT.HEAD.KEYS.KEY basic_quant_degree_rel ] >,
+                                                         COMPS < [ LOCAL mrkd_np_local & [ CAT.HEAD.KEYS.KEY #ckey,
+                                                                                           CONT.HOOK.INDEX #arg2 ] ] > ] ],
+                                             CONT.RELS <! relation,
+                                                          relation,
+                                                          [ PRED compar,
+                                                            ARG2 #arg2 ] !> ],
+                                     LKEYS.--COMPKEY #ckey & _que_p_comp_rel ] ]
+  """
+  a)- (mucho/poco/bastante) + MÁS/MENOS + N' ( + que + N')
+  e.g. (muchos) más niños (que niñas)
+  """.
+
 
 d_pp_cmp-mas_lex := det_cmp_deg_spec &
- [ SYNSEM.LKEYS.ALTKEYREL.PRED _más_q_rel ].
+  [ SYNSEM.LKEYS.ALTKEYREL.PRED _más_q_rel ]
+  """
+  
+  """.
+
 
 d_pp_cmp-menos_lex := det_cmp_deg_spec &
- [ SYNSEM.LKEYS.ALTKEYREL.PRED _menos_q_rel ].
+  [ SYNSEM.LKEYS.ALTKEYREL.PRED _menos_q_rel ]
+  """
+  
+  """.
 
-; b)- (casi) TANTO + N' ( + como N')
-; e.g. tantos niños (como niñas)
+
 d_pp_cmp-tanto_lex := basic-comp-det-lex &
-  [ SYNSEM basic_comp_det_synsem &
-           [ LOCAL [ CAT [ HEAD det & [ KEYS.KEY comp_degree_rel ],
-                           VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
-                                 SPR < [ LOCAL.CAT.HEAD.KEYS.KEY _casi_x_deg_rel ] >,
-                                 COMPS < [ LOCAL mrkd_np_local &
-                                                 [ CAT.HEAD.KEYS.KEY #ckey,  
-                                                   CONT.HOOK.INDEX #arg2 ] ] > ] ],
-                     CONT.RELS <! relation, 
-                                  relation, 
-                                  [ PRED comp_equal_rel, ARG2 #arg2 ] !> ],
-             LKEYS [ ALTKEYREL.PRED _tanto_q_rel,
-                     --COMPKEY #ckey & _como_p_comp_rel ] ] ].
+  [ SYNSEM basic_comp_det_synsem & [ LOCAL [ CAT [ HEAD det & [ KEYS.KEY comp_degree_rel ],
+                                                   VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
+                                                         SPR < [ LOCAL.CAT.HEAD.KEYS.KEY _casi_x_deg_rel ] >,
+                                                         COMPS < [ LOCAL mrkd_np_local & [ CAT.HEAD.KEYS.KEY #ckey,
+                                                                                           CONT.HOOK.INDEX #arg2 ] ] > ] ],
+                                             CONT.RELS <! relation,
+                                                          relation,
+                                                          [ PRED comp_equal_rel,
+                                                            ARG2 #arg2 ] !> ],
+                                     LKEYS [ ALTKEYREL.PRED _tanto_q_rel,
+                                             --COMPKEY #ckey & _como_p_comp_rel ] ] ]
+  """
+  b)- (casi) TANTO + N' ( + como N')
+  e.g. tantos niños (como niñas)
+  """.
+
 
 ; c)- (mucho/poco/bastante) + MÁS/MENOS + 'de' + Number
 ; e.g. más/menos de tres chicos
@@ -9111,7 +9233,15 @@ rel_det_synsem := basic_det_synsem &
 	          [ LIST < [ LTOP #hand,
 			     INDEX #ind ] > ],
     LKEYS [ KEYREL.PRED proper_q_rel,
-            ALTKEYREL #altkey ] ].
+            ALTKEYREL #altkey ] ]
+"""
+; a)-  "cuyo" (whose)
+; - can only appear in restrictive and non-restrictive RCs
+; - does nor agree with the antecedent (i.e. possessor), but the head of the NP (e.g. el autor cuya novela 
+; fue premiada estaba exultante)
+; - only appears sólo puede aparecer al frente de SN determinados. Cuando el elemento poseído es indeterminado,
+; es sustituido por un SP encabezado por "de"
+""".
 
 d_-_rel-poss_lex := det_rel & 
   [ SYNSEM rel_det_synsem ].
@@ -9121,42 +9251,47 @@ d_-_rel-poss_lex := det_rel &
  
 ; --- 6.8. Interrogative determiners
  
-; - qué (what) (e.g. ¿qué libros has leído?)
-d_-_wh-que_lex := det_que & 
-  [ SYNSEM basic_det_synsem &
-           [ LOCAL [ CAT.VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
-                               SPR < >,
-                               COMPS < > ],
-                     CONT [ RELS <! quant-relation !>,
-                            HCONS <! qeq !> ] ],
-             LKEYS.KEYREL.PRED que_q_rel ] ]. 
 
-; - cuál (which) (e.g. ¿cuáles poemas de Neruda conoces?)
-d_-_wh-cual_lex := det_que & 
-  [ SYNSEM basic_det_synsem &
-           [ LOCAL [ CAT.VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
-                               SPR < >,
-                               COMPS < > ],
-                     CONT [ RELS <! quant-relation !>,
-                            HCONS <! qeq !> ] ],
-             LKEYS.KEYREL.PRED que_q_rel ] ]. 
- 
-; - cuánto + Mass/Pl_N' (how much/many) (e.g. ¿cuánto dinero te dieron?)
-d_-_wh-cuanto_lex := det_que & 
-  [ SYNSEM basic_det_synsem &
-           [ LOCAL [ AGR.DIVISIBLE +,
-                     CAT.VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
-                               SPR < >,
-                               COMPS < > ],
-                     CONT [ HOOK [ INDEX #index,
-                                   XARG #larg ], 
-                            RELS <! quant-relation & 
-                                    [ PRED undef_q_rel ],
-                                    #altkey & 
-                                    [ LBL #larg,
-                                      ARG1 #index ] !>,
-			    HCONS <! qeq !> ] ],
-             LKEYS.ALTKEYREL #altkey ] ].
+d_-_wh-que_lex := det_que &
+  [ SYNSEM basic_det_synsem & [ LOCAL [ CAT.VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
+                                                  SPR < >,
+                                                  COMPS < > ],
+                                        CONT [ RELS <! quant-relation !>,
+                                               HCONS <! qeq !> ] ],
+                                LKEYS.KEYREL.PRED que_q_rel ] ]
+  """
+  - qué (what) (e.g. ¿qué libros has leído?)
+  """.
+
+
+d_-_wh-cual_lex := det_que &
+  [ SYNSEM basic_det_synsem & [ LOCAL [ CAT.VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
+                                                  SPR < >,
+                                                  COMPS < > ],
+                                        CONT [ RELS <! quant-relation !>,
+                                               HCONS <! qeq !> ] ],
+                                LKEYS.KEYREL.PRED que_q_rel ] ]
+  """
+  - cuál (which) (e.g. ¿cuáles poemas de Neruda conoces?)
+  """.
+
+
+d_-_wh-cuanto_lex := det_que &
+  [ SYNSEM basic_det_synsem & [ LOCAL [ AGR.DIVISIBLE +,
+                                        CAT.VAL [ SPEC < [ LOCAL.CAT.HEAD noun ] >,
+                                                  SPR < >,
+                                                  COMPS < > ],
+                                        CONT [ HOOK [ INDEX #index,
+                                                      XARG #larg ],
+                                               RELS <! quant-relation & [ PRED undef_q_rel ],
+                                                       #altkey & [ LBL #larg,
+                                                                   ARG1 #index ] !>,
+                                               HCONS <! qeq !> ] ],
+                                LKEYS.ALTKEYREL #altkey ] ]
+  """
+  - cuánto + Mass/Pl_N' (how much/many) (e.g. ¿cuánto dinero te dieron?)
+  """.
+
 
 
 ; --- 6.9. Exclamative determiners 
@@ -9171,7 +9306,11 @@ det_excl := det_nonque_nonrel_nonposs &
                                COMPS < > ] ],
              LKEYS [ KEYREL [ PRED excl_q_rel,
                               LBL #lbl ],
-                     ALTKEYREL.LBL #lbl ] ] ].
+                     ALTKEYREL.LBL #lbl ] ] ]
+"""
+; 'qué/cuánto/cuál' + Sg/Pl_N'
+; e.g. 
+""".
 
 d_-_excl-que_lex := det_excl &
  [ SYNSEM.LKEYS.KEYREL.PRED _que_q_rel ].
@@ -9197,48 +9336,56 @@ d_-_excl-cual_lex := det_excl &
 
 ; --- 7.1. Cardinals (Indef. Quantifiers/Pronoun)
 
-; a)- determiners / indef. adjectives (Z)
-; !!! num + sust pueden formar una unidad inseparable, e.g. esas tristes dos pesetas, 
-; esas famosas tres tardes con Teresa
-; e.g. (los) tres hermanos
-d_-_q-nu-card_lex := det_quant_eval &
-  [ SYNSEM [ LOCAL [ AGR.PNG.PN 3pl, 
-                     CAT.VAL.SPR < > ],
-             LKEYS.ALTKEYREL.PRED card_q_rel ] ].
 
-; b)- pronouns (Z)
-; e.g. dame dos (de ésos/de esos libros), dos (de nosotros) comeremos sopa.
-;n_pp_pr-part-nu-card_lex := partitive-pron-lex &
-;  [ SYNSEM norm_partitive_synsem &
-;           [ LKEYS.ALTKEYREL.PRED card_q_rel ] ].
+d_-_q-nu-card_lex := det_quant_eval &
+  [ SYNSEM [ LOCAL [ AGR.PNG.PN 3pl,
+                     CAT.VAL.SPR < > ],
+             LKEYS.ALTKEYREL.PRED card_q_rel ] ]
+  """
+  a)- determiners / indef. adjectives (Z)
+  !!! num + sust pueden formar una unidad inseparable, e.g. esas tristes dos pesetas,
+  esas famosas tres tardes con Teresa
+  e.g. (los) tres hermanos
+  """.
+
 
 n_pp_pr-part-nu-card_lex := partitive-pron-lex &
-  [ SYNSEM norm-basic-partitive-pron-synsem &
-           [ LOCAL [ AGR.PNG.GEN #gender,
-                     CAT.VAL.COMPS < [ OPT -, 
-                                       LOCAL.CONT.HOOK.INDEX.PNG [ PN plur, 
-                                                                   GEN #gender ] ] > ], 
-             NON-LOCAL.QUE 0-dlist,
-             LKEYS.ALTKEYREL.PRED card_q_rel ] ].
+  [ SYNSEM norm-basic-partitive-pron-synsem & [ LOCAL [ AGR.PNG.GEN #gender,
+                                                        CAT.VAL.COMPS < [ OPT -,
+                                                                          LOCAL.CONT.HOOK.INDEX.PNG [ PN plur,
+                                                                                                      GEN #gender ] ] > ],
+                                                NON-LOCAL.QUE 0-dlist,
+                                                LKEYS.ALTKEYREL.PRED card_q_rel ] ]
+  """
+   b)- pronouns (Z)
+   e.g. dame dos (de ésos/de esos libros), dos (de nosotros) comeremos sopa.
+  n_pp_pr-part-nu-card_lex := partitive-pron-lex &
+    [ SYNSEM norm_partitive_synsem &
+             [ LKEYS.ALTKEYREL.PRED card_q_rel ] ].
+  """.
 
 
-; c)- pseudo-partitive pronouns (Zd): decena, docena, centenar, millar, millón
-; e.g. compró tres docenas (de (*los) huevos)
-n_pp_pr-psd-part-nu-card_lex := basic-nominal-lex & 
-  [ SYNSEM norm-basic-partitive-pron-synsem & 
-           [ LOCAL [ AGR #agr,
-                     CAT.VAL [ SPR #spr & < [ OPT + ] >,
-                               COMPS #comps & < [ OPT -, 
-                                                  LOCAL [ CAT.HEAD.KEYS.ALT2KEY udef_q_rel,
-                                                          CONT.HOOK.INDEX.DIVISIBLE + ] ] > ],
-                     CONT.HOOK.INDEX #agr ] ],
-    ARG-ST < #spr. #comps > ].
+n_pp_pr-psd-part-nu-card_lex := basic-nominal-lex &
+  [ SYNSEM norm-basic-partitive-pron-synsem & [ LOCAL [ AGR #agr,
+                                                        CAT.VAL [ SPR #spr & < [ OPT + ] >,
+                                                                  COMPS #comps & < [ OPT -,
+                                                                                     LOCAL [ CAT.HEAD.KEYS.ALT2KEY udef_q_rel,
+                                                                                             CONT.HOOK.INDEX.DIVISIBLE + ] ] > ],
+                                                        CONT.HOOK.INDEX #agr ] ],
+    ARG-ST < #spr . #comps > ]
+  """
+  c)- pseudo-partitive pronouns (Zd): decena, docena, centenar, millar, millón
+  e.g. compró tres docenas (de (*los) huevos)
+  """.
 
-; d)- pseudo-partitive nouns; e.g. decena, veintena, treintena, 
-n_pp_psd-part-nu-card_lex := n_quant & 
+
+n_pp_psd-part-nu-card_lex := n_quant &
   [ ALTS.PASS -,
-    SYNSEM n_group-or-pseudopart_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ OPT + ] > ] ].
+    SYNSEM n_group-or-pseudopart_synsem & [ LOCAL.CAT.VAL.COMPS < [ OPT + ] > ] ]
+  """
+  d)- pseudo-partitive nouns; e.g. decena, veintena, treintena,
+  """.
+
 
 
 ; --- 7.2. Ordinals (Adjectives)

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -7525,27 +7525,39 @@ av_-_pr-menos_lex := pronominal-lex & norm-zero-arg &
 
 ; --- 4.4.2. Deictic adverbs 
 
-; a)- place (aquí, allí, ahí, acá, allá, acullá, aquende, allende)
 av_-_deic-place_lex := pronominal-lex & norm-zero-arg &
   [ SYNSEM pron_adverb_synsem &
            [ LOCAL [ CAT [ HEAD.KEYS.KEY place_n_rel,
                            VAL.SPR < > ],
-                     CONT.HOOK.INDEX.SORT loc-mod ] ] ].
+                     CONT.HOOK.INDEX.SORT loc-mod ] ] ]
+"""
+; --- 4.4.2. Deictic adverbs 
+; a)- place (aquí, allí, ahí, acá, allá, acullá, aquende, allende)
 
-; b)- temporal (ahora, entonces, hoy, ayer, anteayer, mañana, anoche, anteanoche, anteayer, 
-; anteanteayer, antes de ayer, antes de anoche, pasado mañana, hogaño, antaño) 
+""".
+
 av_-_deic-tmp_lex := pronominal-lex & norm-zero-arg &
   [ SYNSEM pron_adverb_synsem &
            [ LOCAL [ CAT [ HEAD.KEYS.KEY time_n_rel,
                            VAL.SPR < > ],
-                     CONT.HOOK.INDEX.SORT tmp ] ] ].
+                     CONT.HOOK.INDEX.SORT tmp ] ] ]
+"""
+; --- 4.4.2. Deictic adverbs 
+; b)- temporal (ahora, entonces, hoy, ayer, anteayer, mañana, anoche, anteanoche, anteayer, 
+; anteanteayer, antes de ayer, antes de anoche, pasado mañana, hogaño, antaño) 
 
-; c)- manner (así)
+""".
+
 av_-_deic-mann_lex := pronominal-lex & norm-zero-arg &
   [ SYNSEM pron_adverb_synsem &
            [ LOCAL [ CAT [ HEAD.KEYS.KEY manner_n_rel,
                            VAL.SPR < > ],
-                     CONT.HOOK.INDEX.SORT manner-mod ] ] ].
+                     CONT.HOOK.INDEX.SORT manner-mod ] ] ]
+"""
+; --- 4.4.2. Deictic adverbs 
+; c)- manner (así)
+
+""".
 
 ; d)- quant (cuanto)
 ; av_-_deic-qnt_lex := pronominal-lex & norm-zero-arg &
@@ -7556,7 +7568,7 @@ av_-_deic-mann_lex := pronominal-lex & norm-zero-arg &
 
 
 ; --- 4.4.3. Relative adverbs (como, (a)donde, cuando) 
-; pueden aparecer en rel. especificativas, explicativas, yuxtapuestas, predicativas y libres.
+
 rel_loc_adverb_synsem := lex-synsem & 
   [ LOCAL [ AGR ref-ind & [ PNG.PN 3sg ],
             CAT [ HC-LIGHT -,
@@ -7574,7 +7586,12 @@ rel_loc_adverb_synsem := lex-synsem &
     NON-LOCAL [ REL 1-dlist & [ LIST < [ INDEX #objind ] > ],
                 SLASH 0-dlist,
                 QUE 0-dlist ],
-    LKEYS.KEYREL.LBL #khand ].
+    LKEYS.KEYREL.LBL #khand ]
+"""
+; --- 4.4.3. Relative adverbs (como, (a)donde, cuando)
+; pueden aparecer en rel. especificativas, explicativas, yuxtapuestas, predicativas y libres.
+
+""".
 
 rel_adverb_synsem := basic_np_adv_synsem & 
   [ LOCAL [ CAT [ POSTHEAD -,
@@ -7618,68 +7635,81 @@ free_rel_adverb_synsem := lex-synsem &
             ALTKEYREL #key,
             ALT2KEYREL #alt2key ] ].
 
-; a)- "donde" (adonde)
-; - expresses location (with or without the preposition 'en'), and when 
-; co-ocurring with prepositions, denotes todas las gamas de movimiento.
-; - admite antecedentes explícitos: sustantivos locativos (la casa donde vivía), 
-; PP locativo (fue hallada en la casa de Comillas, donde vivió en su juventud), 
-; adverbios pronominales de lugar (allá donde estés tú estaré yo).
-; in fact rel_loc_adverb_synsem
-av_-_rel-place_lex := pronominal-lex & 
-  [ SYNSEM rel_adverb_synsem & 
-           [ LOCAL [ CAT.HEAD.KEYS.KEY state_loc_rel,
-                     CONT.HOOK.INDEX.SORT loc-mod ],
-             NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX.SORT loc-mod ] > ] ] ].
 
-; e.g. [donde vive tu hermano] es demasiado lejos para ir de vacaciones (NPs)
+av_-_rel-place_lex := pronominal-lex &
+  [ SYNSEM rel_adverb_synsem & [ LOCAL [ CAT.HEAD.KEYS.KEY state_loc_rel,
+                                         CONT.HOOK.INDEX.SORT loc-mod ],
+                                 NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX.SORT loc-mod ] > ] ] ]
+  """
+  a)- "donde" (adonde)
+  - expresses location (with or without the preposition 'en'), and when
+  co-ocurring with prepositions, denotes todas las gamas de movimiento.
+  - admite antecedentes explícitos: sustantivos locativos (la casa donde vivía),
+  PP locativo (fue hallada en la casa de Comillas, donde vivió en su juventud),
+  adverbios pronominales de lugar (allá donde estés tú estaré yo).
+  in fact rel_loc_adverb_synsem
+  """.
+
+
 av_-_free-rel-place_lex := free_rel_pro_lex &
-  [ SYNSEM free_rel_adverb_synsem & 
-           [ LOCAL.CONT.HOOK.INDEX.SORT loc-mod,
-             LKEYS [ ALT2KEYREL.PRED unspec_loc_rel,
-                     KEYREL.PRED state_loc_rel ] ] ].
+  [ SYNSEM free_rel_adverb_synsem & [ LOCAL.CONT.HOOK.INDEX.SORT loc-mod,
+                                      LKEYS [ ALT2KEYREL.PRED unspec_loc_rel,
+                                              KEYREL.PRED state_loc_rel ] ] ]
+  """
+  e.g. [donde vive tu hermano] es demasiado lejos para ir de vacaciones (NPs)
+  """.
 
-; b)- cuando 
-; - expresses time. Admite antecedentes explícitos: sustantivos temporales
-; (recuerdo el día cuando dimitió), adverbio pronominal, pero sólo en cláusulas
-; explicativas (hoy, cuando consigas el permiso, podrás volver).
-av_-_rel-tmp_lex := pronominal-lex & 
-  [ SYNSEM rel_adverb_synsem & 
-           [ LOCAL [ CAT.HEAD.KEYS.KEY time_n_rel, 
-                     CONT.HOOK.INDEX.SORT tmp ],
-             NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX.SORT mod ] > ] ] ].
 
-; - en función de complemento directo (recuerdo cuando vino), complemento 
-; predicativo de OD (la ví cuando salía del metro). Tambén puede aparecer como
-; complemento de un nombre (el diploma de cuando te graduaste), de un adjetivo 
-; (preparado para cuando te vayas), de un adverbio (además de cuando hizo la 
-; mili, feu allí un par de veces) y de preposición (para cuando te vayas, ya habrá 
-; llegado el buen tiempo). También en función de adverbiales (cuando consigas el 
-; permiso, podrás volver)
+av_-_rel-tmp_lex := pronominal-lex &
+  [ SYNSEM rel_adverb_synsem & [ LOCAL [ CAT.HEAD.KEYS.KEY time_n_rel,
+                                         CONT.HOOK.INDEX.SORT tmp ],
+                                 NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX.SORT mod ] > ] ] ]
+  """
+  b)- cuando
+  - expresses time. Admite antecedentes explícitos: sustantivos temporales
+  (recuerdo el día cuando dimitió), adverbio pronominal, pero sólo en cláusulas
+  explicativas (hoy, cuando consigas el permiso, podrás volver).
+  """.
+
+
 av_-_free-rel-tmp_lex := free_rel_pro_lex &
-  [ SYNSEM free_rel_adverb_synsem & 
-           [ LOCAL.CONT.HOOK.INDEX.SORT mod,
-             LKEYS [ ALT2KEYREL.PRED unspec_loc_rel,
-                     KEYREL.PRED prep_mod_rel ] ] ].
+  [ SYNSEM free_rel_adverb_synsem & [ LOCAL.CONT.HOOK.INDEX.SORT mod,
+                                      LKEYS [ ALT2KEYREL.PRED unspec_loc_rel,
+                                              KEYREL.PRED prep_mod_rel ] ] ]
+  """
+  - en función de complemento directo (recuerdo cuando vino), complemento
+  predicativo de OD (la ví cuando salía del metro). Tambén puede aparecer como
+  complemento de un nombre (el diploma de cuando te graduaste), de un adjetivo
+  (preparado para cuando te vayas), de un adverbio (además de cuando hizo la
+  mili, feu allí un par de veces) y de preposición (para cuando te vayas, ya habrá
+  llegado el buen tiempo). También en función de adverbiales (cuando consigas el
+  permiso, podrás volver)
+  """.
 
-; c)- como
-; - los únicos sustantivos que puede modificar son propio, manera y forma 
-; (la manera como contestó al periodista), it can also modify the adverb 
-; 'así' (lo hice así, como me había recomendado), and manner adverb/PP 
-; (lo hice distretamente/con precaución, como me había recomendado). 
-; También puede reproducir entidades predicativas (vivía sola, como 
-; siempre había deseado) 
-av_-_rel-mann_lex := pronominal-lex & 
-  [ SYNSEM rel_adverb_synsem & 
-           [ LOCAL.CONT.HOOK.INDEX.SORT manner-mod,
-             NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX.SORT mod ] > ] ] ].
 
-; - en función de atributo (será como tú digas) y de complemento 
-; predicativo (los niños dejaron la sala como ya os podéis imaginar)
+av_-_rel-mann_lex := pronominal-lex &
+  [ SYNSEM rel_adverb_synsem & [ LOCAL.CONT.HOOK.INDEX.SORT manner-mod,
+                                 NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX.SORT mod ] > ] ] ]
+  """
+  c)- como
+  - los únicos sustantivos que puede modificar son propio, manera y forma
+  (la manera como contestó al periodista), it can also modify the adverb
+  'así' (lo hice así, como me había recomendado), and manner adverb/PP
+  (lo hice distretamente/con precaución, como me había recomendado).
+  También puede reproducir entidades predicativas (vivía sola, como
+  siempre había deseado)
+  """.
+
+
 av_-_free-rel-mann_lex := free_rel_pro_lex &
-  [ SYNSEM free_rel_adverb_synsem & 
-           [ LOCAL.CONT.HOOK.INDEX.SORT manner-mod,
-             LKEYS [ ALT2KEYREL.PRED unspec_manner_rel,
-                     KEYREL.PRED prep_mod_rel ] ] ].
+  [ SYNSEM free_rel_adverb_synsem & [ LOCAL.CONT.HOOK.INDEX.SORT manner-mod,
+                                      LKEYS [ ALT2KEYREL.PRED unspec_manner_rel,
+                                              KEYREL.PRED prep_mod_rel ] ] ]
+  """
+  - en función de atributo (será como tú digas) y de complemento
+  predicativo (los niños dejaron la sala como ya os podéis imaginar)
+  """.
+
 
 
 ; --- 4.4.4. Interrogative adverbs (cómo, (a)dónde, cuándo)

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -7713,6 +7713,7 @@ av_-_free-rel-mann_lex := free_rel_pro_lex &
 
 
 ; --- 4.4.4. Interrogative adverbs (cómo, (a)dónde, cuándo)
+
 wh_adverb_synsem := basic_np_adv_synsem & 
   [ LOCAL [ CAT.VAL.SPR < >,
             CONT.RELS <! noun-relation, relation !> ],
@@ -7783,7 +7784,10 @@ specfd_adposition_synsem := basic_adposition_synsem &
                                               XARG #arg0 ] ], 
                           NON-LOCAL.QUE 0-dlist ] >,
     LKEYS.KEYREL [ LBL #ltop, 
-                   ARG0 #arg0 ] ].
+                   ARG0 #arg0 ] ]
+"""
+; modifying prepositions may co-occur with degree adverbs (e.g. muy por debajo de esto)
+""".
 
 basic_nomod-adp_synsem := basic_adposition_synsem & 
   [ LOCAL.CAT [ HEAD.MOD < >,
@@ -7864,14 +7868,17 @@ p_vmod_synsem := basic_mod-adp_synsem &
                 VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #arg2 ],... > ],
     LKEYS.KEYREL.ARG2 #arg2 ].
 
-; !!! la en otros tiempos mujer del año, el último libro en aparecer,
-;                                           VAL.SPR < [ ] >
 p_nmod_synsem := basic_mod-adp_synsem &
   [ LOCAL.CAT [ POSTHEAD +, 
                 HEAD [ PRD prd,
                        MOD < [ LOCAL.CAT [ LASTNMOD -,
                                            HEAD noun ],
-                               NON-LOCAL.SLASH 0-dlist ] > ] ] ]. 
+                               NON-LOCAL.SLASH 0-dlist ] > ] ] ]
+"""
+OZ: Not sure whether this comment belongs here or was free-standing:
+; !!! la en otros tiempos mujer del año, el último libro en aparecer,
+;                                           VAL.SPR < [ ] >
+""". 
 
 p_amod_synsem := basic_mod-adp_synsem &
   [ LOCAL.CAT [ POSTHEAD +, 
@@ -7944,16 +7951,15 @@ p_cp_prop_or_ques_inf := p_cp_prop_or_ques &
                                                VAL.SUBJ < synsem & 
                                                           [ NON-LOCAL.SLASH 0-dlist & [ LIST < > ] ] > ] ] > ].
 
-; control modifying PPs
-p_cp_prop_inf_slash := o_rais-one-arg & 
+
+p_cp_prop_inf_slash := o_rais-one-arg &
   [ SYNSEM [ LOCAL [ CAT [ HEAD [ AUX -,
                                   TAM #tam ],
-                           VAL.COMPS < [ LOCAL vp_inf_local & 
-                                               [ CAT [ MC -,
-                                                       HEAD.TAM #tam,
-                                                       VAL.COMPS < > ],
-                                                 CONT.HOOK [ LTOP #larg,
-                                                             INDEX.SF prop ] ] ] > ],
+                           VAL.COMPS < [ LOCAL vp_inf_local & [ CAT [ MC -,
+                                                                      HEAD.TAM #tam,
+                                                                      VAL.COMPS < > ],
+                                                                CONT.HOOK [ LTOP #larg,
+                                                                            INDEX.SF prop ] ] ] > ],
                      CONT [ HOOK [ LTOP #ltop,
                                    INDEX #index & [ E #tam ] ],
                             RELS <! #keyrel & prep-relation !>,
@@ -7961,124 +7967,156 @@ p_cp_prop_inf_slash := o_rais-one-arg &
                                              LARG #larg ] !> ] ],
              LKEYS.KEYREL #keyrel & [ LBL #ltop,
                                       ARG0 #index,
-                                      ARG2 #harg ] ] ].  
+                                      ARG2 #harg ] ] ]
+  """
+  control modifying PPs
+  """.
 
-; prep + AP, for predicative complements
-; e.g. presume de valiente, lo tienen por tonto
-p_ap := basic-one-arg & 
+
+p_ap := basic-one-arg &
   [ SYNSEM.LOCAL.CAT [ MC na,
                        HEAD.KEYS.ALT2KEY non_free_relative_q_rel,
                        VAL [ COMPS < [ LOCAL.CAT [ MC na,
-				                   HEAD adj, 
-						   VAL [ SUBJ < >,
-						         COMPS < > ] ],
+                                                   HEAD adj,
+                                                   VAL [ SUBJ < >,
+                                                         COMPS < > ] ],
                                        NON-LOCAL [ SLASH 0-dlist,
                                                    REL 0-dlist,
                                                    QUE 0-dlist ] ] >,
-                             CLTS < > ] ] ].  
+                             CLTS < > ] ] ]
+  """
+  prep + AP, for predicative complements
+  e.g. presume de valiente, lo tienen por tonto
+  """.
 
-; prep + ADV
-; e.g. mira hacia atrás
-p_adv := basic-one-arg & 
+
+p_adv := basic-one-arg &
   [ SYNSEM.LOCAL.CAT [ MC na,
                        HEAD.KEYS.ALTKEY basic_adv_rel,
                        VAL [ COMPS < [ LOCAL.CAT [ HEAD +ro,
                                                    VAL.COMPS < > ] ] >,
-                             CLTS < > ] ] ]. 
+                             CLTS < > ] ] ]
+  """
+  prep + ADV
+  e.g. mira hacia atrás
+  """.
 
-; prep + MODNP
-; e.g. como ahora
-p_modnp := basic-one-arg & 
+
+p_modnp := basic-one-arg &
   [ SYNSEM.LOCAL.CAT [ MC na,
-                       HEAD.KEYS.ALTKEY prep_mod_rel, 
-                       VAL [ COMPS < [ LOCAL.CAT [ HEAD modnp & 
-                                                        [ MOD < [ LOCAL.CAT.HEAD verb ] > ],
+                       HEAD.KEYS.ALTKEY prep_mod_rel,
+                       VAL [ COMPS < [ LOCAL.CAT [ HEAD modnp & [ MOD < [ LOCAL.CAT.HEAD verb ] > ],
                                                    VAL.COMPS < > ] ] >,
-                             CLTS < > ] ] ]. 
+                             CLTS < > ] ] ]
+  """
+  prep + MODNP
+  e.g. como ahora
+  """.
 
-; non-locative preposition + locative PP
-; a)- "de" when, with the verb "ser" or with movement verbs, expresses origin, or when it heads a nominal 
-; complement, e.g. es de por ese barrio, salió de tras el matorral, el libro de sobre la mesa
-; b)- "desde" (origin), "hasta" (destination), "por" (path) + locative PP except "en"
-; e.g. se lanzó desde sobre el tejado
-; c)- Carpetazo en el Congreso hasta después de las elecciones europeas.
-p_pp := basic-one-arg & 
+
+p_pp := basic-one-arg &
   [ SYNSEM.LOCAL [ CAT [ MC na,
                          HEAD.KEYS.ALT2KEY non_free_relative_q_rel,
-                         VAL [ COMPS < [ LOCAL [ CAT [ HEAD adp & 
-                                                            [ KEYS.KEY prep_mod_rel,
-                                                              CASE none ],
+                         VAL [ COMPS < [ LOCAL [ CAT [ HEAD adp & [ KEYS.KEY prep_mod_rel,
+                                                                    CASE none ],
                                                        VAL.COMPS < > ],
                                                  CONT.HOOK.LTOP #ltop ] ] >,
                                CLTS < > ] ],
-                   CONT.HOOK.LTOP #ltop ] ]. 
+                   CONT.HOOK.LTOP #ltop ] ]
+  """
+  non-locative preposition + locative PP
+  a)- "de" when, with the verb "ser" or with movement verbs, expresses origin, or when it heads a nominal
+  complement, e.g. es de por ese barrio, salió de tras el matorral, el libro de sobre la mesa
+  b)- "desde" (origin), "hasta" (destination), "por" (path) + locative PP except "en"
+  e.g. se lanzó desde sobre el tejado
+  c)- Carpetazo en el Congreso hasta después de las elecciones europeas.
+  """.
 
-; "de/a" + marked NP_por, e.g. vengo de/a por agua
-p_mrkd_np := basic-one-arg & 
+
+p_mrkd_np := basic-one-arg &
   [ SYNSEM [ LOCAL [ CAT [ HEAD.KEYS.ALT2KEY non_free_relative_q_rel,
                            VAL [ COMPS < [ OPT -,
-                                           LOCAL mrkd_np_local & 
-                                                 [ CAT [ HEAD.KEYS.KEY #ckey,
-                                                         VAL.SPR < > ],
-                                                   CONT.HOOK.INDEX #arg2 ] ] >,
+                                           LOCAL mrkd_np_local & [ CAT [ HEAD.KEYS.KEY #ckey,
+                                                                         VAL.SPR < > ],
+                                                                   CONT.HOOK.INDEX #arg2 ] ] >,
                                  CLTS < > ] ],
                      CONT [ RELS <! prep-relation !>,
-                            HCONS <! !> ] ] ,
+                            HCONS <! !> ] ],
              LKEYS [ KEYREL.ARG2 #arg2,
-                     --COMPKEY #ckey ] ] ]. 
+                     --COMPKEY #ckey ] ] ]
+  """
+  "de/a" + marked NP_por, e.g. vengo de/a por agua
+  """.
 
-; for the ditransitive preposition "a" in "a... de..." expressing distance
-; e.g. Juan vive (a (3km) (de Madrid))/Juan vive a 3km/*Juan vive de Madrid
-p_ditrans := basic-two-arg & 
-  [ SYNSEM [ LOCAL [ CAT [ HEAD.KEYS.ALT2KEY non_free_relative_q_rel,
-                           VAL [ COMPS < [ OPT -,
-                                           LOCAL.CAT [ MC na,
-                                                       HEAD noun,
-                                                       VAL [ SUBJ < >,
-                                                             COMPS < >,
-                                                             SPR < > ] ] ],
-                                         [ OPT -,
-                                           LOCAL mrkd_np_local & 
-                                                 [ CAT.HEAD.KEYS.KEY #ockey,
-                                                   CONT.HOOK.INDEX #arg3 ] ] > ] ] ],
-             LKEYS [ KEYREL.ARG3 #arg3, 
-                     --OCOMPKEY #ockey & _de_p_sel_rel ] ] ]. 
+
+p_ditrans := basic-two-arg &
+  [ SYNSEM [ LOCAL.CAT [ HEAD.KEYS.ALT2KEY non_free_relative_q_rel,
+                         VAL.COMPS < [ OPT -,
+                                       LOCAL.CAT [ MC na,
+                                                   HEAD noun,
+                                                   VAL [ SUBJ < >,
+                                                         COMPS < >,
+                                                         SPR < > ] ] ],
+                                     [ OPT -,
+                                       LOCAL mrkd_np_local & [ CAT.HEAD.KEYS.KEY #ockey,
+                                                               CONT.HOOK.INDEX #arg3 ] ] > ],
+             LKEYS [ KEYREL.ARG3 #arg3,
+                     --OCOMPKEY #ockey & _de_p_sel_rel ] ] ]
+  """
+  for the ditransitive preposition "a" in "a... de..." expressing distance
+  e.g. Juan vive (a (3km) (de Madrid))/Juan vive a 3km/*Juan vive de Madrid
+  """.
+
 
 
 ; --- Marking prepositions
 
-; - marking NPs (a, como, con, contra, de, en, para, por)
-; e.g. sucumbió a la tentación, hay tantos niños como niñas, tan largo como eso, cumple con su deber, 
-; luchó contra el enemigo, depende de tí, creo en el destino, aptitud para la danza, fue hecho por mí
-p_np_ptcl_lex := mark-adp-lex & p_np & 
-  [ SYNSEM p_nmark_synsem & 
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.VAL.SPR < > ] > ] ]. 
 
-p_nb_ptcl_lex := mark-adp-lex & p_np & 
-  [ SYNSEM p_nmark_synsem & 
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.VAL.SPR < [ LOCAL.CONT.RELS <! relation !>,
-                                                           NON-LOCAL [ QUE 0-dlist,
-                                                                       REL 0-dlist ] ] > ] > ] ]. 
+p_np_ptcl_lex := mark-adp-lex & p_np &
+  [ SYNSEM p_nmark_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.VAL.SPR < > ] > ] ]
+  """
+  - marking NPs (a, como, con, contra, de, en, para, por)
+  e.g. sucumbió a la tentación, hay tantos niños como niñas, tan largo como eso, cumple con su deber,
+  luchó contra el enemigo, depende de tí, creo en el destino, aptitud para la danza, fue hecho por mí
+  """.
 
-p_np_ptcl-spd_lex := mark-adp-lex & p_np & 
-  [ SYNSEM p_nmark_synsem & 
-           [ LOCAL.CAT.VAL [ SPR < [ OPT -,
-                                     LOCAL.CAT.HEAD adv & [ KEYS.KEY comp_degree_rel ] ] >,
-                             COMPS < [ LOCAL.CAT.VAL.SPR < > ] > ] ] ]. 
 
-; - marking finite completive clauses/indirect questions (a, con, de, en, por)
-; e.g. esperó a que llegase, me conformo con que vengas, me preocupo de que comáis, confío en que vengan, 
-; voto por que vayamos al cine, depende de cómo lo hagas, pensaré en cómo lo haré/hizo
-p_cp_ptcl_lex := mark-adp-lex & p_cp_prop_or_ques_fin & 
-  [ SYNSEM p_vmark_synsem ].
+p_nb_ptcl_lex := mark-adp-lex & p_np &
+  [ SYNSEM p_nmark_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.VAL.SPR < [ LOCAL.CONT.RELS <! relation !>,
+                                                                            NON-LOCAL [ QUE 0-dlist,
+                                                                                        REL 0-dlist ] ] > ] > ] ]
+  """
+  
+  """.
 
-; - marking VPinf - subject & object control (a, con, de, en, para, por)
-; e.g. aspira a ganar, sueño con ganar, deja de molestar, confío en ganar, capacitado para hacerlo, 
-; voto por ir al cine
-p_vp_ptcl_lex := mark-adp-lex & p_cp_prop_or_ques_inf & 
-  [ SYNSEM p_vmark_synsem & 
-           [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.XARG #ctrl ] >,
-                     CONT.HOOK.XARG #ctrl ] ] ].
+
+p_np_ptcl-spd_lex := mark-adp-lex & p_np &
+  [ SYNSEM p_nmark_synsem & [ LOCAL.CAT.VAL [ SPR < [ OPT -,
+                                                      LOCAL.CAT.HEAD adv & [ KEYS.KEY comp_degree_rel ] ] >,
+                                              COMPS < [ LOCAL.CAT.VAL.SPR < > ] > ] ] ]
+  """
+  
+  """.
+
+
+p_cp_ptcl_lex := mark-adp-lex & p_cp_prop_or_ques_fin &
+  [ SYNSEM p_vmark_synsem ]
+  """
+  - marking finite completive clauses/indirect questions (a, con, de, en, por)
+  e.g. esperó a que llegase, me conformo con que vengas, me preocupo de que comáis, confío en que vengan,
+  voto por que vayamos al cine, depende de cómo lo hagas, pensaré en cómo lo haré/hizo
+  """.
+
+
+p_vp_ptcl_lex := mark-adp-lex & p_cp_prop_or_ques_inf &
+  [ SYNSEM p_vmark_synsem & [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.XARG #ctrl ] >,
+                                      CONT.HOOK.XARG #ctrl ] ] ]
+  """
+  - marking VPinf - subject & object control (a, con, de, en, para, por)
+  e.g. aspira a ganar, sueño con ganar, deja de molestar, confío en ganar, capacitado para hacerlo,
+  voto por ir al cine
+  """.
+
 
 ; - marking VPinf - subject & object raising (de)
 ; e.g. fácil de tocar 

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -7409,92 +7409,118 @@ quant_pron_adverb_synsem := pron_adverb_synsem &
 
 ; --- 4.4.1. Quant pronominal adverbs
 
-; e.g. llovió mucho
 av_-_pr-mucho_lex := pronominal-lex & norm-zero-arg &
   [ SYNSEM quant_pron_adverb_synsem & 
            [ LOCAL [ CAT.VAL.SPR < >,
                      CONT.HOOK.INDEX.PNG.PN 3sg ],
-             LKEYS.ALT2KEYREL.PRED "_mucho_x_rel" ] ].
+             LKEYS.ALT2KEYREL.PRED "_mucho_x_rel" ] ]
+"""
+; --- 4.4.1. Quant pronominal adverbs
+; e.g. llovió mucho
+""".
 
-; e.g. llovió bastante
+
 av_-_pr-bastante_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < >,
-                     CONT.HOOK.INDEX.PNG.PN 3sg ],
-             LKEYS.ALT2KEYREL.PRED "_bastante_x_rel" ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < >,
+                                                CONT.HOOK.INDEX.PNG.PN 3sg ],
+                                        LKEYS.ALT2KEYREL.PRED "_bastante_x_rel" ] ]
+  """
+  e.g. llovió bastante
+  """.
 
-; e.g. llovió demasiado
+
 av_-_pr-demasiado_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < >,
-                     CONT.HOOK.INDEX.PNG.PN 3sg ],
-             LKEYS.ALT2KEYREL.PRED "_demasiado_x_rel" ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < >,
+                                                CONT.HOOK.INDEX.PNG.PN 3sg ],
+                                        LKEYS.ALT2KEYREL.PRED "_demasiado_x_rel" ] ]
+  """
+  e.g. llovió demasiado
+  """.
 
-; e.g. llovió tanto
+
 av_-_pr-tanto_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < >,
-                     CONT.HOOK.INDEX.PNG.PN 3sg ],
-             LKEYS.ALT2KEYREL.PRED "_tanto_x_rel" ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < >,
+                                                CONT.HOOK.INDEX.PNG.PN 3sg ],
+                                        LKEYS.ALT2KEYREL.PRED "_tanto_x_rel" ] ]
+  """
+  e.g. llovió tanto
+  """.
 
-; e.g. llovió algo
+
 av_-_pr-algo_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < >,
-                     CONT.HOOK.INDEX.PNG.PN 3sg ],
-             LKEYS.ALT2KEYREL.PRED "_algo_x_rel" ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < >,
+                                                CONT.HOOK.INDEX.PNG.PN 3sg ],
+                                        LKEYS.ALT2KEYREL.PRED "_algo_x_rel" ] ]
+  """
+  e.g. llovió algo
+  """.
 
-; e.g. llovió suficiente
+
 av_-_pr-suficiente_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < >,
-                     CONT.HOOK.INDEX.PNG.PN 3sg ],
-             LKEYS.ALT2KEYREL.PRED "_suficiente_x_rel" ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < >,
+                                                CONT.HOOK.INDEX.PNG.PN 3sg ],
+                                        LKEYS.ALT2KEYREL.PRED "_suficiente_x_rel" ] ]
+  """
+  e.g. llovió suficiente
+  """.
 
-; e.g. aumentaron el 20%
+
 av_-_pr-mea_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY quant_or_deg_rel ] >,
-                     CONT.HOOK.INDEX.PNG.PN 3sg ] ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY quant_or_deg_rel ] >,
+                                                CONT.HOOK.INDEX.PNG.PN 3sg ] ] ]
+  """
+  e.g. aumentaron el 20%
+  """.
 
-; e.g. llovió un poco
+
 av_-_pr-un-poco_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < >,
-                     CONT.HOOK.INDEX.PNG.PN 3sg ],
-             LKEYS.ALT2KEYREL.PRED "_un_poco_x_rel" ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < >,
+                                                CONT.HOOK.INDEX.PNG.PN 3sg ],
+                                        LKEYS.ALT2KEYREL.PRED "_un_poco_x_rel" ] ]
+  """
+  e.g. llovió un poco
+  """.
 
-; e.g. llovió (casi) nada
+
 av_-_pr-nada_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < [ LOCAL [ CAT.HEAD.KEYS.KEY _casi_x_deg_rel,
-                                             CONT.HOOK.XARG #index ] ] >,
-                     CONT.HOOK.INDEX #index & [ PNG.PN 3sg ] ],
-             LKEYS.ALT2KEYREL.PRED "_nada_x_rel" ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < [ LOCAL [ CAT.HEAD.KEYS.KEY _casi_x_deg_rel,
+                                                                        CONT.HOOK.XARG #index ] ] >,
+                                                CONT.HOOK.INDEX #index & [ PNG.PN 3sg ] ],
+                                        LKEYS.ALT2KEYREL.PRED "_nada_x_rel" ] ]
+  """
+  e.g. llovió (casi) nada
+  """.
 
-; e.g. llovió (bien/muy/bastante/...) poco
+
 av_-_pr-poco_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < [ LOCAL [ CAT.HEAD.KEYS.KEY quant_degree_rel,
-                                             CONT.HOOK.XARG #index ] ] >,
-                     CONT.HOOK.INDEX #index & [ PNG.PN 3sg ] ],
-             LKEYS.ALT2KEYREL.PRED "_poco_x_rel" ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < [ LOCAL [ CAT.HEAD.KEYS.KEY quant_degree_rel,
+                                                                        CONT.HOOK.XARG #index ] ] >,
+                                                CONT.HOOK.INDEX #index & [ PNG.PN 3sg ] ],
+                                        LKEYS.ALT2KEYREL.PRED "_poco_x_rel" ] ]
+  """
+  e.g. llovió (bien/muy/bastante/...) poco
+  """.
 
-; e.g. llovió (mucho/poco/bastante/...) más
+
 av_-_pr-más_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < [ LOCAL [ CAT.HEAD.KEYS.KEY quant_degree_rel,
-                                             CONT.HOOK.XARG #index ] ] >,
-                     CONT.HOOK.INDEX #index & [ PNG.PN 3sg ] ],
-             LKEYS.ALT2KEYREL.PRED "_más_x_rel" ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < [ LOCAL [ CAT.HEAD.KEYS.KEY quant_degree_rel,
+                                                                        CONT.HOOK.XARG #index ] ] >,
+                                                CONT.HOOK.INDEX #index & [ PNG.PN 3sg ] ],
+                                        LKEYS.ALT2KEYREL.PRED "_más_x_rel" ] ]
+  """
+  e.g. llovió (mucho/poco/bastante/...) más
+  """.
 
-; e.g. llovió (mucho/poco/bastante/...) menos
+
 av_-_pr-menos_lex := pronominal-lex & norm-zero-arg &
-  [ SYNSEM quant_pron_adverb_synsem & 
-           [ LOCAL [ CAT.VAL.SPR < [ LOCAL [ CAT.HEAD.KEYS.KEY quant_degree_rel,
-                                             CONT.HOOK.XARG #index ] ] >,
-                     CONT.HOOK.INDEX #index & [ PNG.PN 3sg ] ],
-             LKEYS.ALT2KEYREL.PRED "_menos_x_rel" ] ].
+  [ SYNSEM quant_pron_adverb_synsem & [ LOCAL [ CAT.VAL.SPR < [ LOCAL [ CAT.HEAD.KEYS.KEY quant_degree_rel,
+                                                                        CONT.HOOK.XARG #index ] ] >,
+                                                CONT.HOOK.INDEX #index & [ PNG.PN 3sg ] ],
+                                        LKEYS.ALT2KEYREL.PRED "_menos_x_rel" ] ]
+  """
+  e.g. llovió (mucho/poco/bastante/...) menos
+  """.
+
 
 
 ; --- 4.4.2. Deictic adverbs 

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -10277,7 +10277,16 @@ zero-arg-slash := basic-zero-arg & zero-arg-nonrel & zero-arg-nonque
   e.g., resumptive pronouns in French.
   """.
 
+; Lexical threading types
 
+basic-one-arg := lex-item &
+  [ ARG-ST < [ NON-LOCAL [ SLASH #slash,
+                           REL #rel,
+                           QUE #que ] ] >,
+    SYNSEM.NON-LOCAL [ SLASH #slash,
+                       REL #rel,
+                       QUE #que ] ]
+"""
 ; These non-zero argument types only amalgamate the non-local
 ; feature values of their complements. They do not introduce any
 ; non-local values of their own, nor do they bind off any non-local
@@ -10289,20 +10298,26 @@ zero-arg-slash := basic-zero-arg & zero-arg-nonrel & zero-arg-nonque
 ; value. Elements which both introduce REL or QUE values and take one 
 ; or more arguments will require appropriate new types as well, which
 ; amalgamate everything but add a value in addition.
-
-basic-one-arg := lex-item &
-  [ ARG-ST < [ NON-LOCAL [ SLASH #slash,
-                           REL #rel,
-                           QUE #que ] ] >,
-    SYNSEM.NON-LOCAL [ SLASH #slash,
-                       REL #rel,
-                       QUE #que ] ].
+""".
 
 o_rais-one-arg := lex-item &
   [ ARG-ST < synsem >,
     SYNSEM.NON-LOCAL [ SLASH 0-dlist,
                        REL 0-dlist,
-                       QUE 0-dlist ] ].
+                       QUE 0-dlist ] ]
+"""
+; These non-zero argument types only amalgamate the non-local
+; feature values of their complements. They do not introduce any
+; non-local values of their own, nor do they bind off any non-local
+; feature values. This assumes that the bottom of most long-distance
+; dependencies is handled by a rule that constrains an argument 
+; (either on the ARG-ST list or a valence list) to be a synsem of 
+; type gap. Elements like English tough adjectives which bind off a 
+; slash value will need a new type that doesn't amalgamate that slash 
+; value. Elements which both introduce REL or QUE values and take one 
+; or more arguments will require appropriate new types as well, which
+; amalgamate everything but add a value in addition.
+""".
 
 basic-two-arg := lex-item &
   [ ARG-ST < [ NON-LOCAL [ SLASH [ LIST #smiddle,
@@ -10322,7 +10337,20 @@ basic-two-arg := lex-item &
                        REL [ LIST #rfirst,
                              LAST #rlast ],
                        QUE [ LIST #qfirst,
-                             LAST #qlast ] ] ].
+                             LAST #qlast ] ] ]
+"""
+; These non-zero argument types only amalgamate the non-local
+; feature values of their complements. They do not introduce any
+; non-local values of their own, nor do they bind off any non-local
+; feature values. This assumes that the bottom of most long-distance
+; dependencies is handled by a rule that constrains an argument 
+; (either on the ARG-ST list or a valence list) to be a synsem of 
+; type gap. Elements like English tough adjectives which bind off a 
+; slash value will need a new type that doesn't amalgamate that slash 
+; value. Elements which both introduce REL or QUE values and take one 
+; or more arguments will require appropriate new types as well, which
+; amalgamate everything but add a value in addition.
+""".
 
 cc-two-arg := lex-item &
   [ ARG-ST < [ NON-LOCAL [ SLASH [ LIST #smiddle,
@@ -10342,7 +10370,20 @@ cc-two-arg := lex-item &
                        REL [ LIST #rfirst,
                              LAST #rlast ],
                        QUE [ LIST #qfirst,
-                             LAST #qlast ] ] ].
+                             LAST #qlast ] ] ]
+"""
+; These non-zero argument types only amalgamate the non-local
+; feature values of their complements. They do not introduce any
+; non-local values of their own, nor do they bind off any non-local
+; feature values. This assumes that the bottom of most long-distance
+; dependencies is handled by a rule that constrains an argument 
+; (either on the ARG-ST list or a valence list) to be a synsem of 
+; type gap. Elements like English tough adjectives which bind off a 
+; slash value will need a new type that doesn't amalgamate that slash 
+; value. Elements which both introduce REL or QUE values and take one 
+; or more arguments will require appropriate new types as well, which
+; amalgamate everything but add a value in addition.
+""".
 
 o_rais-two-arg := lex-item &
   [ ARG-ST < [ NON-LOCAL [ SLASH #slash,
@@ -10351,7 +10392,20 @@ o_rais-two-arg := lex-item &
              synsem >,
     SYNSEM.NON-LOCAL [ SLASH #slash,
                        REL #rel,
-                       QUE #que ] ].
+                       QUE #que ] ]
+"""
+; These non-zero argument types only amalgamate the non-local
+; feature values of their complements. They do not introduce any
+; non-local values of their own, nor do they bind off any non-local
+; feature values. This assumes that the bottom of most long-distance
+; dependencies is handled by a rule that constrains an argument 
+; (either on the ARG-ST list or a valence list) to be a synsem of 
+; type gap. Elements like English tough adjectives which bind off a 
+; slash value will need a new type that doesn't amalgamate that slash 
+; value. Elements which both introduce REL or QUE values and take one 
+; or more arguments will require appropriate new types as well, which
+; amalgamate everything but add a value in addition.
+""".
 
 basic-three-arg := lex-item &
   [ ARG-ST < [ NON-LOCAL [ SLASH [ LIST #smiddle2,
@@ -10377,7 +10431,20 @@ basic-three-arg := lex-item &
                        REL [ LIST #rfirst,
                              LAST #rlast ],
                        QUE [ LIST #qfirst,
-                             LAST #qlast ] ] ].
+                             LAST #qlast ] ] ]
+"""
+; These non-zero argument types only amalgamate the non-local
+; feature values of their complements. They do not introduce any
+; non-local values of their own, nor do they bind off any non-local
+; feature values. This assumes that the bottom of most long-distance
+; dependencies is handled by a rule that constrains an argument 
+; (either on the ARG-ST list or a valence list) to be a synsem of 
+; type gap. Elements like English tough adjectives which bind off a 
+; slash value will need a new type that doesn't amalgamate that slash 
+; value. Elements which both introduce REL or QUE values and take one 
+; or more arguments will require appropriate new types as well, which
+; amalgamate everything but add a value in addition.
+""".
 
 cc-three-arg := lex-item &
   [ ARG-ST < [ NON-LOCAL [ SLASH [ LIST #smiddle,
@@ -10403,7 +10470,20 @@ cc-three-arg := lex-item &
                        REL [ LIST #rfirst,
                              LAST #rlast ],
                        QUE [ LIST #qfirst,
-                             LAST #qlast ] ] ].
+                             LAST #qlast ] ] ]
+"""
+; These non-zero argument types only amalgamate the non-local
+; feature values of their complements. They do not introduce any
+; non-local values of their own, nor do they bind off any non-local
+; feature values. This assumes that the bottom of most long-distance
+; dependencies is handled by a rule that constrains an argument 
+; (either on the ARG-ST list or a valence list) to be a synsem of 
+; type gap. Elements like English tough adjectives which bind off a 
+; slash value will need a new type that doesn't amalgamate that slash 
+; value. Elements which both introduce REL or QUE values and take one 
+; or more arguments will require appropriate new types as well, which
+; amalgamate everything but add a value in addition.
+""".
 
 basic-four-arg := lex-item &
   [ ARG-ST < [ NON-LOCAL [ SLASH [ LIST #smiddle3,
@@ -10435,7 +10515,20 @@ basic-four-arg := lex-item &
                        REL [ LIST #rfirst,
                              LAST #rlast ],
                        QUE [ LIST #qfirst,
-                             LAST #qlast ] ] ].
+                             LAST #qlast ] ] ]
+"""
+; These non-zero argument types only amalgamate the non-local
+; feature values of their complements. They do not introduce any
+; non-local values of their own, nor do they bind off any non-local
+; feature values. This assumes that the bottom of most long-distance
+; dependencies is handled by a rule that constrains an argument 
+; (either on the ARG-ST list or a valence list) to be a synsem of 
+; type gap. Elements like English tough adjectives which bind off a 
+; slash value will need a new type that doesn't amalgamate that slash 
+; value. Elements which both introduce REL or QUE values and take one 
+; or more arguments will require appropriate new types as well, which
+; amalgamate everything but add a value in addition.
+""".
 
 
 ; --- Subcategorization types
@@ -10462,6 +10555,11 @@ np_nom_local := np_local &
                       KEYS [ KEY nom_rel,
                              ALTKEY quant_or_wh_rel ] ] ].
 
+np_acc_local := np_local & acc_local &
+  [ COORD -,
+    CAT.HEAD [ CASE acc_or_obl, 
+               KEYS.KEY a_sel_or_indp_rel ] ]
+"""
 ; llevan el marcador "a": 
 ; - sust. individualizados (busco a María/al ayudante/ayudante), 
 ; - pron. tónicos referidos a personas (me miró a mí, no espero a nadie, a quién buscas),
@@ -10473,10 +10571,7 @@ np_nom_local := np_local &
 ; los verbos ditrans no llevan el marcador (presenté mi novia a mis padres)
 ; clitic doubling obligatory when the DO is realized by a strong personal pron
 ; (a mí me golpearon/*a mí golpearon)
-np_acc_local := np_local & acc_local &
-  [ COORD -,
-    CAT.HEAD [ CASE acc_or_obl, 
-               KEYS.KEY a_sel_or_indp_rel ] ]. 
+""". 
 
 np_acc_unmrkd_local := np_acc_local & 
   [ COORD -,
@@ -10814,1008 +10909,1503 @@ c_xp_eso-que_native_le := c_xp_eso-que_lex & native_le
 
 c_xp_eso-que_le := c_xp_eso-que_lex.
 
-;  <type val="v_-_nsbj_le">
-;  <description>Verb, no compl, no subj (weather verbs)
-;  <ex>Llueve.
-;  <todo>
-;  </type>
+
 v_-_nsbj_native_le := v_-_nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_-_nsbj_le">
+  <description>Verb, no compl, no subj (weather verbs)
+  <ex>Llueve.
+  <todo>
+  </type>
   """.
 
-v_-_nsbj_le := v_-_nsbj_lex.
 
-;  <type val="v_np_npsv-nsbj_le">
-;  <description>Verb, NP (don't passivize), no subj
-;  <ex>Hay libros.
-;  <todo>
-;  </type>
+v_-_nsbj_le := v_-_nsbj_lex
+  """
+  
+  """.
+
+
 v_np_npsv-nsbj_native_le := v_np_npsv-nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_npsv-nsbj_le">
+  <description>Verb, NP (don't passivize), no subj
+  <ex>Hay libros.
+  <todo>
+  </type>
   """.
 
-v_np_npsv-nsbj_le := v_np_npsv-nsbj_lex.
 
-;  <type val="v_cp_p-ind-nsbj_le">
-;  <description>Verb, Sent. (ind), no subj
-;  <ex>Resultó que Juan fue el ganador.
-;  <todo>
-;  </type>
+v_np_npsv-nsbj_le := v_np_npsv-nsbj_lex
+  """
+  
+  """.
+
+
 v_cp_p-ind-nsbj_native_le := v_cp_p-ind-nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_p-ind-nsbj_le">
+  <description>Verb, Sent. (ind), no subj
+  <ex>Resultó que Juan fue el ganador.
+  <todo>
+  </type>
   """.
 
-v_cp_p-ind-nsbj_le := v_cp_p-ind-nsbj_lex.
 
-;  <type val="v_cp_p-sub-nsbj_le">
-;  <description>Verb, Sent. (subj), no subj
-;  <ex>Puede que mañana llueva.
-;  <todo>
-;  </type>
+v_cp_p-ind-nsbj_le := v_cp_p-ind-nsbj_lex
+  """
+  
+  """.
+
+
 v_cp_p-sub-nsbj_native_le := v_cp_p-sub-nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_p-sub-nsbj_le">
+  <description>Verb, Sent. (subj), no subj
+  <ex>Puede que mañana llueva.
+  <todo>
+  </type>
   """.
 
-v_cp_p-sub-nsbj_le := v_cp_p-sub-nsbj_lex.
 
-;  <type val="v_cp_p-inf-nsbj_le">
-;  <description>Verb, VPinf, no subj
-;  <ex>Hay que trabajar más
-;  <todo>
-;  </type>
+v_cp_p-sub-nsbj_le := v_cp_p-sub-nsbj_lex
+  """
+  
+  """.
+
+
 v_cp_p-inf-nsbj_native_le := v_cp_p-inf-nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_p-inf-nsbj_le">
+  <description>Verb, VPinf, no subj
+  <ex>Hay que trabajar más
+  <todo>
+  </type>
   """.
 
-v_cp_p-inf-nsbj_le := v_cp_p-inf-nsbj_lex.
 
-;  <type val="v_pp_e-nsbj-prn_le">
-;  <description>Verb (pron), PPsel, no subj
-;  <ex>Se trata de un goleador nato.
-;  <todo>
-;  </type>
+v_cp_p-inf-nsbj_le := v_cp_p-inf-nsbj_lex
+  """
+  
+  """.
+
+
 v_pp_e-nsbj-prn_native_le := v_pp_e-nsbj-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-nsbj-prn_le">
+  <description>Verb (pron), PPsel, no subj
+  <ex>Se trata de un goleador nato.
+  <todo>
+  </type>
   """.
 
-v_pp_e-nsbj-prn_le := v_pp_e-nsbj-prn_lex.
 
-;  <type val="v_pp_e-nsbj_le">
-;  <description>Verb, PPsel, no subj
-;  <ex>basta con 100 ptas.
-;  <todo>
-;  </type>
+v_pp_e-nsbj-prn_le := v_pp_e-nsbj-prn_lex
+  """
+  
+  """.
+
+
 v_pp_e-nsbj_native_le := v_pp_e-nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-nsbj_le">
+  <description>Verb, PPsel, no subj
+  <ex>basta con 100 ptas.
+  <todo>
+  </type>
   """.
 
-v_pp_e-nsbj_le := v_pp_e-nsbj_lex.
 
-;  <type val="v_pp_e-cp-p-nsbj_le">
-;  <description>Verb, PPsel (sent), no subj
-;  <ex>basta con que vengas.
-;  <todo>
-;  </type>
+v_pp_e-nsbj_le := v_pp_e-nsbj_lex
+  """
+  
+  """.
+
+
 v_pp_e-cp-p-nsbj_native_le := v_pp_e-cp-p-nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-cp-p-nsbj_le">
+  <description>Verb, PPsel (sent), no subj
+  <ex>basta con que vengas.
+  <todo>
+  </type>
   """.
 
-v_pp_e-cp-p-nsbj_le := v_pp_e-cp-p-nsbj_lex.
 
-;  <type val="v_pp_e-vp-nsbj_le">
-;  <description>Verb, PPsel (VPinf), no subj
-;  <ex>basta con verte
-;  <todo>
-;  </type>
+v_pp_e-cp-p-nsbj_le := v_pp_e-cp-p-nsbj_lex
+  """
+  
+  """.
+
+
 v_pp_e-vp-nsbj_native_le := v_pp_e-vp-nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-vp-nsbj_le">
+  <description>Verb, PPsel (VPinf), no subj
+  <ex>basta con verte
+  <todo>
+  </type>
   """.
 
-v_pp_e-vp-nsbj_le := v_pp_e-vp-nsbj_lex.
 
-;  <type val="v_ppa-pp_e-nsbj_le">
-;  <description>Verb, PPa and PPsel, no subj
-;  <ex>Me sobra con 100 ptas.
-;  <todo>
-;  </type>
+v_pp_e-vp-nsbj_le := v_pp_e-vp-nsbj_lex
+  """
+  
+  """.
+
+
 v_ppa-pp_e-nsbj_native_le := v_ppa-pp_e-nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa-pp_e-nsbj_le">
+  <description>Verb, PPa and PPsel, no subj
+  <ex>Me sobra con 100 ptas.
+  <todo>
+  </type>
   """.
 
-v_ppa-pp_e-nsbj_le := v_ppa-pp_e-nsbj_lex.
 
-;  <type val="v_ppa-pp_e-cp-p-nsbj_le">
-;  <description>Verb, PPa and PPsel (sent), no subj
-;  <ex>Me basta con que vengas.
-;  <todo>
-;  </type>
+v_ppa-pp_e-nsbj_le := v_ppa-pp_e-nsbj_lex
+  """
+  
+  """.
+
+
 v_ppa-pp_e-cp-p-nsbj_native_le := v_ppa-pp_e-cp-p-nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa-pp_e-cp-p-nsbj_le">
+  <description>Verb, PPa and PPsel (sent), no subj
+  <ex>Me basta con que vengas.
+  <todo>
+  </type>
   """.
 
-v_ppa-pp_e-cp-p-nsbj_le := v_ppa-pp_e-cp-p-nsbj_lex.
 
-;  <type val="v_ppa-pp_e-vp-nsbj_le">
-;  <description>Verb, PPa and PPsel (VPinf), no subj
-;  <ex>Me basta con verte
-;  <todo>
-;  </type>
+v_ppa-pp_e-cp-p-nsbj_le := v_ppa-pp_e-cp-p-nsbj_lex
+  """
+  
+  """.
+
+
 v_ppa-pp_e-vp-nsbj_native_le := v_ppa-pp_e-vp-nsbj_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa-pp_e-vp-nsbj_le">
+  <description>Verb, PPa and PPsel (VPinf), no subj
+  <ex>Me basta con verte
+  <todo>
+  </type>
   """.
 
-v_ppa-pp_e-vp-nsbj_le := v_ppa-pp_e-vp-nsbj_lex.
 
-;  <type val="v_-_sbj-cp-p_le">
-;  <description>Verb, no compl, Subj Sent
-;  <ex>En el contrato no figura que el acuerdo es/sea irreversible.
-;  <todo>
-;  </type>
+v_ppa-pp_e-vp-nsbj_le := v_ppa-pp_e-vp-nsbj_lex
+  """
+  
+  """.
+
+
 v_-_sbj-cp-p_native_le := v_-_sbj-cp-p_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_-_sbj-cp-p_le">
+  <description>Verb, no compl, Subj Sent
+  <ex>En el contrato no figura que el acuerdo es/sea irreversible.
+  <todo>
+  </type>
   """.
 
-v_-_sbj-cp-p_le := v_-_sbj-cp-p_lex.
 
-;  <type val="v_-_sbj-cp-p-prn_le">
-;  <description>Verb (pron), no compl, Subj Sent
-;  <ex>De ahí se desprende que la situación es/sea imposible.
-;  <todo>
-;  </type>
+v_-_sbj-cp-p_le := v_-_sbj-cp-p_lex
+  """
+  
+  """.
+
+
 v_-_sbj-cp-p-prn_native_le := v_-_sbj-cp-p-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_-_sbj-cp-p-prn_le">
+  <description>Verb (pron), no compl, Subj Sent
+  <ex>De ahí se desprende que la situación es/sea imposible.
+  <todo>
+  </type>
   """.
 
-v_-_sbj-cp-p-prn_le := v_-_sbj-cp-p-prn_lex.
 
-;  <type val="v_ppa*_sbj-cp-p_le">
-;  <description>Verb, PPa (opt), Subj Sent
-;  <ex>(Le) ocurre que no hicieron lo que les había pedido
-;  <todo>
-;  </type>
+v_-_sbj-cp-p-prn_le := v_-_sbj-cp-p-prn_lex
+  """
+  
+  """.
+
+
 v_ppa*_sbj-cp-p_native_le := v_ppa*_sbj-cp-p_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*_sbj-cp-p_le">
+  <description>Verb, PPa (opt), Subj Sent
+  <ex>(Le) ocurre que no hicieron lo que les había pedido
+  <todo>
+  </type>
   """.
 
-v_ppa*_sbj-cp-p_le := v_ppa*_sbj-cp-p_lex.
 
-;  <type val="v_ppa*_sbj-cp-p-cv_le">
-;  <description>Verb, PPa (opt), Subj Sent/VPinf
-;  <ex>No (me) consta que estuviese aquí.
-;  <todo>
-;  </type>
+v_ppa*_sbj-cp-p_le := v_ppa*_sbj-cp-p_lex
+  """
+  
+  """.
+
+
 v_ppa*_sbj-cp-p-cv_native_le := v_ppa*_sbj-cp-p-cv_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*_sbj-cp-p-cv_le">
+  <description>Verb, PPa (opt), Subj Sent/VPinf
+  <ex>No (me) consta que estuviese aquí.
+  <todo>
+  </type>
   """.
 
-v_ppa*_sbj-cp-p-cv_le := v_ppa*_sbj-cp-p-cv_lex.
 
-;  <type val="v_ppa*_sbj-cp-p-sub-cv_le">
-;  <description>Verb, PPa (opt), Subj Sent subj/VPinf
-;  <ex>(Me) basta que vengas
-;  <todo>
-;  </type>
+v_ppa*_sbj-cp-p-cv_le := v_ppa*_sbj-cp-p-cv_lex
+  """
+  
+  """.
+
+
 v_ppa*_sbj-cp-p-sub-cv_native_le := v_ppa*_sbj-cp-p-sub-cv_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*_sbj-cp-p-sub-cv_le">
+  <description>Verb, PPa (opt), Subj Sent subj/VPinf
+  <ex>(Me) basta que vengas
+  <todo>
+  </type>
   """.
 
-v_ppa*_sbj-cp-p-sub-cv_le := v_ppa*_sbj-cp-p-sub-cv_lex.
 
-;  <type val="v_ppa*_sbj-cp-p-sub_le">
-;  <description>Verb, PPa (opt), Subj Sent subj/VPinf
-;  <ex>No (me) gusta que a los toros te pongas la minifalda.
-;  <todo>
-;  </type>
+v_ppa*_sbj-cp-p-sub-cv_le := v_ppa*_sbj-cp-p-sub-cv_lex
+  """
+  
+  """.
+
+
 v_ppa*_sbj-cp-p-sub_native_le := v_ppa*_sbj-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*_sbj-cp-p-sub_le">
+  <description>Verb, PPa (opt), Subj Sent subj/VPinf
+  <ex>No (me) gusta que a los toros te pongas la minifalda.
+  <todo>
+  </type>
   """.
 
-v_ppa*_sbj-cp-p-sub_le := v_ppa*_sbj-cp-p-sub_lex.
 
-;  <type val="v_ppa*_sbj-cp-p-sub-prn_le">
-;  <description>Verb (pron), PPa (opt), Subj Sent subj/VPinf
-;  <ex>se le antojó que vinieran.
-;  <todo>
-;  </type>
+v_ppa*_sbj-cp-p-sub_le := v_ppa*_sbj-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_ppa*_sbj-cp-p-sub-prn_native_le := v_ppa*_sbj-cp-p-sub-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*_sbj-cp-p-sub-prn_le">
+  <description>Verb (pron), PPa (opt), Subj Sent subj/VPinf
+  <ex>se le antojó que vinieran.
+  <todo>
+  </type>
   """.
 
-v_ppa*_sbj-cp-p-sub-prn_le := v_ppa*_sbj-cp-p-sub-prn_lex.
 
-;  <type val="v_pp_e-sbj-cp-p-sub_le">
-;  <description>Verb, PPsel, Subj Sent subj/VPinf
-;  <ex>(el) que las clases sean malas repercute en los alumnos
-;  <todo>
-;  </type>
+v_ppa*_sbj-cp-p-sub-prn_le := v_ppa*_sbj-cp-p-sub-prn_lex
+  """
+  
+  """.
+
+
 v_pp_e-sbj-cp-p-sub_native_le := v_pp_e-sbj-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-sbj-cp-p-sub_le">
+  <description>Verb, PPsel, Subj Sent subj/VPinf
+  <ex>(el) que las clases sean malas repercute en los alumnos
+  <todo>
+  </type>
   """.
 
-v_pp_e-sbj-cp-p-sub_le := v_pp_e-sbj-cp-p-sub_lex.
 
-;  <type val="v_pp_e-sbj-cp-p-sub-prn_le">
-;  <description>Verb (pron), PPsel, Subj Sent subj/VPinf
-;  <ex>(el) que las clases sean malas se traduce en un mal resultado
-;  <todo>
-;  </type>
+v_pp_e-sbj-cp-p-sub_le := v_pp_e-sbj-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_pp_e-sbj-cp-p-sub-prn_native_le := v_pp_e-sbj-cp-p-sub-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-sbj-cp-p-sub-prn_le">
+  <description>Verb (pron), PPsel, Subj Sent subj/VPinf
+  <ex>(el) que las clases sean malas se traduce en un mal resultado
+  <todo>
+  </type>
   """.
 
-v_pp_e-sbj-cp-p-sub-prn_le := v_pp_e-sbj-cp-p-sub-prn_lex.
 
-;  <type val="v_ppa*-pp_e-sbj-cp-p-sub_le">
-;  <description>Verb, PPa, PPsel, Subj Sent subj/VPinf
-;  <ex>de nada /le) sirve luchar que luchen/luchar
-;  <todo>
-;  </type>
+v_pp_e-sbj-cp-p-sub-prn_le := v_pp_e-sbj-cp-p-sub-prn_lex
+  """
+  
+  """.
+
+
 v_ppa*-pp_e-sbj-cp-p-sub_native_le := v_ppa*-pp_e-sbj-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-pp_e-sbj-cp-p-sub_le">
+  <description>Verb, PPa, PPsel, Subj Sent subj/VPinf
+  <ex>de nada /le) sirve luchar que luchen/luchar
+  <todo>
+  </type>
   """.
 
-v_ppa*-pp_e-sbj-cp-p-sub_le := v_ppa*-pp_e-sbj-cp-p-sub_lex.
 
-;  <type val="v_np_sbj-cp-p-sub_le">
-;  <description>Verb, NP, Subj Sent subj/VPinf
-;  <ex>que el poder político se descomponga no significa necesariamente una decadencia.
-;  <todo>
-;  </type>
+v_ppa*-pp_e-sbj-cp-p-sub_le := v_ppa*-pp_e-sbj-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_np_sbj-cp-p-sub_native_le := v_np_sbj-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_sbj-cp-p-sub_le">
+  <description>Verb, NP, Subj Sent subj/VPinf
+  <ex>que el poder político se descomponga no significa necesariamente una decadencia.
+  <todo>
+  </type>
   """.
 
-v_np_sbj-cp-p-sub_le := v_np_sbj-cp-p-sub_lex.
 
-;  <type val="v_np_sbj-cp-p-sub-idm_le">
-;  <description>Verb, NP, Subj Sent subj/VPinf (idioms)
-;  <ex>Vale la pega que vengan/pagar tanto
-;  <todo>
-;  </type>
+v_np_sbj-cp-p-sub_le := v_np_sbj-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_np_sbj-cp-p-sub-idm_native_le := v_np_sbj-cp-p-sub-idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_sbj-cp-p-sub-idm_le">
+  <description>Verb, NP, Subj Sent subj/VPinf (idioms)
+  <ex>Vale la pega que vengan/pagar tanto
+  <todo>
+  </type>
   """.
 
-v_np_sbj-cp-p-sub-idm_le := v_np_sbj-cp-p-sub-idm_lex.
 
-;  <type val="v_np-pp_e-sbj-cp-p_-suble">
-;  <description>Verb, NP and PPsel, Subj Sent sub/VPinf
-;  <ex>que su partido haya perdido las elecciones lo apartará del poder
-;  <todo>
-;  </type>
+v_np_sbj-cp-p-sub-idm_le := v_np_sbj-cp-p-sub-idm_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-sbj-cp-p-sub_native_le := v_np-pp_e-sbj-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-sbj-cp-p_-suble">
+  <description>Verb, NP and PPsel, Subj Sent sub/VPinf
+  <ex>que su partido haya perdido las elecciones lo apartará del poder
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-sbj-cp-p-sub_le := v_np-pp_e-sbj-cp-p-sub_lex.
 
-;  <type val="v_np-ppa*_sbj-cp-p-sub_le">
-;  <description>Verb, NP and PPa (opt), Subj Sent subj/VPinf
-;  <ex>que haya dicho esto le acarrea le acarrea muchos problemas (a María).
-;  <todo>
-;  </type>
+v_np-pp_e-sbj-cp-p-sub_le := v_np-pp_e-sbj-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_np-ppa*_sbj-cp-p-sub_native_le := v_np-ppa*_sbj-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-ppa*_sbj-cp-p-sub_le">
+  <description>Verb, NP and PPa (opt), Subj Sent subj/VPinf
+  <ex>que haya dicho esto le acarrea le acarrea muchos problemas (a María).
+  <todo>
+  </type>
   """.
 
-v_np-ppa*_sbj-cp-p-sub_le := v_np-ppa*_sbj-cp-p-sub_lex.
 
-;  <type val="v_cp_p-sbj-cp-p-sub_le">
-;  <description>Verb, Sent/VPinf, Subj Sent subj/VPinf
-;  <ex>que te haya aprobado no significa que no tengas que venir a clase
-;  <todo>
-;  </type>
+v_np-ppa*_sbj-cp-p-sub_le := v_np-ppa*_sbj-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_cp_p-sbj-cp-p-sub_native_le := v_cp_p-sbj-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_p-sbj-cp-p-sub_le">
+  <description>Verb, Sent/VPinf, Subj Sent subj/VPinf
+  <ex>que te haya aprobado no significa que no tengas que venir a clase
+  <todo>
+  </type>
   """.
+
 
 v_cp_p-sbj-cp-p-sub_le := v_cp_p-sbj-cp-p-sub_lex.
 
-;  <type val="v_ppa*-cp_p-sbj-cp-p-sub_le">
-;  <description>Verb, PPa (opt) and Sent/VPinf, Subj Sent subj/VPinf
-;  <ex>oír música no (te) impide que trabajes
-;  <todo>
-;  </type>
+
 v_ppa*-cp_p-sbj-cp-p-sub_native_le := v_ppa*-cp_p-sbj-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-cp_p-sbj-cp-p-sub_le">
+  <description>Verb, PPa (opt) and Sent/VPinf, Subj Sent subj/VPinf
+  <ex>oír música no (te) impide que trabajes
+  <todo>
+  </type>
   """.
 
-v_ppa*-cp_p-sbj-cp-p-sub_le := v_ppa*-cp_p-sbj-cp-p-sub_lex.
 
-;  <type val="v_ap_sbj-vp-inf-ser_le">
-;  <description> Verb (ser), AP, Subj VPinf
-;  <ex>es imposible vivir en el centro
-;  <todo>
-;  </type>
+v_ppa*-cp_p-sbj-cp-p-sub_le := v_ppa*-cp_p-sbj-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_ap_sbj-vp-inf-ser_native_le := v_ap_sbj-vp-inf-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ap_sbj-vp-inf-ser_le">
+  <description> Verb (ser), AP, Subj VPinf
+  <ex>es imposible vivir en el centro
+  <todo>
+  </type>
   """.
 
-v_ap_sbj-vp-inf-ser_le := v_ap_sbj-vp-inf-ser_lex.
 
-;  <type val="v_pp_e-sbj-vp-inf-ser_le">
-;  <description>Verb (ser), PPsel, Subj VPinf
-;  <ex>rectificar es de sabios 
-;  <todo>
-;  </type>
+v_ap_sbj-vp-inf-ser_le := v_ap_sbj-vp-inf-ser_lex
+  """
+  
+  """.
+
+
 v_pp_e-sbj-vp-inf-ser_native_le := v_pp_e-sbj-vp-inf-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-sbj-vp-inf-ser_le">
+  <description>Verb (ser), PPsel, Subj VPinf
+  <ex>rectificar es de sabios
+  <todo>
+  </type>
   """.
 
-v_pp_e-sbj-vp-inf-ser_le := v_pp_e-sbj-vp-inf-ser_lex.
 
-;  <type val="v_np_npsv-sbj-vp-inf-ser_le">
-;  <description>Verb (ser), NP, Subj VPinf
-;  <ex>regalar detalles es una cursilería 
-;  <todo>
-;  </type>
+v_pp_e-sbj-vp-inf-ser_le := v_pp_e-sbj-vp-inf-ser_lex
+  """
+  
+  """.
+
+
 v_np_npsv-sbj-vp-inf-ser_native_le := v_np_npsv-sbj-vp-inf-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_npsv-sbj-vp-inf-ser_le">
+  <description>Verb (ser), NP, Subj VPinf
+  <ex>regalar detalles es una cursilería
+  <todo>
+  </type>
   """.
 
-v_np_npsv-sbj-vp-inf-ser_le := v_np_npsv-sbj-vp-inf-ser_lex.
 
-;  <type val="v_vp_sbj-vp-inf-ser_le">
-;  <description>>Verb (ser), VPinf, Subj VPinf
-;  <ex>Tolerar es simplemente reconocer que el otro existe.
-;  <todo>
-;  </type>
+v_np_npsv-sbj-vp-inf-ser_le := v_np_npsv-sbj-vp-inf-ser_lex
+  """
+  
+  """.
+
+
 v_vp_sbj-vp-inf-ser_native_le := v_vp_sbj-vp-inf-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_sbj-vp-inf-ser_le">
+  <description>>Verb (ser), VPinf, Subj VPinf
+  <ex>Tolerar es simplemente reconocer que el otro existe.
+  <todo>
+  </type>
   """.
 
-v_vp_sbj-vp-inf-ser_le := v_vp_sbj-vp-inf-ser_lex.
 
-;  <type val="v_ap_sbj-cp-p-ser_le">
-;  <description>Verb (ser), AP, Subj Sent
-;  <ex>es imposible que no venga
-;  <todo>
-;  </type>
+v_vp_sbj-vp-inf-ser_le := v_vp_sbj-vp-inf-ser_lex
+  """
+  
+  """.
+
+
 v_ap_sbj-cp-p-ser_native_le := v_ap_sbj-cp-p-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ap_sbj-cp-p-ser_le">
+  <description>Verb (ser), AP, Subj Sent
+  <ex>es imposible que no venga
+  <todo>
+  </type>
   """.
 
-v_ap_sbj-cp-p-ser_le := v_ap_sbj-cp-p-ser_lex.
 
-;  <type val="v_np_sbj-cp-p-ser_le">
-;  <description>Verb (ser), NP, Subj Sent
-;  <ex>
-;  <todo>
-;  </type>
+v_ap_sbj-cp-p-ser_le := v_ap_sbj-cp-p-ser_lex
+  """
+  
+  """.
+
+
 v_np_sbj-cp-p-ser_native_le := v_np_sbj-cp-p-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_sbj-cp-p-ser_le">
+  <description>Verb (ser), NP, Subj Sent
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np_sbj-cp-p-ser_le := v_np_sbj-cp-p-ser_lex.
 
-;  <type val="v_ppart_sbj-vp-inf-estar_le">
-;  <description>Verb (estar), ppart, Subj VPinf
-;  <ex>está prohibido fumar aqui.
-;  <todo>
-;  </type>
+v_np_sbj-cp-p-ser_le := v_np_sbj-cp-p-ser_lex
+  """
+  
+  """.
+
+
 v_ppart_sbj-vp-inf-estar_native_le := v_ppart_sbj-vp-inf-estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppart_sbj-vp-inf-estar_le">
+  <description>Verb (estar), ppart, Subj VPinf
+  <ex>está prohibido fumar aqui.
+  <todo>
+  </type>
   """.
 
-v_ppart_sbj-vp-inf-estar_le := v_ppart_sbj-vp-inf-estar_lex.
 
-;  <type val="v_ap_sbj-cp-p-estar_le">
-;  <description>Verb (estar), AP, Subj Sent 
-;  <ex>no está claro que ha ocurrido
-;  <todo>
-;  </type>
+v_ppart_sbj-vp-inf-estar_le := v_ppart_sbj-vp-inf-estar_lex
+  """
+  
+  """.
+
+
 v_ap_sbj-cp-p-estar_native_le := v_ap_sbj-cp-p-estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ap_sbj-cp-p-estar_le">
+  <description>Verb (estar), AP, Subj Sent
+  <ex>no está claro que ha ocurrido
+  <todo>
+  </type>
   """.
 
-v_ap_sbj-cp-p-estar_le := v_ap_sbj-cp-p-estar_lex.
 
-;  <type val="v_adv_sbj-cp-p-estar_le">
-;  <description>Verb (estar), ADV, Subj Sent
-;  <ex>está bien que Guillermo lo haga
-;  <todo>
-;  </type>
+v_ap_sbj-cp-p-estar_le := v_ap_sbj-cp-p-estar_lex
+  """
+  
+  """.
+
+
 v_adv_sbj-cp-p-estar_native_le := v_adv_sbj-cp-p-estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_adv_sbj-cp-p-estar_le">
+  <description>Verb (estar), ADV, Subj Sent
+  <ex>está bien que Guillermo lo haga
+  <todo>
+  </type>
   """.
 
-v_adv_sbj-cp-p-estar_le := v_adv_sbj-cp-p-estar_lex.
 
-;  <type val="v_-_psv_le">
-;  <description>Verb, no compl, (unacc, may appear in APC)
-;  <ex>floreció el rosal.
-; <todo>
-;  </type>
+v_adv_sbj-cp-p-estar_le := v_adv_sbj-cp-p-estar_lex
+  """
+  
+  """.
+
+
 v_-_psv_native_le := v_-_psv_lex & native_le
   """
-  This is a native lexical entry type, for words that are in the lexicon.
+   This is a native lexical entry type, for words that are in the lexicon.
+  
+   <type val="v_-_psv_le">
+   <description>Verb, no compl, (unacc, may appear in APC)
+   <ex>floreció el rosal.
+  <todo>
+   </type>
   """.
 
-v_-_psv_le := v_-_psv_lex.
 
-;  <type val="v_-_psv-prn_le">
-;  <description>Verb (pron), no compl, (unacc, may appear in APC)
-;  <ex>el jersey se encogió.
-; <todo>
-;  </type>
+v_-_psv_le := v_-_psv_lex
+  """
+  
+  """.
+
+
 v_-_psv-prn_native_le := v_-_psv-prn_lex & native_le
   """
-  This is a native lexical entry type, for words that are in the lexicon.
+   This is a native lexical entry type, for words that are in the lexicon.
+  
+   <type val="v_-_psv-prn_le">
+   <description>Verb (pron), no compl, (unacc, may appear in APC)
+   <ex>el jersey se encogió.
+  <todo>
+   </type>
   """.
 
-v_-_psv-prn_le := v_-_psv-prn_lex.
 
-;  <type val="v_pp_loc_le">
-;  <description>Verb, PPloc (unacc, don't appear in APC)
-;  <ex>vive
-;  <todo>
-;  </type>
+v_-_psv-prn_le := v_-_psv-prn_lex
+  """
+  
+  """.
+
+
 v_pp_loc_native_le := v_pp_loc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_loc_le">
+  <description>Verb, PPloc (unacc, don't appear in APC)
+  <ex>vive
+  <todo>
+  </type>
   """.
 
-v_pp_loc_le := v_pp_loc_lex.
 
-;  <type val="v_pp*_loc_le">
-;  <description>Verb, PPloc (opt) (unacc, don't appear in APC)
-;  <ex>permaneció (en la ciudad).
-;  <todo>
-;  </type>
+v_pp_loc_le := v_pp_loc_lex
+  """
+  
+  """.
+
+
 v_pp*_loc_native_le := v_pp*_loc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_loc_le">
+  <description>Verb, PPloc (opt) (unacc, don't appear in APC)
+  <ex>permaneció (en la ciudad).
+  <todo>
+  </type>
   """.
 
-v_pp*_loc_le := v_pp*_loc_lex.
 
-;  <type val="v_pp*_loc-psv_le">
-;  <description>Verb, PPloc (opt) (unacc, may appear in APC)
-;  <ex>aterrizó (en el aeropuerto de Barcelona).
-;  <todo>
-;  </type>
+v_pp*_loc_le := v_pp*_loc_lex
+  """
+  
+  """.
+
+
 v_pp*_loc-psv_native_le := v_pp*_loc-psv_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_loc-psv_le">
+  <description>Verb, PPloc (opt) (unacc, may appear in APC)
+  <ex>aterrizó (en el aeropuerto de Barcelona).
+  <todo>
+  </type>
   """.
 
-v_pp*_loc-psv_le := v_pp*_loc-psv_lex.
 
-;  <type val="v_pp_loc-prn_le">
-;  <description>Verb (pron), PPloc (unacc, don't appear in APC)
-;  <ex>se alojó en mi casa.
-;  <todo>
-;  </type>
+v_pp*_loc-psv_le := v_pp*_loc-psv_lex
+  """
+  
+  """.
+
+
 v_pp_loc-prn_native_le := v_pp_loc-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_loc-prn_le">
+  <description>Verb (pron), PPloc (unacc, don't appear in APC)
+  <ex>se alojó en mi casa.
+  <todo>
+  </type>
   """.
 
-v_pp_loc-prn_le := v_pp_loc-prn_lex.
 
-;  <type val="v_pp*_loc-prn_le">
-;  <description>Verb (pron), PPloc (opt) (unacc, don't appear in APC)
-;  <ex>se presentó (en casa).
-;  <todo>
-;  </type>
+v_pp_loc-prn_le := v_pp_loc-prn_lex
+  """
+  
+  """.
+
+
 v_pp*_loc-prn_native_le := v_pp*_loc-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_loc-prn_le">
+  <description>Verb (pron), PPloc (opt) (unacc, don't appear in APC)
+  <ex>se presentó (en casa).
+  <todo>
+  </type>
   """.
 
-v_pp*_loc-prn_le := v_pp*_loc-prn_lex.
 
-;  <type val="v_pp*_loc-psv-prn_le">
-;  <description>Verb (pron), PPloc (opt) (unacc, may appear in APC)
-;  <ex>se atrincheraron (en un bar).
-;  <todo>
-;  </type>
+v_pp*_loc-prn_le := v_pp*_loc-prn_lex
+  """
+  
+  """.
+
+
 v_pp*_loc-psv-prn_native_le := v_pp*_loc-psv-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_loc-psv-prn_le">
+  <description>Verb (pron), PPloc (opt) (unacc, may appear in APC)
+  <ex>se atrincheraron (en un bar).
+  <todo>
+  </type>
   """.
 
-v_pp*_loc-psv-prn_le := v_pp*_loc-psv-prn_lex.
 
-;  <type val="v_pp_dir_le">
-;  <description>Verb, PPdir (unacc, don't appear in APC)
-;  <ex>Dolly se vuelve huracán y enfila hacia Texas.
-;  <todo>
-;  </type>
+v_pp*_loc-psv-prn_le := v_pp*_loc-psv-prn_lex
+  """
+  
+  """.
+
+
 v_pp_dir_native_le := v_pp_dir_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_dir_le">
+  <description>Verb, PPdir (unacc, don't appear in APC)
+  <ex>Dolly se vuelve huracán y enfila hacia Texas.
+  <todo>
+  </type>
   """.
 
-v_pp_dir_le := v_pp_dir_lex.
 
-;  <type val="v_pp*_dir_le">
-;  <description>Verb, PPdir (opt) (unacc, don't appear in APC)
-;  <ex>acudieron (a la reunión).
-;  <todo>
-;  </type>
+v_pp_dir_le := v_pp_dir_lex
+  """
+  
+  """.
+
+
 v_pp*_dir_native_le := v_pp*_dir_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_dir_le">
+  <description>Verb, PPdir (opt) (unacc, don't appear in APC)
+  <ex>acudieron (a la reunión).
+  <todo>
+  </type>
   """.
 
-v_pp*_dir_le := v_pp*_dir_lex.
 
-;  <type val="v_pp*_dir-psv_le">
-;  <description>Verb, PPdir (opt) (unacc, may appear in APC)
-;  <ex>partieron (hacia Nueva York).
-;  <todo>
-;  </type>
+v_pp*_dir_le := v_pp*_dir_lex
+  """
+  
+  """.
+
+
 v_pp*_dir-psv_native_le := v_pp*_dir-psv_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_dir-psv_le">
+  <description>Verb, PPdir (opt) (unacc, may appear in APC)
+  <ex>partieron (hacia Nueva York).
+  <todo>
+  </type>
   """.
 
-v_pp*_dir-psv_le := v_pp*_dir-psv_lex.
 
-;  <type val="v_pp*_dir-prn_le">
-;  <description>Verb (pron), PPdir (opt) (unacc, don't appear in APC)
-;  <ex>se extiende (hacia el sur).
-;  <todo>
-;  </type>
+v_pp*_dir-psv_le := v_pp*_dir-psv_lex
+  """
+  
+  """.
+
+
 v_pp*_dir-prn_native_le := v_pp*_dir-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_dir-prn_le">
+  <description>Verb (pron), PPdir (opt) (unacc, don't appear in APC)
+  <ex>se extiende (hacia el sur).
+  <todo>
+  </type>
   """.
 
-v_pp*_dir-prn_le := v_pp*_dir-prn_lex.
 
-;  <type val="v_pp_dir-prn_le">
-;  <description>Verb (pron), PPdir (unacc, don't appear in APC)
-;  <ex>me dirigí al norte
-;  <todo>
-;  </type>
+v_pp*_dir-prn_le := v_pp*_dir-prn_lex
+  """
+  
+  """.
+
+
 v_pp_dir-prn_native_le := v_pp_dir-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_dir-prn_le">
+  <description>Verb (pron), PPdir (unacc, don't appear in APC)
+  <ex>me dirigí al norte
+  <todo>
+  </type>
   """.
 
-v_pp_dir-prn_le := v_pp_dir-prn_lex.
 
-;  <type val="v_pp*_dir-psv-prn_le">
-;  <description>Verb (pron), PPdir (opt) (unacc, may appear in APC)
-;  <ex>se deslizó (hacia el otro lado).
-;  <todo>
-;  </type>
+v_pp_dir-prn_le := v_pp_dir-prn_lex
+  """
+  
+  """.
+
+
 v_pp*_dir-psv-prn_native_le := v_pp*_dir-psv-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_dir-psv-prn_le">
+  <description>Verb (pron), PPdir (opt) (unacc, may appear in APC)
+  <ex>se deslizó (hacia el otro lado).
+  <todo>
+  </type>
   """.
 
-v_pp*_dir-psv-prn_le := v_pp*_dir-psv-prn_lex.
 
-;  <type val="v_-_le">
-;  <description>Verb, no compl
-;  <ex>esquía muy bien.
-;  <todo>
-;  </type>
+v_pp*_dir-psv-prn_le := v_pp*_dir-psv-prn_lex
+  """
+  
+  """.
+
+
 v_-_native_le := v_-_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_-_le">
+  <description>Verb, no compl
+  <ex>esquía muy bien.
+  <todo>
+  </type>
   """.
 
-v_-_le := v_-_lex.
 
-;  <type val="v_-_prn_le">
-;  <description>Verb (pron), no compl
-;  <ex>se suicidó.
-;  <todo>
-;  </type>
+v_-_le := v_-_lex
+  """
+  
+  """.
+
+
 v_-_prn_native_le := v_-_prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_-_prn_le">
+  <description>Verb (pron), no compl
+  <ex>se suicidó.
+  <todo>
+  </type>
   """.
 
-v_-_prn_le := v_-_prn_lex.
 
-;  <type val="v_pp_e_le">
-;  <description>Verb, PPsel
-;  <ex>sucumbió a la tentación.
-;  <todo>
-;  </type>
+v_-_prn_le := v_-_prn_lex
+  """
+  
+  """.
+
+
 v_pp_e_native_le := v_pp_e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e_le">
+  <description>Verb, PPsel
+  <ex>sucumbió a la tentación.
+  <todo>
+  </type>
   """.
 
-v_pp_e_le := v_pp_e_lex.
 
-;  <type val="v_pp*_e_le">
-;  <description>Verb, PPsel (opt)
-;  <ex>desertó (del ejercito).
-;  <todo>
-;  </type>
+v_pp_e_le := v_pp_e_lex
+  """
+  
+  """.
+
+
 v_pp*_e_native_le := v_pp*_e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_e_le">
+  <description>Verb, PPsel (opt)
+  <ex>desertó (del ejercito).
+  <todo>
+  </type>
   """.
 
-v_pp*_e_le := v_pp*_e_lex.
 
-;  <type val="v_pp_e-prn_le">
-;  <description>Verb (pron), PPsel
-;  <ex>se encapricho de/con aquella muchacha.
-;  <todo>
-;  </type>
+v_pp*_e_le := v_pp*_e_lex
+  """
+  
+  """.
+
+
 v_pp_e-prn_native_le := v_pp_e-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-prn_le">
+  <description>Verb (pron), PPsel
+  <ex>se encapricho de/con aquella muchacha.
+  <todo>
+  </type>
   """.
 
-v_pp_e-prn_le := v_pp_e-prn_lex.
 
-;  <type val="v_pp*_e-prn_le">
-;  <description>Verb (pron), PPsel (opt)
-;  <ex>no supo adaptarse (a la nueva situación)
-;  <todo>
-;  </type>
+v_pp_e-prn_le := v_pp_e-prn_lex
+  """
+  
+  """.
+
+
 v_pp*_e-prn_native_le := v_pp*_e-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_e-prn_le">
+  <description>Verb (pron), PPsel (opt)
+  <ex>no supo adaptarse (a la nueva situación)
+  <todo>
+  </type>
   """.
 
-v_pp*_e-prn_le := v_pp*_e-prn_lex.
 
-;  <type val="v_pp_e-idm_le">
-;  <description>Verb, PPsel, idiom
-;  <ex>entrar en vigor
-;  <todo>
-;  </type>
+v_pp*_e-prn_le := v_pp*_e-prn_lex
+  """
+  
+  """.
+
+
 v_pp_e-idm_native_le := v_pp_e-idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-idm_le">
+  <description>Verb, PPsel, idiom
+  <ex>entrar en vigor
+  <todo>
+  </type>
   """.
 
-v_pp_e-idm_le := v_pp_e-idm_lex.
 
-;  <type val="v_pp_e-prn-idm_le">
-;  <description>Verb (pron), PPsel, idiom
-;  <ex>encogerse de hombros
-;  <todo>
-;  </type>
+v_pp_e-idm_le := v_pp_e-idm_lex
+  """
+  
+  """.
+
+
 v_pp_e-prn-idm_native_le := v_pp_e-prn-idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-prn-idm_le">
+  <description>Verb (pron), PPsel, idiom
+  <ex>encogerse de hombros
+  <todo>
+  </type>
   """.
 
-v_pp_e-prn-idm_le := v_pp_e-prn-idm_lex.
 
-;  <type val="v_pp_e-vp-sc_le">
-;  <description>Verb, PPsel (VPinf)
-;  <ex>aprendió a jugar a tenis
-;  <todo>
-;  </type>
+v_pp_e-prn-idm_le := v_pp_e-prn-idm_lex
+  """
+  
+  """.
+
+
 v_pp_e-vp-sc_native_le := v_pp_e-vp-sc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-vp-sc_le">
+  <description>Verb, PPsel (VPinf)
+  <ex>aprendió a jugar a tenis
+  <todo>
+  </type>
   """.
 
-v_pp_e-vp-sc_le := v_pp_e-vp-sc_lex.
 
-;  <type val="v_pp_e-vp-sc-prn_le">
-;  <description>Verb (pron), PPsel (VPinf)
-;  <ex>se comprometió a hacerlo.
-;  <todo>
-;  </type>
+v_pp_e-vp-sc_le := v_pp_e-vp-sc_lex
+  """
+  
+  """.
+
+
 v_pp_e-vp-sc-prn_native_le := v_pp_e-vp-sc-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-vp-sc-prn_le">
+  <description>Verb (pron), PPsel (VPinf)
+  <ex>se comprometió a hacerlo.
+  <todo>
+  </type>
   """.
 
-v_pp_e-vp-sc-prn_le := v_pp_e-vp-sc-prn_lex.
 
-;  <type val="v_pp_e-cp-p_le">
-;  <description>Verb, PPsel (Sent ind/subj)
-;  <ex>confío en que vengas/vendrás.
-;  <todo>
-;  </type>
+v_pp_e-vp-sc-prn_le := v_pp_e-vp-sc-prn_lex
+  """
+  
+  """.
+
+
 v_pp_e-cp-p_native_le := v_pp_e-cp-p_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-cp-p_le">
+  <description>Verb, PPsel (Sent ind/subj)
+  <ex>confío en que vengas/vendrás.
+  <todo>
+  </type>
   """.
 
-v_pp_e-cp-p_le := v_pp_e-cp-p_lex.
 
-;  <type val="v_pp_e-cp-p-prn_le">
-;  <description>Verb (pron), PPsel (Sent ind/subj)
-;  <ex>se asustó de que lloviera tanto
-;  <todo>
-;  </type>
+v_pp_e-cp-p_le := v_pp_e-cp-p_lex
+  """
+  
+  """.
+
+
 v_pp_e-cp-p-prn_native_le := v_pp_e-cp-p-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-cp-p-prn_le">
+  <description>Verb (pron), PPsel (Sent ind/subj)
+  <ex>se asustó de que lloviera tanto
+  <todo>
+  </type>
   """.
 
-v_pp_e-cp-p-prn_le := v_pp_e-cp-p-prn_lex.
 
-;  <type val="v_pp*_e-cp-p_le">
-;  <description>Verb, PPsel (opt, Sent ind/subj)
-;  <ex>sueño con que vengas/irás
-;  <todo>
-;  </type>
-v_pp*_e-cp-p_le := v_pp*_e-cp-p_lex.
+v_pp_e-cp-p-prn_le := v_pp_e-cp-p-prn_lex
+  """
+  
+  """.
 
-;  <type val="v_pp*_e-cp-p-prn_le">
-;  <description>Verb (pron), PPsel (opt, Sent ind/subj)
-;  <ex>se queja de que no tomes/tomarás nuevas iniciativas
-;  <todo>
-;  </type>
-v_pp*_e-cp-p-prn_le := v_pp*_e-cp-p-prn_lex.
 
-;  <type val="v_pp_e*-cp-p_le">
-;  <description>Verb, PPsel (Sent ind/subj), opt prep
-;  <ex>sueño (con) que vendrán
-;  <todo>
-;  </type>
+v_pp*_e-cp-p_le := v_pp*_e-cp-p_lex
+  """
+  <type val="v_pp*_e-cp-p_le">
+  <description>Verb, PPsel (opt, Sent ind/subj)
+  <ex>sueño con que vengas/irás
+  <todo>
+  </type>
+  """.
+
+
+v_pp*_e-cp-p-prn_le := v_pp*_e-cp-p-prn_lex
+  """
+  <type val="v_pp*_e-cp-p-prn_le">
+  <description>Verb (pron), PPsel (opt, Sent ind/subj)
+  <ex>se queja de que no tomes/tomarás nuevas iniciativas
+  <todo>
+  </type>
+  """.
+
+
 v_pp_e*-cp-p_native_le := v_pp_e*-cp-p_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e*-cp-p_le">
+  <description>Verb, PPsel (Sent ind/subj), opt prep
+  <ex>sueño (con) que vendrán
+  <todo>
+  </type>
   """.
 
-v_pp_e*-cp-p_le := v_pp_e*-cp-p_lex.
 
-;  <type val="v_pp_e*-cp-p-prn_le">
-;  <description>Verb (pron), PPsel (Sent ind/subj), opt prep
-;  <ex>se enteró (de) que vendrán
-;  <todo>
-;  </type>
+v_pp_e*-cp-p_le := v_pp_e*-cp-p_lex
+  """
+  
+  """.
+
+
 v_pp_e*-cp-p-prn_native_le := v_pp_e*-cp-p-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e*-cp-p-prn_le">
+  <description>Verb (pron), PPsel (Sent ind/subj), opt prep
+  <ex>se enteró (de) que vendrán
+  <todo>
+  </type>
   """.
 
-v_pp_e*-cp-p-prn_le := v_pp_e*-cp-p-prn_lex.
 
-;  <type val="v_pp_e-cp-p-ind_le">
-;  <description>Verb, PPsel (Sent ind)
-;  <ex>alardea de que es el mejor
-;  <todo>
-;  </type>
+v_pp_e*-cp-p-prn_le := v_pp_e*-cp-p-prn_lex
+  """
+  
+  """.
+
+
 v_pp_e-cp-p-ind_native_le := v_pp_e-cp-p-ind_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-cp-p-ind_le">
+  <description>Verb, PPsel (Sent ind)
+  <ex>alardea de que es el mejor
+  <todo>
+  </type>
   """.
 
-v_pp_e-cp-p-ind_le := v_pp_e-cp-p-ind_lex.
 
-;  <type val="v_pp_e-cp-p-ind-prn_le">
-;  <description>Verb (pron), PPsel (Sent ind)
-;  <ex>el candidato se conforta con que hizo todo lo posible para obtener el puesto
-;  <todo>
-;  </type>
+v_pp_e-cp-p-ind_le := v_pp_e-cp-p-ind_lex
+  """
+  
+  """.
+
+
 v_pp_e-cp-p-ind-prn_native_le := v_pp_e-cp-p-ind-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-cp-p-ind-prn_le">
+  <description>Verb (pron), PPsel (Sent ind)
+  <ex>el candidato se conforta con que hizo todo lo posible para obtener el puesto
+  <todo>
+  </type>
   """.
 
-v_pp_e-cp-p-ind-prn_le := v_pp_e-cp-p-ind-prn_lex.
 
-;  <type val="v_pp_e-cp-p-sub_le">
-;  <description>Verb, PPsel (Sent subj)
-;  <ex>esperó a que llegase
-;  <todo>
-;  </type>
+v_pp_e-cp-p-ind-prn_le := v_pp_e-cp-p-ind-prn_lex
+  """
+  
+  """.
+
+
 v_pp_e-cp-p-sub_native_le := v_pp_e-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-cp-p-sub_le">
+  <description>Verb, PPsel (Sent subj)
+  <ex>esperó a que llegase
+  <todo>
+  </type>
   """.
 
-v_pp_e-cp-p-sub_le := v_pp_e-cp-p-sub_lex.
 
-;  <type val="v_pp_e-cp-p-sub-prn_le">
-;  <description>Verb (pron), PPsel (Sent subj)
-;  <ex>se esfuerza por que todo salga bien
-;  <todo>
-;  </type>
+v_pp_e-cp-p-sub_le := v_pp_e-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_pp_e-cp-p-sub-prn_native_le := v_pp_e-cp-p-sub-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-cp-p-sub-prn_le">
+  <description>Verb (pron), PPsel (Sent subj)
+  <ex>se esfuerza por que todo salga bien
+  <todo>
+  </type>
   """.
 
-v_pp_e-cp-p-sub-prn_le := v_pp_e-cp-p-sub-prn_lex.
 
-;  <type val="v_pp*_e-cp-p-sub-prn_le">
-;  <description>Verb (pron), PPsel (opt, Sent subj)
-;  <ex>se contenta con que vengas.
-;  <todo>
-;  </type>
-v_pp*_e-cp-p-sub-prn_le := v_pp*_e-cp-p-sub-prn_lex.
+v_pp_e-cp-p-sub-prn_le := v_pp_e-cp-p-sub-prn_lex
+  """
+  
+  """.
 
-;  <type val="v_pp_e*-cp-p-sub-prn_le">
-;  <description>Verb (pron), PPsel (Sent subj), opt prep
-;  <ex>
-;  <todo>
-;  </type>
+
+v_pp*_e-cp-p-sub-prn_le := v_pp*_e-cp-p-sub-prn_lex
+  """
+  <type val="v_pp*_e-cp-p-sub-prn_le">
+  <description>Verb (pron), PPsel (opt, Sent subj)
+  <ex>se contenta con que vengas.
+  <todo>
+  </type>
+  """.
+
+
 v_pp_e*-cp-p-sub-prn_native_le := v_pp_e*-cp-p-sub-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e*-cp-p-sub-prn_le">
+  <description>Verb (pron), PPsel (Sent subj), opt prep
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_pp_e*-cp-p-sub-prn_le := v_pp_e*-cp-p-sub-prn_lex.
 
-;  <type val="v_pp_e-cp-q_le">
-;  <description>Verb, PPsel (Ques)
-;  <ex>depende de cómo lo hagas  
-;  <todo>
-;  </type>
+v_pp_e*-cp-p-sub-prn_le := v_pp_e*-cp-p-sub-prn_lex
+  """
+  
+  """.
+
+
 v_pp_e-cp-q_native_le := v_pp_e-cp-q_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-cp-q_le">
+  <description>Verb, PPsel (Ques)
+  <ex>depende de cómo lo hagas
+  <todo>
+  </type>
   """.
 
-v_pp_e-cp-q_le := v_pp_e-cp-q_lex.
 
-;  <type val="v_pp_e-cp-q-prn_le">
-;  <description>Verb (pron), PPsel (Ques)
-;  <ex>se interesa por cómo lo hacen
-;  <todo>
-;  </type>
+v_pp_e-cp-q_le := v_pp_e-cp-q_lex
+  """
+  
+  """.
+
+
 v_pp_e-cp-q-prn_native_le := v_pp_e-cp-q-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-cp-q-prn_le">
+  <description>Verb (pron), PPsel (Ques)
+  <ex>se interesa por cómo lo hacen
+  <todo>
+  </type>
   """.
 
-v_pp_e-cp-q-prn_le := v_pp_e-cp-q-prn_lex.
 
-;  <type val="v_ppa_le">
-;  <description>Verb, PPa
-;  <ex>le consume la duda.
-;  <todo>
-;  </type>
+v_pp_e-cp-q-prn_le := v_pp_e-cp-q-prn_lex
+  """
+  
+  """.
+
+
 v_ppa_native_le := v_ppa_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa_le">
+  <description>Verb, PPa
+  <ex>le consume la duda.
+  <todo>
+  </type>
   """.
 
-v_ppa_le := v_ppa_lex.
 
-;  <type val="v_ppa*_le">
-;  <description>Verb, PPa (opt)
-;  <ex>(me) gustan (las acelgas).
-;  <todo>
-;  </type>
+v_ppa_le := v_ppa_lex
+  """
+  
+  """.
+
+
 v_ppa*_native_le := v_ppa*_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*_le">
+  <description>Verb, PPa (opt)
+  <ex>(me) gustan (las acelgas).
+  <todo>
+  </type>
   """.
 
-v_ppa*_le := v_ppa*_lex.
 
-;  <type val="v_ppa_prn_le">
-;  <description>Verb (pron), PPa
-;  <ex>se le acercó.
-;  <todo>
-;  </type>
+v_ppa*_le := v_ppa*_lex
+  """
+  
+  """.
+
+
 v_ppa_prn_native_le := v_ppa_prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa_prn_le">
+  <description>Verb (pron), PPa
+  <ex>se le acercó.
+  <todo>
+  </type>
   """.
 
-v_ppa_prn_le := v_ppa_prn_lex.
 
-;  <type val="v_ppa*_prn_le">
-;  <description>Verb (pron), PPa (opt)
-;  <ex>se le indigestó la comida.
-;  <todo>
-;  </type>
+v_ppa_prn_le := v_ppa_prn_lex
+  """
+  
+  """.
+
+
 v_ppa*_prn_native_le := v_ppa*_prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*_prn_le">
+  <description>Verb (pron), PPa (opt)
+  <ex>se le indigestó la comida.
+  <todo>
+  </type>
   """.
 
-v_ppa*_prn_le := v_ppa*_prn_lex.
 
-;  <type val="v_ppa-pp*_e_le">
-;  <description>Verb, PPa and PPsel (opt)
-;  <ex>le sucedió (en el trono)
-;  <todo>
-;  </type>
+v_ppa*_prn_le := v_ppa*_prn_lex
+  """
+  
+  """.
+
+
 v_ppa-pp*_e_native_le := v_ppa-pp*_e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa-pp*_e_le">
+  <description>Verb, PPa and PPsel (opt)
+  <ex>le sucedió (en el trono)
+  <todo>
+  </type>
   """.
 
-v_ppa-pp*_e_le := v_ppa-pp*_e_lex.
 
-;  <type val="v_ppa*-pp_e_le">
-;  <description>Verb, PPa (opt) and PPsel
-;  <ex>(le) preguntó por tí
-;  <todo>
-;  </type>
+v_ppa-pp*_e_le := v_ppa-pp*_e_lex
+  """
+  
+  """.
+
+
 v_ppa*-pp_e_native_le := v_ppa*-pp_e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-pp_e_le">
+  <description>Verb, PPa (opt) and PPsel
+  <ex>(le) preguntó por tí
+  <todo>
+  </type>
   """.
 
-v_ppa*-pp_e_le := v_ppa*-pp_e_lex.
 
-;  <type val="v_ppa*-pp*_e_le">
-;  <description>Verb, PPa (opt) and PPsel (opt)
-;  <ex>(le) hablé (de tí)
-;  <todo>
-;  </type>
+v_ppa*-pp_e_le := v_ppa*-pp_e_lex
+  """
+  
+  """.
+
+
 v_ppa*-pp*_e_native_le := v_ppa*-pp*_e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-pp*_e_le">
+  <description>Verb, PPa (opt) and PPsel (opt)
+  <ex>(le) hablé (de tí)
+  <todo>
+  </type>
   """.
 
-v_ppa*-pp*_e_le := v_ppa*-pp*_e_lex.
 
-;  <type val="v_ppa-pp_e-idm_le">
-;  <description>Verb, PPa and PPsel (idiom)
-;  <ex>le echaba en falta
-;  <todo>
-;  </type>
+v_ppa*-pp*_e_le := v_ppa*-pp*_e_lex
+  """
+  
+  """.
+
+
 v_ppa-pp_e-idm_native_le := v_ppa-pp_e-idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa-pp_e-idm_le">
+  <description>Verb, PPa and PPsel (idiom)
+  <ex>le echaba en falta
+  <todo>
+  </type>
   """.
 
-v_ppa-pp_e-idm_le := v_ppa-pp_e-idm_lex.
 
-;  <type val="v_pp-pp_e-e-prn-idm_le">
-;  <description>Verb, PPsel and PPsel (idiom)
-;  <ex>ponerse en contacto con
-;  <todo>
-;  </type>
+v_ppa-pp_e-idm_le := v_ppa-pp_e-idm_lex
+  """
+  
+  """.
+
+
 v_pp-pp_e-e-prn-idm_native_le := v_pp-pp_e-e-prn-idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp-pp_e-e-prn-idm_le">
+  <description>Verb, PPsel and PPsel (idiom)
+  <ex>ponerse en contacto con
+  <todo>
+  </type>
   """.
 
-v_pp-pp_e-e-prn-idm_le := v_pp-pp_e-e-prn-idm_lex.
 
-;  <type val="v_vp_inf-ssr_le">
-;  <description>Verb, VPinf (subj-subj-raising)
-;  <ex>deberían hacerlo
-;  <todo>
-;  </type>
+v_pp-pp_e-e-prn-idm_le := v_pp-pp_e-e-prn-idm_lex
+  """
+  
+  """.
+
+
 v_vp_inf-ssr_native_le := v_vp_inf-ssr_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_inf-ssr_le">
+  <description>Verb, VPinf (subj-subj-raising)
+  <ex>deberían hacerlo
+  <todo>
+  </type>
   """.
+
 
 v_vp_inf-ssr_le := v_vp_inf-ssr_lex.
 

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -9755,129 +9755,187 @@ norm_coordconj_synsem := basic_coordconj_synsem &
                    LBL #ltop,
                    C-ARG #index ] ].
 
-; norel_coordconj contributes no relation, used in "omnisyndeton" coord.
-norel_coordconj_synsem := basic_coordconj_synsem & 
+
+norel_coordconj_synsem := basic_coordconj_synsem &
   [ LOCAL [ COORD-STRAT two,
             CAT.HEAD.KEYS.KEY #key,
             CONT.RELS <! !> ],
-    LKEYS.KEYREL.PRED #key ].
+    LKEYS.KEYREL.PRED #key ]
+  """
+  norel_coordconj contributes no relation, used in "omnisyndeton" coord.
+  """.
 
 
-; -- punctuations as conjunctions
 c_xp_comma_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT one,
-             LKEYS.KEYREL.PRED _comma_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT one,
+                                     LKEYS.KEYREL.PRED _comma_c_rel ] ]
+  """
+  -- punctuations as conjunctions
+  """.
+
 
 c_xp_fstop_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT one,
-             LKEYS.KEYREL.PRED _full-stop_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT one,
+                                     LKEYS.KEYREL.PRED _full-stop_c_rel ] ]
+  """
+  
+  """.
+
 
 c_xp_semi-cln_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT one,
-             LKEYS.KEYREL.PRED _semi-cln_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT one,
+                                     LKEYS.KEYREL.PRED _semi-cln_c_rel ] ]
+  """
+  
+  """.
 
-; - multiple copulative coordination: 'y' (and) (e.g. Juan y Pedro lloran).
+
 c_xp_y_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT one,
-             LKEYS.KEYREL.PRED _y_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT one,
+                                     LKEYS.KEYREL.PRED _y_c_rel ] ]
+  """
+  - multiple copulative coordination: 'y' (and) (e.g. Juan y Pedro lloran).
+  """.
+
 
 c_xp_e_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT one,
-             LKEYS.KEYREL.PRED _y_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT one,
+                                     LKEYS.KEYREL.PRED _y_c_rel ] ]
+  """
+  
+  """.
 
-; - multiple disjunctive coordination: 'o' (or) (Juan o Pedro lloran).
+
 c_xp_o_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LKEYS.KEYREL.PRED _o_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LKEYS.KEYREL.PRED _o_c_rel ] ]
+  """
+  - multiple disjunctive coordination: 'o' (or) (Juan o Pedro lloran).
+  """.
+
 
 c_xp_u_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LKEYS.KEYREL.PRED _o_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LKEYS.KEYREL.PRED _o_c_rel ] ]
+  """
+  
+  """.
 
-; - exclusive disjunction: 'o...o' (either) (e.g. o Juan o Marta traerán el regalo) 
-; Not with imperatives, interrogatives and exclamatives
+
 c_xp_o-nrel_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _o_c_rel >,
-             LKEYS.KEYREL.PRED _o_c_rel ] ].
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _o_c_rel >,
+                                      LKEYS.KEYREL.PRED _o_c_rel ] ]
+  """
+  - exclusive disjunction: 'o...o' (either) (e.g. o Juan o Marta traerán el regalo)
+  Not with imperatives, interrogatives and exclamatives
+  """.
+
 
 c_xp_u-nrel_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _o_c_rel >,
-             LKEYS.KEYREL.PRED _o_c_rel ] ].
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _o_c_rel >,
+                                      LKEYS.KEYREL.PRED _o_c_rel ] ]
+  """
+  
+  """.
 
-; - '(ni)...ni' (neither) (e.g. no traje el libro ni para Juan ni para Pedro)
-; Can't co-occur within a prepositional complement (*traje el libro para Juan ni Pedro, 
-; *no traje el libro para Juan ni Pedro, *no traje el libro para ni Juan ni Pedro)
-; La posibilidad de omitir el primer 'ni' depende de la posición del sintagma: en 
-; posición pre-verbal no es posible, en posición post-verbal sí.
+
 c_xp_ni_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LKEYS.KEYREL.PRED _ni_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LKEYS.KEYREL.PRED _ni_c_rel ] ]
+  """
+  - '(ni)...ni' (neither) (e.g. no traje el libro ni para Juan ni para Pedro)
+  Can't co-occur within a prepositional complement (*traje el libro para Juan ni Pedro,
+  *no traje el libro para Juan ni Pedro, *no traje el libro para ni Juan ni Pedro)
+  La posibilidad de omitir el primer 'ni' depende de la posición del sintagma: en
+  posición pre-verbal no es posible, en posición post-verbal sí.
+  """.
+
 
 c_xp_ni-nrel_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _ni_c_rel >,
-             LKEYS.KEYREL.PRED _ni_c_rel ] ].
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _ni_c_rel >,
+                                      LKEYS.KEYREL.PRED _ni_c_rel ] ]
+  """
+  
+  """.
 
-; - 'sea...(o) sea' (be it) (e.g. lo compraremos de todos modos, sea grande (o) sea pequeño)
-; Can't co-occur in argumental complements (*el monstruo era sea grande (o) sea pequeño).
+
 c_xp_sea_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT two,
-             LKEYS.KEYREL.PRED _sea_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT two,
+                                     LKEYS.KEYREL.PRED _sea_c_rel ] ]
+  """
+  - 'sea...(o) sea' (be it) (e.g. lo compraremos de todos modos, sea grande (o) sea pequeño)
+  Can't co-occur in argumental complements (*el monstruo era sea grande (o) sea pequeño).
+  """.
+
 
 c_xp_sea-nrel_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _sea_c_rel >,
-             LKEYS.KEYREL.PRED _sea_c_rel ] ]. 
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _sea_c_rel >,
+                                      LKEYS.KEYREL.PRED _sea_c_rel ] ]
+  """
+  
+  """.
+
 
 c_xp_o-sea-nrel_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _sea_c_rel >,
-             LKEYS.KEYREL.PRED _o_sea_c_rel ] ].
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _sea_c_rel >,
+                                      LKEYS.KEYREL.PRED _o_sea_c_rel ] ]
+  """
+  
+  """.
 
-; - '(o) bien...(o) bien' (either) e.g. recoge el correo (o) bien en la tarde (o) bien en la mañana
+
 c_xp_bien_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT two,
-             LKEYS.KEYREL.PRED _bien_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT two,
+                                     LKEYS.KEYREL.PRED _bien_c_rel ] ]
+  """
+  - '(o) bien...(o) bien' (either) e.g. recoge el correo (o) bien en la tarde (o) bien en la mañana
+  """.
+
 
 c_xp_bien-nrel_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _bien_c_rel >,
-             LKEYS.KEYREL.PRED _bien_c_rel ] ].
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _bien_c_rel >,
+                                      LKEYS.KEYREL.PRED _bien_c_rel ] ]
+  """
+  
+  """.
+
 
 c_xp_o-bien_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT two,
-             LKEYS.KEYREL.PRED _o_bien_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT two,
+                                     LKEYS.KEYREL.PRED _o_bien_c_rel ] ]
+  """
+  
+  """.
+
 
 c_xp_o-bien-nrel_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _bien_c_rel >,
-             LKEYS.KEYREL.PRED _o_bien_c_rel ] ].
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _bien_c_rel >,
+                                      LKEYS.KEYREL.PRED _o_bien_c_rel ] ]
+  """
+  
+  """.
+
 
 c_xp_o-bien-nrel-o-bien_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _o_bien_c_rel >,
-             LKEYS.KEYREL.PRED _o_bien_c_rel ] ].
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _o_bien_c_rel >,
+                                      LKEYS.KEYREL.PRED _o_bien_c_rel ] ]
+  """
+  
+  """.
 
-; - 'ora...ora' (e.g. tomando ora la espada, ora la pluma)
+
 c_xp_ora_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT two,
-             LKEYS.KEYREL.PRED _ora_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT two,
+                                     LKEYS.KEYREL.PRED _ora_c_rel ] ]
+  """
+  - 'ora...ora' (e.g. tomando ora la espada, ora la pluma)
+  """.
+
 
 c_xp_ora-nrel_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _ora_c_rel >,
-             LKEYS.KEYREL.PRED _ora_c_rel ] ]. 
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _ora_c_rel >,
+                                      LKEYS.KEYREL.PRED _ora_c_rel ] ]
+  """
+  
+  """.
+
 
 ; - 'siquiera' (e.g. siquiera venga, siquiera no venga')
 ;c_xp_siquiera_lex := basic-coordconj-lex & basic-one-arg &

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -8416,83 +8416,108 @@ pp_-_i-vm_lex := mod-pp-lex & norm-sem-lex-item &
   e.g. tengo que ser honesta conmigo
   """.
 
-
 ; --- Adjectival modifying prepositions (degree)
 
-; - taking NP (a, hasta)
-; e.g. (*muy) irritante al máximo, (*muy) fiel hasta la muerte
-p_np_i-am_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_amod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.VAL.SPR < >,
-                                             CONT.HOOK.INDEX #arg2 & [ SORT non-loc ] ] ] >,
-             LKEYS.KEYREL.ARG2 #arg2 ] ]. 
+p_np_i-am_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_amod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.VAL.SPR < >,
+                                                             CONT.HOOK.INDEX #arg2 & [ SORT non-loc ] ] ] >,
+                             LKEYS.KEYREL.ARG2 #arg2 ] ]
+  """
+  --- Adjectival modifying prepositions (degree)
+  - taking NP (a, hasta)
+  e.g. (*muy) irritante al máximo, (*muy) fiel hasta la muerte
+  """.
 
-; - taking temporal NP (desde)
-; e.g. la más alta desde 1945
-p_np_i-tmp-am_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_amod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.VAL.SPR < >,
-                                             CONT.HOOK.INDEX.SORT tmp ] ] >,
-             LKEYS.KEYREL.PRED temp_loc_rel ] ]. 
 
-; - taking Nbar
-p_nb_i-am_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_amod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_free_relative_nom_rel,
-                                                               ALTKEY explicit_q_rel ], 
-                                                   VAL.SPR < [ LOCAL.CONT.RELS <! relation !>,
-                                                               NON-LOCAL [ SLASH 0-dlist,
-                                                                           QUE 0-dlist,
-                                                                           REL 0-dlist ] ] > ],
-                                             CONT.HOOK.INDEX #arg2 & [ SORT non-temp ] ] ] >,
-             LKEYS.KEYREL.ARG2 #arg2 ] ]. 
+p_np_i-tmp-am_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_amod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.VAL.SPR < >,
+                                                             CONT.HOOK.INDEX.SORT tmp ] ] >,
+                             LKEYS.KEYREL.PRED temp_loc_rel ] ]
+  """
+  --- Adjectival modifying prepositions (degree)
+  - taking temporal NP (desde)
+  e.g. la más alta desde 1945
+  """.
 
-; - taking NEs
-p_np_i-pn-am_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_amod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS.KEY named_rel,
-                                                   VAL.SPR < > ],
-                                             CONT.HOOK.INDEX #arg2 & [ PRONTYPE not_pron ] ] ] >,
-             LKEYS.KEYREL.ARG2 #arg2 ] ]. 
 
-; - Taking VPinf (a, hasta)
-; e.g. !!! (*muy) llenas a/hasta reventar de vino/lleno de vino a reventar.
-p_vp_i-ctrl-am_lex := mod-adp-lex & p_cp_prop_inf_slash & 
-  [ SYNSEM p_amod_synsem &
-           [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CONT.HOOK.XARG #ctrl ] >,
-                         VAL.COMPS < [ LOCAL [ CAT.HEAD.KEYS.ALTKEY prop,
-                                               CONT.HOOK.XARG #ctrl & ref-ind ],
-                                       NON-LOCAL.SLASH 0-dlist ] > ] ] ].
+p_nb_i-am_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_amod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_free_relative_nom_rel,
+                                                                               ALTKEY explicit_q_rel ],
+                                                                   VAL.SPR < [ LOCAL.CONT.RELS <! relation !>,
+                                                                               NON-LOCAL [ SLASH 0-dlist,
+                                                                                           QUE 0-dlist,
+                                                                                           REL 0-dlist ] ] > ],
+                                                             CONT.HOOK.INDEX #arg2 & [ SORT non-temp ] ] ] >,
+                             LKEYS.KEYREL.ARG2 #arg2 ] ]
+  """
+  --- Adjectival modifying prepositions (degree)
+  - taking Nbar
+  """.
+
+
+p_np_i-pn-am_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_amod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS.KEY named_rel,
+                                                                   VAL.SPR < > ],
+                                                             CONT.HOOK.INDEX #arg2 & [ PRONTYPE not_pron ] ] ] >,
+                             LKEYS.KEYREL.ARG2 #arg2 ] ]
+  """
+  --- Adjectival modifying prepositions (degree)
+  - taking NEs
+  """.
+
+
+p_vp_i-ctrl-am_lex := mod-adp-lex & p_cp_prop_inf_slash &
+  [ SYNSEM p_amod_synsem & [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CONT.HOOK.XARG #ctrl ] >,
+                                         VAL.COMPS < [ LOCAL [ CAT.HEAD.KEYS.ALTKEY prop,
+                                                               CONT.HOOK.XARG #ctrl & ref-ind ],
+                                                       NON-LOCAL.SLASH 0-dlist ] > ] ] ]
+  """
+  --- Adjectival modifying prepositions (degree)
+  - Taking VPinf (a, hasta)
+  e.g. !!! (*muy) llenas a/hasta reventar de vino/lleno de vino a reventar.
+  """.
+
 
 
 ; --- Ordinal modifying prepositions (degree)
 
-; - taking NP (con)
-; e.g. Rusia, primera con tres puntos,...
 p_np_i-num_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
   [ SYNSEM p_numod_synsem &
            [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.VAL.SPR < >,
                                              CONT.HOOK.INDEX #arg2 & [ SORT non-loc ] ] ] >,
-             LKEYS.KEYREL.ARG2 #arg2 ] ]. 
+             LKEYS.KEYREL.ARG2 #arg2 ] ]
+"""
+; --- Ordinal modifying prepositions (degree)
+
+; - taking NP (con)
+; e.g. Rusia, primera con tres puntos,...
+""". 
 
 
 ; --- Prepositional modifying prepositions (PPmod + PPhd)
 
-; - the first expresses distance, the second includes a locative preposition (a, al)
-; e.g. a 20 metros sobre el nivel del mar, a mitad de camino entre Madrid y Cáceres
 p_np_i-pm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
   [ SYNSEM p_pmod_synsem &
            [ LOCAL.CAT [ HEAD.MOD < [ LOCAL [ CAT.HEAD.KEYS.KEY state_loc_rel,
                                               CONT.HOOK.INDEX.SORT location ] ] >,
-                         VAL.COMPS < [ LOCAL.CAT.VAL.SPR < > ] > ] ] ].
+                         VAL.COMPS < [ LOCAL.CAT.VAL.SPR < > ] > ] ] ]
+"""
+; --- Prepositional modifying prepositions (PPmod + PPhd)
+; - the first expresses distance, the second includes a locative preposition (a, al)
+; e.g. a 20 metros sobre el nivel del mar, a mitad de camino entre Madrid y Cáceres
 
-; - they express a distance / period of time (de, desde) 
-; e.g. corrió de un extremo al otro, voy de aquí para allá, duró desde las 4 hasta las 6
+""".
+
 p_np_i-orig-pm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
   [ SYNSEM p_pmod_synsem &
            [ LOCAL.CAT [ HEAD.MOD < [ LOCAL [ CAT.HEAD.KEYS.KEY period_rel,
                                               CONT.HOOK.INDEX.SORT #sort ] ] >,
-                         VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SORT #sort & location ] > ] ] ].
+                         VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SORT #sort & location ] > ] ] ]
+"""
+; --- Prepositional modifying prepositions (PPmod + PPhd)
+; - they express a distance / period of time (de, desde) 
+; e.g. corrió de un extremo al otro, voy de aquí para allá, duró desde las 4 hasta las 6
+""".
 
 
 
@@ -8517,7 +8542,13 @@ basic-det-lex := lex-item &
                      COORD-STRAT zero,
                      CAT [ HEAD det & [ KEYS.KEY quant_rel ],
                            VAL.COMPS #comps ] ] ],
-    ARG-ST #comps ].
+    ARG-ST #comps ]
+"""
+; --- 6. Determiners
+; !!! LOCAL.AGR checks full morpho-syntactic agreement within the NP, 
+; whereas CONT.HOOK.INDEX does not check 'NUMBER', with this we can deal 
+; with 'ad-sensum' agr. 
+""".
 
 basic_det_synsem := lex-synsem & 
   [ LOCAL [ COORD-STRAT zero,
@@ -8541,7 +8572,13 @@ basic_det_synsem := lex-synsem &
     LKEYS.KEYREL #keyrel & [ LBL #ltop,
                              ARG0 #index,
                              PRED #pred,
-                             RSTR #harg ] ].
+                             RSTR #harg ] ]
+"""
+; --- 6. Determiners
+; !!! LOCAL.AGR checks full morpho-syntactic agreement within the NP, 
+; whereas CONT.HOOK.INDEX does not check 'NUMBER', with this we can deal 
+; with 'ad-sensum' agr. 
+""".
 
 ; dets taking spr and building a DP
 specfd_det_synsem := basic_det_synsem &

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -8123,222 +8123,299 @@ p_vp_ptcl_lex := mark-adp-lex & p_cp_prop_or_ques_inf &
 
 
 ; - comparatives
-; e.g. tan distantes como antes
 p_rg_ptcl_lex := mark-adp-lex & p_adv & 
   [ SYNSEM basic_mark-adp_synsem & 
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY adv_rel ] > ] ].
+           [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY adv_rel ] > ] ]
+"""
+; - comparatives
+; e.g. tan distantes como antes
+""".
 
-; e.g. igual que en una película, contará con más funciones que en la anterior
 p_pp_ptcl_lex := mark-adp-lex & p_pp & 
   [ SYNSEM basic_mark-adp_synsem & 
            [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT [ MC na,
-                                                 HEAD.MOD < [ LOCAL.CAT.HEAD noun ] > ] ]> ] ].  
+                                                 HEAD.MOD < [ LOCAL.CAT.HEAD noun ] > ] ]> ] ]
+"""
+; - comparatives
+; e.g. igual que en una película, contará con más funciones que en la anterior
+""".  
 
-; e.g. tan maravillada como rutinatia
 p_ap_ptcl_lex := mark-adp-lex & p_ap & 
   [ SYNSEM basic_mark-adp_synsem & 
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.MC na ] > ] ].
+           [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.MC na ] > ] ]
+"""
+; - comparatives
+; e.g. tan maravillada como rutinatia
+""".
+
+; --- Nominal modifying prepositions
+
+p_np_i-nm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_nmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_free_relative_nom_rel,
+                                                                               ALTKEY explicit_q_rel ],
+                                                                   VAL.SPR < > ],
+                                                             CONT.HOOK.INDEX #arg2 & [ SORT non-temp ] ] ] >,
+                             LKEYS.KEYREL.ARG2 #arg2 ] ]
+  """
+  --- Nominal modifying prepositions
+  - taking NPs
+  """.
 
 
-
-; --- Nominal modifying prepositions   
-
-; - taking NPs
-p_np_i-nm_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_nmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_free_relative_nom_rel,
-                                                               ALTKEY explicit_q_rel ], 
-                                                   VAL.SPR < > ],
-                                             CONT.HOOK.INDEX #arg2 & [ SORT non-temp ] ] ] >,
-             LKEYS.KEYREL.ARG2 #arg2 ] ]. 
-
-; - taking Nbar
-p_nb_i-nm_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_nmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_free_relative_nom_rel,
-                                                               ALTKEY explicit_q_rel ], 
-                                                   VAL.SPR < [ LOCAL.CONT.RELS <! relation !>,
-                                                               NON-LOCAL [ SLASH 0-dlist,
-                                                                           QUE 0-dlist,
-                                                                           REL 0-dlist ] ] > ],
-                                             CONT.HOOK.INDEX #arg2 ] ] >,
-             LKEYS.KEYREL.ARG2 #arg2 ] ]. 
-
-; - taking NEs
-p_np_i-pn-nm_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_nmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS.KEY named_rel,
-                                                   VAL.SPR < > ],
-                                             CONT.HOOK.INDEX #arg2 & [ PRONTYPE not_pron ] ] ] >,
-             LKEYS.KEYREL.ARG2 #arg2 ] ]. 
-
-; - taking temporal NPs (de, hasta, para)
-; e.g. el concierto del otro día/de ayer, tengo entradas para el jueves/mañana
-p_np_i-tmp-nm_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_nmod_synsem &
-           [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CAT.HEAD.KEYS.KEY non_modable_rel ] >, 
-                         VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_free_relative_nom_rel,
-                                                                 ALTKEY explicit_q_rel ],
-                                                     VAL.SPR < > ],
-                                               CONT.HOOK.INDEX #arg2 & [ SORT tmp ] ] ] > ],
-             LKEYS.KEYREL.ARG2 #arg2 ] ].  
+p_nb_i-nm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_nmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_free_relative_nom_rel,
+                                                                               ALTKEY explicit_q_rel ],
+                                                                   VAL.SPR < [ LOCAL.CONT.RELS <! relation !>,
+                                                                               NON-LOCAL [ SLASH 0-dlist,
+                                                                                           QUE 0-dlist,
+                                                                                           REL 0-dlist ] ] > ],
+                                                             CONT.HOOK.INDEX #arg2 ] ] >,
+                             LKEYS.KEYREL.ARG2 #arg2 ] ]
+  """
+  --- Nominal modifying prepositions
+  - taking Nbar
+  """.
 
 
-; - taking verbal complements (por, sin)
-; e.g. pan por cocer
-p_vp_i-ctrl-nm_lex := mod-adp-lex & p_cp_prop_inf_slash & 
-  [ SYNSEM p_nmod_synsem &
-           [ LOCAL [ CAT [ HEAD.MOD #mod & < [ LOCAL.CAT.HEAD.KEYS.KEY non_modable_rel ] >,
-                           VAL.COMPS < [ NON-LOCAL.SLASH <! np_acc_local &
-                                                            [ CAT.HEAD.MOD #mod,
-                                                              CONT.HOOK.INDEX #ctrl ] !> ] > ],
-                     CONT.HOOK.XARG #ctrl & ref-ind ] ] ].
-
-; e.g. satisfacción por estar aquí
-p_vp_i-nm_lex := mod-adp-lex & p_cp_prop_inf_slash & 
-  [ SYNSEM p_nmod_synsem &
-           [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CAT.HEAD.KEYS.KEY non_modable_rel ] >,
-                         VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.ALTKEY prop,
-                                       NON-LOCAL.SLASH 0-dlist ] > ] ] ].
-
-; Taking ADV
-; e.g. tengo las ganas de siempre
-p_adv_i-nm_lex := mod-adp-lex & p_adv & norm-sem-lex-item & 
-  [ SYNSEM p_nmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY adv_rel ] > ] ].
-
-; - taking PPs (de (orig) + PP (loc))
-; e.g. el libro de sobre la mesa
-p_pp_i-nm_lex := mod-adp-lex & p_pp & norm-sem-lex-item & 
-  [ SYNSEM p_nmod_synsem &
-           [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CAT [ HEAD noun & [ KEYS.KEY non_modable_rel ],
-                                                  VAL.COMPS < > ] ] >,
-                         VAL.COMPS < [ LOCAL [ CAT.HEAD.MOD < [ LOCAL.CAT.HEAD noun ] >,
-                                               CONT.HOOK.INDEX #arg2 ] ] > ],
-             LKEYS.KEYREL.ARG2 #arg2 ] ]. 
-
-; non-temporal lexical PPs 
-; e.g. seis horas más, un nombré así.
-pp_-_i-nm_lex := mod-pp-lex & norm-sem-lex-item & 
-  [ SYNSEM pp_nmod_synsem ]. 
-
-; temporal lexical PPs: antes, después
-; e.g. Los agentes sospechan de la mujer rescatada bajo un sofá nueve horas después.
-pp_-_i-nm-tmp_lex := mod-pp-lex & norm-sem-lex-item & 
-  [ SYNSEM pp_nmod_synsem &
-           [ LOCAL.CAT.HEAD.MOD < [ LOCAL.CONT.HOOK.INDEX.SORT tmp ] > ] ]. 
-
-; - taking APs (de, por)
-; e.g. presume de valiente, lo acusó de traidor, ¿me tomas por tonto?
-p_ap_i-nm_lex := mod-adp-lex & p_ap & norm-sem-lex-item & 
-  [ SYNSEM p_nmod_synsem &
-         [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #arg2 ] >,
-           LKEYS.KEYREL.ARG2 #arg2 ] ].
+p_np_i-pn-nm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_nmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS.KEY named_rel,
+                                                                   VAL.SPR < > ],
+                                                             CONT.HOOK.INDEX #arg2 & [ PRONTYPE not_pron ] ] ] >,
+                             LKEYS.KEYREL.ARG2 #arg2 ] ]
+  """
+  --- Nominal modifying prepositions
+  - taking NEs
+  """.
 
 
-; --- Verbal modifying prepositions 
+p_np_i-tmp-nm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_nmod_synsem & [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CAT.HEAD.KEYS.KEY non_modable_rel ] >,
+                                         VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_free_relative_nom_rel,
+                                                                                 ALTKEY explicit_q_rel ],
+                                                                     VAL.SPR < > ],
+                                                               CONT.HOOK.INDEX #arg2 & [ SORT tmp ] ] ] > ],
+                             LKEYS.KEYREL.ARG2 #arg2 ] ]
+  """
+  --- Nominal modifying prepositions
+  - taking temporal NPs (de, hasta, para)
+  e.g. el concierto del otro día/de ayer, tengo entradas para el jueves/mañana
+  """.
 
-; - taking Nbar
-p_nb_i-vm_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_vmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY common_nom_rel,
-                                                               ALTKEY explicit_q_rel ], 
-                                                   VAL.SPR < [ LOCAL.CONT.RELS <! relation !>,
-                                                               NON-LOCAL [ QUE 0-dlist,
-                                                                           REL 0-dlist ] ] > ],
-                                             CONT.HOOK.INDEX.SORT non-temp ] ] >,
-             LKEYS.KEYREL.PRED prep_mod_rel ] ].  
 
-; - taking NPs
-p_np_i-vm_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_vmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_named_non_modable_rel,
-                                                               ALTKEY explicit_q_rel ], 
-                                                   VAL.SPR < > ],
-                                             CONT.HOOK.INDEX.SORT non-temp ] ] >,
-             LKEYS.KEYREL.PRED prep_mod_rel ] ]. 
+p_vp_i-ctrl-nm_lex := mod-adp-lex & p_cp_prop_inf_slash &
+  [ SYNSEM p_nmod_synsem & [ LOCAL [ CAT [ HEAD.MOD #mod & < [ LOCAL.CAT.HEAD.KEYS.KEY non_modable_rel ] >,
+                                           VAL.COMPS < [ NON-LOCAL.SLASH <! np_acc_local & [ CAT.HEAD.MOD #mod,
+                                                                                             CONT.HOOK.INDEX #ctrl ] !> ] > ],
+                                     CONT.HOOK.XARG #ctrl & ref-ind ] ] ]
+  """
+  --- Nominal modifying prepositions
+  - taking verbal complements (por, sin)
+  e.g. pan por cocer
+  """.
 
-; - taking NEs
-p_np_i-pn-vm_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_vmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS.KEY named_rel, 
-                                                   VAL.SPR < > ],
-                                             CONT.HOOK.INDEX.PRONTYPE not_pron ],
-                                     NON-LOCAL.QUE 0-dlist ] >,
-             LKEYS.KEYREL.PRED prep_mod_rel ] ].  
 
-; - taking temporal NPs (a, desde, en, entre, hace, hacia, hasta, para, por, sobre, tras)
-; e.g. te espero a las cinco; no he vuelto desde el mes pasado/ayer; nací en 1967; 
-; quedamos entre las 9 y las 10 de la mañana; vino hace un mes; ¿quedamos hacia las dos? 
-; se despidió hasta la noche/mañana; lo dejaremos para el jueves; trabajaremos por la mañana;
-; lo dejaremos para la noche/mañana; el tren llegará sobre las diez
-p_np_i-tmp-vm_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_vmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.VAL.SPR < >,
-                                             CONT.HOOK.INDEX.SORT tmp ] ] >,
-             LKEYS.KEYREL.PRED temp_loc_rel ] ].
+p_vp_i-nm_lex := mod-adp-lex & p_cp_prop_inf_slash &
+  [ SYNSEM p_nmod_synsem & [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CAT.HEAD.KEYS.KEY non_modable_rel ] >,
+                                         VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.ALTKEY prop,
+                                                       NON-LOCAL.SLASH 0-dlist ] > ] ] ]
+  """
+  --- Nominal modifying prepositions
+  e.g. satisfacción por estar aquí
+  """.
 
-; durante
-p_np_i-tmp-durante-vm_lex := mod-adp-lex & p_np & norm-sem-lex-item & 
-  [ SYNSEM p_vmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.VAL.SPR < > ] >,
-             LKEYS.KEYREL.PRED temp_loc_rel ] ].
 
-; -- ditransitive preposition "a" in "a... de..." expressing distance
-; e.g. Juan vive (a (3km) (de Madrid))/Juan vive a 3km/*Juan vive de Madrid
-p_np-pp_i-vm_lex := mod-adp-lex & p_ditrans & norm-sem-lex-item & 
-  [ SYNSEM p_vmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS.ALTKEY non_free_relative_q_rel,
-                                                   VAL.SPR < > ],
-                                             CONT.HOOK.INDEX.SORT mea ] ], 
-                                   [ LOCAL.CONT.HOOK.INDEX.SORT loc  ] >,
-             LKEYS.KEYREL.PRED state_loc_rel ] ]. 
+p_adv_i-nm_lex := mod-adp-lex & p_adv & norm-sem-lex-item &
+  [ SYNSEM p_nmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY adv_rel ] > ] ]
+  """
+  --- Nominal modifying prepositions
+  Taking ADV
+  e.g. tengo las ganas de siempre
+  """.
 
-; - taking APs (por, de)
-; e.g. lloró por tonto/de impotencia
-p_ap_i-vm_lex := mod-adp-lex & p_ap & norm-sem-lex-item & 
-  [ SYNSEM p_vmod_synsem & 
-          [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CONT.HOOK.XARG #ctrl ] >,
-                         VAL.COMPS < [ LOCAL.CONT.HOOK.XARG #ctrl ] > ],
-             LKEYS.KEYREL.PRED prep_mod_rel ] ].
 
-; Taking ADV
-; e.g. mira hacia atrás
-p_adv_i-vm_lex := mod-adp-lex & p_adv & norm-sem-lex-item & 
-  [ SYNSEM p_vmod_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SORT non-temp ] >,
-             LKEYS.KEYREL.PRED prep_mod_rel ] ].
+p_pp_i-nm_lex := mod-adp-lex & p_pp & norm-sem-lex-item &
+  [ SYNSEM p_nmod_synsem & [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CAT [ HEAD noun & [ KEYS.KEY non_modable_rel ],
+                                                                  VAL.COMPS < > ] ] >,
+                                         VAL.COMPS < [ LOCAL [ CAT.HEAD.MOD < [ LOCAL.CAT.HEAD noun ] >,
+                                                               CONT.HOOK.INDEX #arg2 ] ] > ],
+                             LKEYS.KEYREL.ARG2 #arg2 ] ]
+  """
+  --- Nominal modifying prepositions
+  - taking PPs (de (orig) + PP (loc))
+  e.g. el libro de sobre la mesa
+  """.
 
-; Taking MODNP
-; e.g. Como ahora
-p_modnp_i-vm_lex := mod-adp-lex & p_modnp & norm-sem-lex-item & 
-  [ SYNSEM p_vmod_synsem &
-           [ LKEYS.KEYREL.PRED prep_mod_rel ] ].
 
-; - taking PPs, there are two types:
-; a)- "de" when, with the verb "ser" or with movement verbs, expresses origin, or when it heads a nominal 
-; complement; e.g. es de por ese barrio, salió de tras el matorral, el libro de sobre la mesa
-; b)- "desde" (origin), "hasta" (destination), "por" (path) + locative PP except "en"
-; e.g. se lanzó desde sobre el tejado
-p_pp_i-vm_lex := mod-adp-lex & p_pp & norm-sem-lex-item & 
+pp_-_i-nm_lex := mod-pp-lex & norm-sem-lex-item &
+  [ SYNSEM pp_nmod_synsem ]
+  """
+  --- Nominal modifying prepositions
+  non-temporal lexical PPs
+  e.g. seis horas más, un nombré así.
+  """.
+
+
+pp_-_i-nm-tmp_lex := mod-pp-lex & norm-sem-lex-item &
+  [ SYNSEM pp_nmod_synsem & [ LOCAL.CAT.HEAD.MOD < [ LOCAL.CONT.HOOK.INDEX.SORT tmp ] > ] ]
+  """
+  --- Nominal modifying prepositions
+  temporal lexical PPs: antes, después
+  e.g. Los agentes sospechan de la mujer rescatada bajo un sofá nueve horas después.
+  """.
+
+
+p_ap_i-nm_lex := mod-adp-lex & p_ap & norm-sem-lex-item &
+  [ SYNSEM p_nmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #arg2 ] >,
+                             LKEYS.KEYREL.ARG2 #arg2 ] ]
+  """
+  --- Nominal modifying prepositions
+  - taking APs (de, por)
+  e.g. presume de valiente, lo acusó de traidor, ¿me tomas por tonto?
+  """.
+
+
+; --- Verbal modifying prepositions
+  
+
+p_nb_i-vm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_vmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY common_nom_rel,
+                                                                               ALTKEY explicit_q_rel ],
+                                                                   VAL.SPR < [ LOCAL.CONT.RELS <! relation !>,
+                                                                               NON-LOCAL [ QUE 0-dlist,
+                                                                                           REL 0-dlist ] ] > ],
+                                                             CONT.HOOK.INDEX.SORT non-temp ] ] >,
+                             LKEYS.KEYREL.PRED prep_mod_rel ] ]
+  """
+  --- Verbal modifying prepositions
+  - taking Nbar
+  """.
+
+
+p_np_i-vm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_vmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_named_non_modable_rel,
+                                                                               ALTKEY explicit_q_rel ],
+                                                                   VAL.SPR < > ],
+                                                             CONT.HOOK.INDEX.SORT non-temp ] ] >,
+                             LKEYS.KEYREL.PRED prep_mod_rel ] ]
+  """
+  --- Verbal modifying prepositions
+  - taking NPs
+  """.
+
+
+p_np_i-pn-vm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_vmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS.KEY named_rel,
+                                                                   VAL.SPR < > ],
+                                                             CONT.HOOK.INDEX.PRONTYPE not_pron ],
+                                                     NON-LOCAL.QUE 0-dlist ] >,
+                             LKEYS.KEYREL.PRED prep_mod_rel ] ]
+  """
+  --- Verbal modifying prepositions
+  - taking NEs
+  """.
+
+
+p_np_i-tmp-vm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_vmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.VAL.SPR < >,
+                                                             CONT.HOOK.INDEX.SORT tmp ] ] >,
+                             LKEYS.KEYREL.PRED temp_loc_rel ] ]
+  """
+  --- Verbal modifying prepositions
+  - taking temporal NPs (a, desde, en, entre, hace, hacia, hasta, para, por, sobre, tras)
+  e.g. te espero a las cinco; no he vuelto desde el mes pasado/ayer; nací en 1967;
+  quedamos entre las 9 y las 10 de la mañana; vino hace un mes; ¿quedamos hacia las dos?
+  se despidió hasta la noche/mañana; lo dejaremos para el jueves; trabajaremos por la mañana;
+  lo dejaremos para la noche/mañana; el tren llegará sobre las diez
+  """.
+
+
+p_np_i-tmp-durante-vm_lex := mod-adp-lex & p_np & norm-sem-lex-item &
+  [ SYNSEM p_vmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.VAL.SPR < > ] >,
+                             LKEYS.KEYREL.PRED temp_loc_rel ] ]
+  """
+  --- Verbal modifying prepositions
+  durante
+  """.
+
+
+p_np-pp_i-vm_lex := mod-adp-lex & p_ditrans & norm-sem-lex-item &
+  [ SYNSEM p_vmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT [ HEAD.KEYS.ALTKEY non_free_relative_q_rel,
+                                                                   VAL.SPR < > ],
+                                                             CONT.HOOK.INDEX.SORT mea ] ],
+                                                   [ LOCAL.CONT.HOOK.INDEX.SORT loc ] >,
+                             LKEYS.KEYREL.PRED state_loc_rel ] ]
+  """
+  --- Verbal modifying prepositions
+  -- ditransitive preposition "a" in "a... de..." expressing distance
+  e.g. Juan vive (a (3km) (de Madrid))/Juan vive a 3km/*Juan vive de Madrid
+  """.
+
+
+p_ap_i-vm_lex := mod-adp-lex & p_ap & norm-sem-lex-item &
+  [ SYNSEM p_vmod_synsem & [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CONT.HOOK.XARG #ctrl ] >,
+                                         VAL.COMPS < [ LOCAL.CONT.HOOK.XARG #ctrl ] > ],
+                             LKEYS.KEYREL.PRED prep_mod_rel ] ]
+  """
+  --- Verbal modifying prepositions
+  - taking APs (por, de)
+  e.g. lloró por tonto/de impotencia
+  """.
+
+
+p_adv_i-vm_lex := mod-adp-lex & p_adv & norm-sem-lex-item &
+  [ SYNSEM p_vmod_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SORT non-temp ] >,
+                             LKEYS.KEYREL.PRED prep_mod_rel ] ]
+  """
+  --- Verbal modifying prepositions
+  Taking ADV
+  e.g. mira hacia atrás
+  """.
+
+
+p_modnp_i-vm_lex := mod-adp-lex & p_modnp & norm-sem-lex-item &
+  [ SYNSEM p_vmod_synsem & [ LKEYS.KEYREL.PRED prep_mod_rel ] ]
+  """
+  --- Verbal modifying prepositions
+  Taking MODNP
+  e.g. Como ahora
+  """.
+
+
+p_pp_i-vm_lex := mod-adp-lex & p_pp & norm-sem-lex-item &
   [ SYNSEM [ LOCAL.CAT [ HEAD [ PRD non-prd,
                                 MOD < [ LOCAL [ CAT.HEAD verb & [ AUX - ],
                                                 CONT.HOOK.INDEX.SF prop ] ] > ],
                          VAL.COMPS < [ LOCAL [ CAT.HEAD.MOD < [ LOCAL.CAT.HEAD verb ] >,
-                                               CONT.HOOK.INDEX #arg2 ] ],... > ],
-             LKEYS.KEYREL.ARG2 #arg2 ] ].
+                                               CONT.HOOK.INDEX #arg2 ] ], ... > ],
+             LKEYS.KEYREL.ARG2 #arg2 ] ]
+  """
+  --- Verbal modifying prepositions
+  - taking PPs, there are two types:
+  a)- "de" when, with the verb "ser" or with movement verbs, expresses origin, or when it heads a nominal
+  complement; e.g. es de por ese barrio, salió de tras el matorral, el libro de sobre la mesa
+  b)- "desde" (origin), "hasta" (destination), "por" (path) + locative PP except "en"
+  e.g. se lanzó desde sobre el tejado
+  """.
 
-; - taking marked NPs
-; !!! in fact, only with with movement verbs: "de/a" + PP_por, e.g. vengo de/a por agua
-p_pp_i-e-vm_lex := mod-adp-lex & p_mrkd_np & norm-sem-lex-item & 
-  [ SYNSEM p_vmod_synsem &
-           [ LOCAL.CAT.MC na,
-             LKEYS [ KEYREL.PRED dir_rel,
-                     --COMPKEY  _por_p_sel_rel ] ] ].  
 
-; e.g. tengo que ser honesta conmigo
-pp_-_i-vm_lex := mod-pp-lex & norm-sem-lex-item & 
-  [ SYNSEM pp_vmod_synsem ]. 
+p_pp_i-e-vm_lex := mod-adp-lex & p_mrkd_np & norm-sem-lex-item &
+  [ SYNSEM p_vmod_synsem & [ LOCAL.CAT.MC na,
+                             LKEYS [ KEYREL.PRED dir_rel,
+                                     --COMPKEY _por_p_sel_rel ] ] ]
+  """
+  --- Verbal modifying prepositions
+  - taking marked NPs
+  !!! in fact, only with with movement verbs: "de/a" + PP_por, e.g. vengo de/a por agua
+  """.
+
+
+pp_-_i-vm_lex := mod-pp-lex & norm-sem-lex-item &
+  [ SYNSEM pp_vmod_synsem ]
+  """
+  --- Verbal modifying prepositions
+  e.g. tengo que ser honesta conmigo
+  """.
+
 
 ; --- Adjectival modifying prepositions (degree)
 

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -7095,43 +7095,65 @@ av_-_s-xm-spd_lex := spec-adverb-lex & basic-one-arg &
 
 ; --- 4.2. Intersective adverbs
 
+; --- 4.2.1. S modifiers 
+
+av_-_i-sm_lex := nonspec-adverb-lex & norm-zero-arg &
+  [ SYNSEM nonspec_intersect_s_adverb_synsem & 
+           [ local.cat.posthead - ] ]
+"""
+; --- 4.2. Intersective adverbs
+
 ; --- 4.2.1. S modifiers (davant subject o parentetics -entre comes
 ; --- que no sempre apareixen- en qualsevol posició)
 ; e.g. 
-av_-_i-sm_lex := nonspec-adverb-lex & norm-zero-arg &
-  [ SYNSEM nonspec_intersect_s_adverb_synsem & 
-           [ local.cat.posthead - ] ].
+""".
 
 
 ; --- 4.2.2. VP modifiers (any position after the verb)
 
-; e.g. (*muy) mortalmente
 av_-_i-vm_lex := nonspec-adverb-lex & norm-zero-arg &
   [ synsem nonspec_intersect_vp_adverb_synsem & 
-           [ local.cat.posthead + ] ].
+           [ local.cat.posthead + ] ]
+"""
+; --- 4.2.2. VP modifiers (any position after the verb)
+; e.g. (*muy) mortalmente
 
-; e.g. (muy) negativamente
+""".
+
 av_-_i-vm-spd_lex := spec-adverb-lex & basic-one-arg &
   [ synsem intersect_vp_adverb_synsem & 
-           [ local.cat.posthead + ] ].
+           [ local.cat.posthead + ] ]
+"""
+; --- 4.2.2. VP modifiers (any position after the verb)
+; e.g. (muy) negativamente
 
-; e.g. (*muy) recien llegados
+""".
+
 av_-_i-vm-ppart_lex := nonspec-adverb-lex & norm-zero-arg &
   [ synsem nonspec_intersect_vp_adverb_synsem & 
            [ local.cat [ posthead -,
                          head [ keys.key adv_rel,
                                 mod < [ local.cat [ head.vform part,
-                                                    val.subj < [ ] > ] ] > ] ] ] ].
+                                                    val.subj < [ ] > ] ] > ] ] ] ]
+"""
+; --- 4.2.2. VP modifiers (any position after the verb)
+; e.g. (*muy) recien llegados
+
+""".
 
 
 ; --- 4.3. degree adverbs (modify adverbs/adjectives (& pastparts))
-; !!! missing: así de tonto, igual de extraño, cómo de pequeño (interrogativo); qué (exclamativo); 
-; doblemente bueno; (*muy) cortés hasta la adulación; (*muy) fiel a sus ideas hasta la muerte 
+
 basic_degree_spec_synsem := canonical-synsem &
   [ local local &
           [ cat [ head adv & [ prd non-prd,
                                mod < > ],
-                  val.subj < > ] ] ].
+                  val.subj < > ] ] ]
+"""
+; --- 4.3. degree adverbs (modify adverbs/adjectives (& pastparts))
+; !!! missing: así de tonto, igual de extraño, cómo de pequeño (interrogativo); qué (exclamativo); 
+; doblemente bueno; (*muy) cortés hasta la adulación; (*muy) fiel a sus ideas hasta la muerte 
+""".
 
 basic_lex_degree_spec_synsem := basic_degree_spec_synsem & lex-synsem &
   [ local [ cont [ hook.index #index,
@@ -7230,32 +7252,40 @@ spec_degree_spec_lex := basic_degree_spec_lex &
 
 
 ; --- 4.3.1. quant degree adverbs
-; modify adverbs, adjectives, pastparts, and quant. pronom adverbs (e.g. mucho más)
-; - mucho, bien, algo, bastante, demasiado, super, nada, medio: can't co-occur with "muy" 
-; - un poco, un tanto: can't co-occur with any degree adverb
+
 av_-_dg-qnt_lex := degree_spec_lex & norm-zero-arg &
   [ synsem lex_degree_spec_synsem &
            [ local [ cat [ posthead -,
                            head.keys.key quant_degree_rel,
-                           val.spec < [ local.cat.head +nvjr ] > ] ] ] ].
+                           val.spec < [ local.cat.head +nvjr ] > ] ] ] ]
+"""
+; --- 4.3.1. quant degree adverbs
+; modify adverbs, adjectives, pastparts, and quant. pronom adverbs (e.g. mucho más)
+; - mucho, bien, algo, bastante, demasiado, super, nada, medio: can't co-occur with "muy" 
+; - un poco, un tanto: can't co-occur with any degree adverb
+""".
 
-; - for 'casi' and 'muy', which may specify determiners; e.g. muy pocos/casi todos los chicos lloran
-; and also modify adverbs, adjectives, pastparts, and pps
-; also for tan (tan metafísicamente imposible)
 av_-_dg-muy-and-casi_lex := degree_spec_lex & norm-zero-arg &
   [ synsem lex_degree_spec_synsem &
            [ local.cat [ posthead -,
                          val.spec < [ local.cat [ head +vjrpd,
-                                                  val.comps < > ] ] > ] ] ].
+                                                  val.comps < > ] ] > ] ] ]
+"""
+; - for 'casi' and 'muy', which may specify determiners; e.g. muy pocos/casi todos los chicos lloran
+; and also modify adverbs, adjectives, pastparts, and pps
+; also for tan (tan metafísicamente imposible)
+""".
 
-; - for 'casi', which may specify pronouns; e.g. casi nadie/nada/ninguno
 av_-_dg-casi_lex := degree_spec_lex & norm-zero-arg &
   [ synsem lex_degree_spec_synsem &
            [ local.cat [ posthead -,
                          val.spec < [ local [ agr.prontype real_pron,
                                               cat [ head noun,
                                                     val [ comps < >,
-                                                          spr < [ local.cat.head.keys.key _casi_x_deg_rel ] > ] ] ] ] > ] ] ].
+                                                          spr < [ local.cat.head.keys.key _casi_x_deg_rel ] > ] ] ] ] > ] ] ]
+"""
+; - for 'casi', which may specify pronouns; e.g. casi nadie/nada/ninguno
+""".
 
 ;av_-_dg-un-tanto_lex := basic_degree_spec_lex & basic-one-arg &
 ;  [ synsem lex_degree_spec_synsem &
@@ -7269,15 +7299,20 @@ av_-_dg-casi_lex := degree_spec_lex & norm-zero-arg &
 ;    arg-st #spr ].
 
 ; --- 4.3.2. degree adverbs (ending in '-mente')
-; modify adjectives, adverbs and pastparts: they may have a degree adverbs "tan metafísicamente imposible"
+
 av_-_dg_lex := spec_degree_spec_lex & basic-one-arg & 
   [ synsem lex_degree_spec_synsem &
            [ local.cat [ posthead -,
                          head.keys.key non-quant_degree_rel,
-                         val [ spec < [ local.cat.head +vjr ] > ] ] ] ].
+                         val [ spec < [ local.cat.head +vjr ] > ] ] ] ]
+"""
+; --- 4.3.2. degree adverbs (ending in '-mente')
+; modify adjectives, adverbs and pastparts: they may have a degree adverbs "tan metafísicamente imposible"
+""".
 
 
 ; --- 4.3.3. comparative degree adverbs
+
 comp_degree_spec_lex := basic_degree_spec_lex & basic-two-arg &
   [ synsem basic_comp_degree_spec_synsem &
            [ local [ cat [ posthead -,
@@ -7286,21 +7321,31 @@ comp_degree_spec_lex := basic_degree_spec_lex & basic-two-arg &
                                  comps #comps ] ],
                      cont [ rels <! arg12-relation !>,
                             hcons <! !> ] ] ], 
-    arg-st < #spr . #comps > ].
+    arg-st < #spr . #comps > ]
+"""
+; --- 4.3.3. comparative degree adverbs
+""".
 
-; e.g. (mucho/poco/bastante) más/menos guapo que 
 av_-_dg-cmp_lex := comp_degree_spec_lex &
   [ synsem [ local.cat.val.spr < [ local.cat.head.keys.key basic_quant_degree_rel ] >,
-             lkeys.--compkey _que_p_comp_rel ] ].
+             lkeys.--compkey _que_p_comp_rel ] ]
+"""
+; --- 4.3.3. comparative degree adverbs
+; e.g. (mucho/poco/bastante) más/menos guapo que 
+""".
 
 ; e.g. (casi) tan guapo como
 av_-_dg-cmp-eq_lex := comp_degree_spec_lex &
   [ synsem [ local.cat.val.spr < [ local.cat.head.keys.key _casi_x_deg_rel ] >,
-             lkeys.--compkey _como_p_comp_rel ] ].
+             lkeys.--compkey _como_p_comp_rel ] ]
+"""
+; --- 4.3.3. comparative degree adverbs
+; e.g. (casi) tan guapo como
+""".
 
 
 ; --- 4.3.5. Superlative degree adverbs
-; e.g. la más/menos guapa de 
+
 av_-_dg-sup_lex := basic_degree_spec_lex & basic-one-arg &
   [ SYNSEM basic_sup_degree_spec_synsem &
            [ LOCAL [ CAT [ POSTHEAD -,
@@ -7310,7 +7355,11 @@ av_-_dg-sup_lex := basic_degree_spec_lex & basic-one-arg &
                             HCONS <! !> ] ], 
              LKEYS [ KEYREL.PRED superl,
                      --COMPKEY _de_p_sel_rel ] ],
-    ARG-ST #comps ].
+    ARG-ST #comps ]
+"""
+; --- 4.3.5. Superlative degree adverbs
+; e.g. la más/menos guapa de 
+""".
 
 
 ; --- 4.4. Ordinal adverbs

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -6999,34 +6999,53 @@ nonspec_scopal_xp_adverb_synsem := basic_scopal_adverb_synsem &
 
 ;--- 4.1.1. focus adverbs
 
-; e.g. especialmente bajo la escalera/aquí/simpático/estos chicos
 av_-_s_lex := nonspec-adverb-lex & norm-zero-arg &
   [ SYNSEM nonspec_scopal_xp_adverb_synsem &
            [ LOCAL.CAT [ POSTHEAD -,
                          HEAD.MOD < [ LOCAL.CAT [ HEAD +nvjrp,
                                                   VAL.COMPS < > ],
-                                      NON-LOCAL.REL 0-dlist ] > ] ] ].
+                                      NON-LOCAL.REL 0-dlist ] > ] ] ]
+"""
+; --- 4.1. Scopal adverbs
+;--- 4.1.1. focus adverbs
+; e.g. especialmente bajo la escalera/aquí/simpático/estos chicos
+""".
 
-; e.g. Los Colegios deben velar muy especialmente por el cumplimiento de estas normas.
+
 av_-_s-spd_lex := spec-adverb-lex & basic-one-arg & 
   [ SYNSEM scopal_xp_adverb_synsem &
            [ LOCAL.CAT [ POSTHEAD -,
                          HEAD.MOD < [ LOCAL.CAT [ HEAD +nvjrp,
-                                                  VAL.COMPS < > ] ] > ] ] ].
+                                                  VAL.COMPS < > ] ] > ] ] ]
+"""
+; --- 4.1. Scopal adverbs
+;--- 4.1.1. focus adverbs
+; e.g. Los Colegios deben velar muy especialmente por el cumplimiento de estas normas.
+""".
 
 ; e.g. mañana/en la mesa mismo; *mismo mañana/en la mesa
 av_-_s-psth_lex := nonspec-adverb-lex & norm-zero-arg &
   [ SYNSEM nonspec_scopal_xp_adverb_synsem & 
            [ LOCAL.CAT [ POSTHEAD +,
-                         HEAD.MOD < [ LOCAL.CAT.HEAD +vjrp ] > ] ] ].
+                         HEAD.MOD < [ LOCAL.CAT.HEAD +vjrp ] > ] ] ]
+"""
+; --- 4.1. Scopal adverbs
+;--- 4.1.1. focus adverbs
+; e.g. mañana/en la mesa mismo; *mismo mañana/en la mesa
+""".
 
-; e.g. e.g. también
 av_-_s-psth-n_lex := nonspec-adverb-lex & norm-zero-arg &
   [ SYNSEM nonspec_scopal_xp_adverb_synsem & 
            [ LOCAL.CAT [ POSTHEAD +,
                          HEAD.MOD < [ LOCAL [ CAT [ LASTNMOD -,
                                                     HEAD noun,
-                                                    VAL.SPR < > ] ] ] > ] ] ].
+                                                    VAL.SPR < > ] ] ] > ] ] ]
+"""
+; --- 4.1. Scopal adverbs
+;--- 4.1.1. focus adverbs
+; e.g. e.g. también
+"""
+.
 
 ; --- 4.1.2. modal adverbs
 

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -7072,18 +7072,25 @@ av_-_s-vm-spd_lex := spec-adverb-lex & basic-one-arg &
 
 ; --- non-verb modifiers
 
-; e.g. (*muy) quizás yo
 av_-_s-xm_lex := nonspec-adverb-lex & norm-zero-arg &
   [ SYNSEM nonspec_scopal_xp_adverb_synsem & 
            [ LOCAL.CAT.HEAD [ PRD non-prd,
                               MOD < [ LOCAL.CAT [ HEAD +njrp,
-                                                  VAL.COMPS < > ] ] > ] ] ].
+                                                  VAL.COMPS < > ] ] > ] ] ]
+"""
+; --- non-verb modifiers
+; e.g. (*muy) quizás yo
+""".
 
 ; e.g. (muy) probablemente yo
 av_-_s-xm-spd_lex := spec-adverb-lex & basic-one-arg &
   [ SYNSEM scopal_xp_adverb_synsem & 
           [ LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD +njrp,
-                                               VAL.COMPS < > ] ] > ] ].
+                                               VAL.COMPS < > ] ] > ] ]
+"""
+; --- non-verb modifiers
+; e.g. (*muy) quizás yo
+""".
 
 
 ; --- 4.2. Intersective adverbs

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -9948,46 +9948,63 @@ c_xp_ora-nrel_lex := basic-coordconj-lex & basic-one-arg &
 ;           [ LOCAL.CAT.HEAD.LEFT < _siquera_c_rel >,
 ;             LKEYS.KEYREL.PRED _siquera_c_rel ] ]. 
 
-; - complex conjunctions (tanto...como, no solo... sino, así como) (e.g. tanto el vino como la 
-; cerveza/no sólo el vino, sino la cerveza,/el vino, así como la cerveza, contienen alcohol)
-; May co-occur with the same categories as 'y' except with finite and non-finite main sentences 
-; (e.g. *tanto el padre trabaja como el hijo estudia); subordinated clauses may be coordinated 
-; (e.g. espero tanto que Ana estudie filología como que Rosa estudie veterinaria; espero que tanto 
-; Ana estudie filología como que/*que como Rosa estudie veterinaria)
+
 c_xp_tanto_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LKEYS.KEYREL.PRED _tanto_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LKEYS.KEYREL.PRED _tanto_c_rel ] ]
+  """
+  - complex conjunctions (tanto...como, no solo... sino, así como) (e.g. tanto el vino como la
+  cerveza/no sólo el vino, sino la cerveza,/el vino, así como la cerveza, contienen alcohol)
+  May co-occur with the same categories as 'y' except with finite and non-finite main sentences
+  (e.g. *tanto el padre trabaja como el hijo estudia); subordinated clauses may be coordinated
+  (e.g. espero tanto que Ana estudie filología como que Rosa estudie veterinaria; espero que tanto
+  Ana estudie filología como que/*que como Rosa estudie veterinaria)
+  """.
+
 
 c_xp_como-nrel_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _tanto_c_rel >,
-             LKEYS.KEYREL.PRED _como_c_rel ] ].
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _tanto_c_rel >,
+                                      LKEYS.KEYREL.PRED _como_c_rel ] ]
+  """
+  
+  """.
+
 
 c_xp_no-sólo_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT two,
-             LKEYS.KEYREL.PRED _no_sólo_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT two,
+                                     LKEYS.KEYREL.PRED _no_sólo_c_rel ] ]
+  """
+  
+  """.
+
 
 c_xp_sino-nrel_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norel_coordconj_synsem &
-           [ LOCAL.CAT.HEAD.LEFT < _no_sólo_c_rel >,
-             LKEYS.KEYREL.PRED _sino_c_rel ] ].
+  [ SYNSEM norel_coordconj_synsem & [ LOCAL.CAT.HEAD.LEFT < _no_sólo_c_rel >,
+                                      LKEYS.KEYREL.PRED _sino_c_rel ] ]
+  """
+  
+  """.
+
 
 c_xp_así-como_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LKEYS.KEYREL.PRED _así_como_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LKEYS.KEYREL.PRED _así_como_c_rel ] ]
+  """
+  
+  """.
 
-; - adversative conjunctions 'pero', 'mas', 'sino' (but), 'aunque', 'siquiera' (though), 
-; (e.g. el miércoles iremos a ver a Pepe, pero el jueves volveremos aquí (*,pero el viernes nos vamos)). 
-; 'aunque','siquiera', 'pero' and 'mas' do not co-occur with nouns unless the second one is negated 
-; (e.g. vino con mi hermano, pero/aunque/mas no con mi hermana), or the noun is modified (only with 'pero' 
-; (e.g. vimos conejos enormes, *aunque/pero liebres pequeñitas.)
-; 'sino' exige la presencia de la negación (e.g. no recogímos a Rosa sino a Elena), no puede aparecer 
-; como sujeto (e.g. *no Rosa sino Ana vino) a menos que haya pausa (e.g. No Rosa, sino Ana vino).
+
 c_xp_aunque_lex := basic-coordconj-lex & basic-one-arg &
-  [ SYNSEM norm_coordconj_synsem &
-           [ LOCAL.COORD-STRAT one,
-             LKEYS.KEYREL.PRED _aunque_c_rel ] ].
+  [ SYNSEM norm_coordconj_synsem & [ LOCAL.COORD-STRAT one,
+                                     LKEYS.KEYREL.PRED _aunque_c_rel ] ]
+  """
+  - adversative conjunctions 'pero', 'mas', 'sino' (but), 'aunque', 'siquiera' (though),
+  (e.g. el miércoles iremos a ver a Pepe, pero el jueves volveremos aquí (*,pero el viernes nos vamos)).
+  'aunque','siquiera', 'pero' and 'mas' do not co-occur with nouns unless the second one is negated
+  (e.g. vino con mi hermano, pero/aunque/mas no con mi hermana), or the noun is modified (only with 'pero'
+  (e.g. vimos conejos enormes, *aunque/pero liebres pequeñitas.)
+  'sino' exige la presencia de la negación (e.g. no recogímos a Rosa sino a Elena), no puede aparecer
+  como sujeto (e.g. *no Rosa sino Ana vino) a menos que haya pausa (e.g. No Rosa, sino Ana vino).
+  """.
+
 
 c_xp_siquiera_lex := basic-coordconj-lex & basic-one-arg &
   [ SYNSEM norm_coordconj_synsem &
@@ -10193,43 +10210,73 @@ single-rel-lex := lex-item &
 no-hcons-lex := lex-item & 
   [ SYNSEM.LOCAL.CONT.HCONS <! !> ].
 
-; most lexical items contribute only one relation, and have empty HCONS values.
-norm-sem-lex-item := norm-hook-lex & single-rel-lex & no-hcons-lex.
-norm-sem-lex := norm-hook-lex & single-rel-lex.
+
+norm-sem-lex-item := norm-hook-lex & single-rel-lex & no-hcons-lex
+  """
+  most lexical items contribute only one relation, and have empty HCONS values.
+  """.
 
 
-; --- NON-LOCAL feature values and amalgamation
+norm-sem-lex := norm-hook-lex & single-rel-lex
+  """
+  
+  """.
 
-; basic_zero_arg lexical items have empty ARG-ST lists.  They may
-; introduce a non-empty value for one of the non-local features.
+
 basic-zero-arg := lex-item &
-  [ ARG-ST < > ].
+  [ ARG-ST < > ]
+  """
+  --- NON-LOCAL feature values and amalgamation
+  basic_zero_arg lexical items have empty ARG-ST lists.  They may
+  introduce a non-empty value for one of the non-local features.
+  """.
+
 
 zero-arg-nonslash := lex-item &
-  [ SYNSEM.NON-LOCAL.SLASH 0-dlist ].
+  [ SYNSEM.NON-LOCAL.SLASH 0-dlist ]
+  """
+  
+  """.
+
 
 zero-arg-nonrel := lex-item &
-  [ SYNSEM.NON-LOCAL.REL 0-dlist ].
+  [ SYNSEM.NON-LOCAL.REL 0-dlist ]
+  """
+  
+  """.
+
 
 zero-arg-nonque := lex-item &
-  [ SYNSEM.NON-LOCAL.QUE 0-dlist ].
+  [ SYNSEM.NON-LOCAL.QUE 0-dlist ]
+  """
+  
+  """.
 
-; Non-argument taking items which introduce no non-local values.
-norm-zero-arg := basic-zero-arg & zero-arg-nonslash & 
-                 zero-arg-nonrel & zero-arg-nonque.
 
-; Non-argument taking items introducing a rel value.
-zero-arg-rel := basic-zero-arg & zero-arg-nonslash & 
-                zero-arg-nonque.
+norm-zero-arg := basic-zero-arg & zero-arg-nonslash & zero-arg-nonrel & zero-arg-nonque
+  """
+  Non-argument taking items which introduce no non-local values.
+  """.
 
-; Non-argument taking items introducing a que value.
-zero-arg-que := basic-zero-arg & zero-arg-nonslash & 
-                zero-arg-nonrel.
 
-; Non-argument taking items introducing a slash value, 
-; e.g., resumptive pronouns in French.
-zero-arg-slash := basic-zero-arg & zero-arg-nonrel & 
-                  zero-arg-nonque.
+zero-arg-rel := basic-zero-arg & zero-arg-nonslash & zero-arg-nonque
+  """
+  Non-argument taking items introducing a rel value.
+  """.
+
+
+zero-arg-que := basic-zero-arg & zero-arg-nonslash & zero-arg-nonrel
+  """
+  Non-argument taking items introducing a que value.
+  """.
+
+
+zero-arg-slash := basic-zero-arg & zero-arg-nonrel & zero-arg-nonque
+  """
+  Non-argument taking items introducing a slash value,
+  e.g., resumptive pronouns in French.
+  """.
+
 
 ; These non-zero argument types only amalgamate the non-local
 ; feature values of their complements. They do not introduce any

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -12407,5025 +12407,7659 @@ v_vp_inf-ssr_native_le := v_vp_inf-ssr_lex & native_le
   """.
 
 
-v_vp_inf-ssr_le := v_vp_inf-ssr_lex.
+v_vp_inf-ssr_le := v_vp_inf-ssr_lex
+  """
+  
+  """.
 
-;  <type val="v_pp_e-vp-inf-ssr_le">
-;  <description>Verb, PPsel (VPinf, subj-subj-raising)
-;  <ex>deberías de hacerlo
-;  <todo>
-;  </type>
+
 v_pp_e-vp-inf-ssr_native_le := v_pp_e-vp-inf-ssr_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-vp-inf-ssr_le">
+  <description>Verb, PPsel (VPinf, subj-subj-raising)
+  <ex>deberías de hacerlo
+  <todo>
+  </type>
   """.
 
-v_pp_e-vp-inf-ssr_le := v_pp_e-vp-inf-ssr_lex.
 
-;  <type val="v_pp_e-vp-inf-ssr-prn_le">
-;  <description>Verb (pron), PPsel (VPinf, subj-subj raising)
-;  <ex>se echó a llorar
-;  <todo>
-;  </type>
+v_pp_e-vp-inf-ssr_le := v_pp_e-vp-inf-ssr_lex
+  """
+  
+  """.
+
+
 v_pp_e-vp-inf-ssr-prn_native_le := v_pp_e-vp-inf-ssr-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-vp-inf-ssr-prn_le">
+  <description>Verb (pron), PPsel (VPinf, subj-subj raising)
+  <ex>se echó a llorar
+  <todo>
+  </type>
   """.
 
-v_pp_e-vp-inf-ssr-prn_le := v_pp_e-vp-inf-ssr-prn_lex.
 
-;  <type val="v_vp_ger-ssr_le">
-;  <description>Verb, VPger (subj-subj raising)
-;  <ex>anda cantando
-;  <todo>
-;  </type>
+v_pp_e-vp-inf-ssr-prn_le := v_pp_e-vp-inf-ssr-prn_lex
+  """
+  
+  """.
+
+
 v_vp_ger-ssr_native_le := v_vp_ger-ssr_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_ger-ssr_le">
+  <description>Verb, VPger (subj-subj raising)
+  <ex>anda cantando
+  <todo>
+  </type>
   """.
 
-v_vp_ger-ssr_le := v_vp_ger-ssr_lex.
 
-;  <type val="v_vp_ger-ssr-prn_le">
-;  <description>Verb (pron), VPger (subj-subj raising)
-;  <ex>se quedó llorando
-;  <todo>
-;  </type>
-v_vp_ger-ssr-prn_le := v_vp_ger-ssr-prn_lex.
+v_vp_ger-ssr_le := v_vp_ger-ssr_lex
+  """
+  
+  """.
 
-;  <type val="v_adv_le">
-;  <description>Verb, ADV 
-;  <ex>haces bien/mal
-;  <todo>
-;  </type>
+
+v_vp_ger-ssr-prn_le := v_vp_ger-ssr-prn_lex
+  """
+  <type val="v_vp_ger-ssr-prn_le">
+  <description>Verb (pron), VPger (subj-subj raising)
+  <ex>se quedó llorando
+  <todo>
+  </type>
+  """.
+
+
 v_adv_native_le := v_adv_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_adv_le">
+  <description>Verb, ADV
+  <ex>haces bien/mal
+  <todo>
+  </type>
   """.
 
-v_adv_le := v_adv_lex.
 
-;  <type val="v_adv_prn_le">
-;  <description>Verb (pron), ADV 
-;  <ex>el niño se porta bien
-;  <todo>
-;  </type>
+v_adv_le := v_adv_lex
+  """
+  
+  """.
+
+
 v_adv_prn_native_le := v_adv_prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_adv_prn_le">
+  <description>Verb (pron), ADV
+  <ex>el niño se porta bien
+  <todo>
+  </type>
   """.
 
-v_adv_prn_le := v_adv_prn_lex.
 
-;  <type val="v_adv*_prn_le">
-;  <description>Verb (pron), ADV (opt)
-;  <ex>se conserva (muy bien)
-;  <todo>
-;  </type>
+v_adv_prn_le := v_adv_prn_lex
+  """
+  
+  """.
+
+
 v_adv*_prn_native_le := v_adv*_prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_adv*_prn_le">
+  <description>Verb (pron), ADV (opt)
+  <ex>se conserva (muy bien)
+  <todo>
+  </type>
   """.
 
-v_adv*_prn_le := v_adv*_prn_lex.
 
-;  <type val="v_adv-ppa*_le">
-;  <description>Verb, ADV and PPa (opt)
-;  <ex>(le) sentó bien
-;  <todo>
-;  </type>
+v_adv*_prn_le := v_adv*_prn_lex
+  """
+  
+  """.
+
+
 v_adv-ppa*_native_le := v_adv-ppa*_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_adv-ppa*_le">
+  <description>Verb, ADV and PPa (opt)
+  <ex>(le) sentó bien
+  <todo>
+  </type>
   """.
 
-v_adv-ppa*_le := v_adv-ppa*_lex.
 
-;  <type val="v_modnp-ppa*_idm_le">
-;  <description>Verb, MODNP and PPa (opt), idiom
-;  <ex>me da igual
-;  <todo>
-;  </type>
+v_adv-ppa*_le := v_adv-ppa*_lex
+  """
+  
+  """.
+
+
 v_modnp-ppa*_idm_native_le := v_modnp-ppa*_idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_modnp-ppa*_idm_le">
+  <description>Verb, MODNP and PPa (opt), idiom
+  <ex>me da igual
+  <todo>
+  </type>
   """.
 
-v_modnp-ppa*_idm_le := v_modnp-ppa*_idm_lex.
 
-;  <type val=" v_adv-pp_e-prn-idm_le">
-;  <description>Verb, ADV and PPe 
-;  <ex>llevarse bien/mal con
-;  <todo>
-;  </type>
+v_modnp-ppa*_idm_le := v_modnp-ppa*_idm_lex
+  """
+  
+  """.
+
+
 v_adv-pp_e-prn-idm_native_le := v_adv-pp_e-prn-idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val=" v_adv-pp_e-prn-idm_le">
+  <description>Verb, ADV and PPe
+  <ex>llevarse bien/mal con
+  <todo>
+  </type>
   """.
 
-v_adv-pp_e-prn-idm_le := v_adv-pp_e-prn-idm_lex.
 
-;  <type val="v_np_npsv_le">
-;  <description>Verb, NP (don't passivize)
-;  <ex>la reunión duró tres horas
-;  <todo>
-;  </type>
+v_adv-pp_e-prn-idm_le := v_adv-pp_e-prn-idm_lex
+  """
+  
+  """.
+
+
 v_np_npsv_native_le := v_np_npsv_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_npsv_le">
+  <description>Verb, NP (don't passivize)
+  <ex>la reunión duró tres horas
+  <todo>
+  </type>
   """.
 
-v_np_npsv_le := v_np_npsv_lex.
 
-;  <type val="v_np*_npsv_le">
-;  <description>Verb, NP (opt, don't passivize)
-;  <ex>adelgazó (3 kg)
-;  <todo>
-;  </type>
+v_np_npsv_le := v_np_npsv_lex
+  """
+  
+  """.
+
+
 v_np*_npsv_native_le := v_np*_npsv_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*_npsv_le">
+  <description>Verb, NP (opt, don't passivize)
+  <ex>adelgazó (3 kg)
+  <todo>
+  </type>
   """.
 
-v_np*_npsv_le := v_np*_npsv_lex.
 
-;  <type val="v_np_npsv-prn_le">
-;  <description>Verb (pron), NP (don't passivize)
-;  <ex>
-;  <todo>
-;  </type>
+v_np*_npsv_le := v_np*_npsv_lex
+  """
+  
+  """.
+
+
 v_np_npsv-prn_native_le := v_np_npsv-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_npsv-prn_le">
+  <description>Verb (pron), NP (don't passivize)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np_npsv-prn_le := v_np_npsv-prn_lex.
 
-;  <type val="v_np*_npsv-prn_le">
-;  <description>Verb (pron), NP (opt, don't passivize)
-;  <ex>
-;  <todo>
-;  </type>
+v_np_npsv-prn_le := v_np_npsv-prn_lex
+  """
+  
+  """.
+
+
 v_np*_npsv-prn_native_le := v_np*_npsv-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*_npsv-prn_le">
+  <description>Verb (pron), NP (opt, don't passivize)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np*_npsv-prn_le := v_np*_npsv-prn_lex.
 
-;  <type val="v_np_npsv-id_le">
-;  <description>Verb, NP (id, don't passivive)
-;  <ex>devenir
-;  <todo>
-;  </type>
+v_np*_npsv-prn_le := v_np*_npsv-prn_lex
+  """
+  
+  """.
+
+
 v_np_npsv-id_native_le := v_np_npsv-id_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_npsv-id_le">
+  <description>Verb, NP (id, don't passivive)
+  <ex>devenir
+  <todo>
+  </type>
   """.
 
-v_np_npsv-id_le := v_np_npsv-id_lex.
 
-;  <type val="v_np_npsv-id-ser_le">
-;  <description>Verb (ser), NP (id, don't passivive)
-;  <ex>este chico es mi novio
-;  <todo>
-;  </type>
+v_np_npsv-id_le := v_np_npsv-id_lex
+  """
+  
+  """.
+
+
 v_np_npsv-id-ser_native_le := v_np_npsv-id-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_npsv-id-ser_le">
+  <description>Verb (ser), NP (id, don't passivive)
+  <ex>este chico es mi novio
+  <todo>
+  </type>
   """.
 
-v_np_npsv-id-ser_le := v_np_npsv-id-ser_lex.
 
-;  <type val="v_np_npsv-id-prn_le">
-;  <description>Verb (pron), NP (id, don't passivive)
-;  <ex>me llamo Montse
-;  <todo>
-;  </type>
+v_np_npsv-id-ser_le := v_np_npsv-id-ser_lex
+  """
+  
+  """.
+
+
 v_np_npsv-id-prn_native_le := v_np_npsv-id-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_npsv-id-prn_le">
+  <description>Verb (pron), NP (id, don't passivive)
+  <ex>me llamo Montse
+  <todo>
+  </type>
   """.
 
-v_np_npsv-id-prn_le := v_np_npsv-id-prn_lex.
 
-;  <type val="v_np_le">
-;  <description>Verb, NP
-;  <ex>pintó la casa
-;  <todo>
-;  </type>
+v_np_npsv-id-prn_le := v_np_npsv-id-prn_lex
+  """
+  
+  """.
+
+
 v_np_native_le := v_np_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_le">
+  <description>Verb, NP
+  <ex>pintó la casa
+  <todo>
+  </type>
   """.
 
-v_np_le := v_np_lex.
 
-;  <type val="v_np*_le">
-;  <description>Verb, NP (opt) 
-;  <ex>comeremos (sopa)
-;  <todo>
-;  </type>
+v_np_le := v_np_lex
+  """
+  
+  """.
+
+
 v_np*_native_le := v_np*_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*_le">
+  <description>Verb, NP (opt)
+  <ex>comeremos (sopa)
+  <todo>
+  </type>
   """.
 
-v_np*_le := v_np*_lex.
 
-;  <type val="v_np_rfx_le">
-;  <description>Verb, NP (rfx)
-;  <ex>secó los pantalones
-;  <todo>
-;  </type>
+v_np*_le := v_np*_lex
+  """
+  
+  """.
+
+
 v_np_rfx_native_le := v_np_rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_rfx_le">
+  <description>Verb, NP (rfx)
+  <ex>secó los pantalones
+  <todo>
+  </type>
   """.
 
-v_np_rfx_le := v_np_rfx_lex.
 
-;  <type val="v_np*_rfx_le">
-;  <description>Verb, NP (opt, rfx)
-;  <ex>Juan se curó
-;  <todo>
-;  </type>
+v_np_rfx_le := v_np_rfx_lex
+  """
+  
+  """.
+
+
 v_np*_rfx_native_le := v_np*_rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*_rfx_le">
+  <description>Verb, NP (opt, rfx)
+  <ex>Juan se curó
+  <todo>
+  </type>
   """.
 
-v_np*_rfx_le := v_np*_rfx_lex.
 
-;  <type val="v_np_rcp_le">
-;  <description>Verb, NP (rcp)
-;  <ex>se aman
-;  <todo>
-;  </type>
+v_np*_rfx_le := v_np*_rfx_lex
+  """
+  
+  """.
+
+
 v_np_rcp_native_le := v_np_rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_rcp_le">
+  <description>Verb, NP (rcp)
+  <ex>se aman
+  <todo>
+  </type>
   """.
 
-v_np_rcp_le := v_np_rcp_lex.
 
-;  <type val="v_np*_rcp_le">
-;  <description>Verb, NP (opt, rcp) 
-;  <ex>(se) insultan
-;  <todo>
-;  </type>
+v_np_rcp_le := v_np_rcp_lex
+  """
+  
+  """.
+
+
 v_np*_rcp_native_le := v_np*_rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*_rcp_le">
+  <description>Verb, NP (opt, rcp)
+  <ex>(se) insultan
+  <todo>
+  </type>
   """.
 
-v_np*_rcp_le := v_np*_rcp_lex.
 
-;  <type val="v_np_rfx-rcp_le">
-;  <description>Verb, NP (rfx, rcp)
-;  <ex>se contradicen
-;  <todo>
-;  </type>
+v_np*_rcp_le := v_np*_rcp_lex
+  """
+  
+  """.
+
+
 v_np_rfx-rcp_native_le := v_np_rfx-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_rfx-rcp_le">
+  <description>Verb, NP (rfx, rcp)
+  <ex>se contradicen
+  <todo>
+  </type>
   """.
 
-v_np_rfx-rcp_le := v_np_rfx-rcp_lex.
 
-;  <type val="v_np*_rfx-rcp_le">
-;  <description>Verb, NP (opt, rfx, rcp)
-;  <ex>engaño a su hermano
-;  <todo>
-;  </type>
+v_np_rfx-rcp_le := v_np_rfx-rcp_lex
+  """
+  
+  """.
+
+
 v_np*_rfx-rcp_native_le := v_np*_rfx-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*_rfx-rcp_le">
+  <description>Verb, NP (opt, rfx, rcp)
+  <ex>engaño a su hermano
+  <todo>
+  </type>
   """.
 
-v_np*_rfx-rcp_le := v_np*_rfx-rcp_lex.
 
-;  <type val="v_np_prn_le">
-;  <description>Verb (pron), NP
-;  <ex>el alumno se saltó la clase
-;  <todo>
-;  </type>
+v_np*_rfx-rcp_le := v_np*_rfx-rcp_lex
+  """
+  
+  """.
+
+
 v_np_prn_native_le := v_np_prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_prn_le">
+  <description>Verb (pron), NP
+  <ex>el alumno se saltó la clase
+  <todo>
+  </type>
   """.
 
-v_np_prn_le := v_np_prn_lex.
 
-;  <type val="v_np*_prn_le">
-;  <description>Verb (pron), NP (opt) 
-;  <ex>María se peina el pelo
-;  <todo>
-;  </type>
+v_np_prn_le := v_np_prn_lex
+  """
+  
+  """.
+
+
 v_np*_prn_native_le := v_np*_prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*_prn_le">
+  <description>Verb (pron), NP (opt)
+  <ex>María se peina el pelo
+  <todo>
+  </type>
   """.
 
-v_np*_prn_le := v_np*_prn_lex.
 
-;  <type val="v_np_npsv-idm_le">
-;  <description>Verb (pron), NP, idiom
-;  <ex>tirar la toalla
-;  <todo>
-;  </type>
+v_np*_prn_le := v_np*_prn_lex
+  """
+  
+  """.
+
+
 v_np_npsv-idm_native_le := v_np_npsv-idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np_npsv-idm_le">
+  <description>Verb (pron), NP, idiom
+  <ex>tirar la toalla
+  <todo>
+  </type>
   """.
 
-v_np_npsv-idm_le := v_np_npsv-idm_lex.
 
-;  <type val="v_np-pp*_npsv-e_le">
-;  <description>Verb, NP (don't passivize) and PPsel (opt) 
-;  <ex>dista 3km de la capital
-;  <todo>
-;  </type>
+v_np_npsv-idm_le := v_np_npsv-idm_lex
+  """
+  
+  """.
+
+
 v_np-pp*_npsv-e_native_le := v_np-pp*_npsv-e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_npsv-e_le">
+  <description>Verb, NP (don't passivize) and PPsel (opt)
+  <ex>dista 3km de la capital
+  <todo>
+  </type>
   """.
 
-v_np-pp*_npsv-e_le := v_np-pp*_npsv-e_lex.
 
-;  <type val="v_np-pp_e_le">
-;  <description>Verb, NP and PPsel
-;  <ex>lo arrancó de la pared
-;  <todo>
-;  </type>
+v_np-pp*_npsv-e_le := v_np-pp*_npsv-e_lex
+  """
+  
+  """.
+
+
 v_np-pp_e_native_le := v_np-pp_e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e_le">
+  <description>Verb, NP and PPsel
+  <ex>lo arrancó de la pared
+  <todo>
+  </type>
   """.
 
-v_np-pp_e_le := v_np-pp_e_lex.
 
-;  <type val="v_np*-pp_e_le">
-;  <description>Verb, NP (opt) and PPsel
-;  <ex>he roto (las relaciones) con mi novio
-;  <todo>
-;  </type>
+v_np-pp_e_le := v_np-pp_e_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e_native_le := v_np*-pp_e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e_le">
+  <description>Verb, NP (opt) and PPsel
+  <ex>he roto (las relaciones) con mi novio
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e_le := v_np*-pp_e_lex.
 
-;  <type val="v_np-pp*_e_le">
-;  <description>Verb, NP and PPsel (opt)
-;  <ex>incorporaremos todos los nombres (a la lista)
-;  <todo>
-;  </type>
+v_np*-pp_e_le := v_np*-pp_e_lex
+  """
+  
+  """.
+
+
 v_np-pp*_e_native_le := v_np-pp*_e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_e_le">
+  <description>Verb, NP and PPsel (opt)
+  <ex>incorporaremos todos los nombres (a la lista)
+  <todo>
+  </type>
   """.
 
-v_np-pp*_e_le := v_np-pp*_e_lex.
 
-;  <type val="v_np*-pp*_e_le">
-;  <description>Verb, NP (opt) and PPsel (opt)
-;  <ex>he invertido (tres millones) (en bolsa)
-;  <todo>
-;  </type>
+v_np-pp*_e_le := v_np-pp*_e_lex
+  """
+  
+  """.
+
+
 v_np*-pp*_e_native_le := v_np*-pp*_e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp*_e_le">
+  <description>Verb, NP (opt) and PPsel (opt)
+  <ex>he invertido (tres millones) (en bolsa)
+  <todo>
+  </type>
   """.
 
-v_np*-pp*_e_le := v_np*-pp*_e_lex.
 
-;  <type val="v_np*-pp_e-prn_le">
-;  <description>Verb (pron), NP (opt) and PPsel
-;  <ex>se turna (el coche) con su hermana
-;  <todo>
-;  </type>
+v_np*-pp*_e_le := v_np*-pp*_e_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-prn_native_le := v_np*-pp_e-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-prn_le">
+  <description>Verb (pron), NP (opt) and PPsel
+  <ex>se turna (el coche) con su hermana
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-prn_le := v_np*-pp_e-prn_lex.
 
-;  <type val="v_np-pp_e-rcp_le">
-;  <description>Verb, NP and PPsel (rcp)
-;  <ex>se atraen
-;  <todo>
-;  </type>
+v_np*-pp_e-prn_le := v_np*-pp_e-prn_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-rcp_native_le := v_np-pp_e-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-rcp_le">
+  <description>Verb, NP and PPsel (rcp)
+  <ex>se atraen
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-rcp_le := v_np-pp_e-rcp_lex.
 
-;  <type val="v_np*-pp_e-rcp_le">
-;  <description>Verb, NP (opt) and PPsel (rcp)
-;  <ex>amenazr
-;  <todo>
-;  </type>
+v_np-pp_e-rcp_le := v_np-pp_e-rcp_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-rcp_native_le := v_np*-pp_e-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-rcp_le">
+  <description>Verb, NP (opt) and PPsel (rcp)
+  <ex>amenazr
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-rcp_le := v_np*-pp_e-rcp_lex.
 
-;  <type val="v_np-pp*_e-rcp_le">
-;  <description>Verb, NP and PPsel (opt) (rcp)
-;  <ex>recubrir
-;  <todo>
-;  </type>
+v_np*-pp_e-rcp_le := v_np*-pp_e-rcp_lex
+  """
+  
+  """.
+
+
 v_np-pp*_e-rcp_native_le := v_np-pp*_e-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_e-rcp_le">
+  <description>Verb, NP and PPsel (opt) (rcp)
+  <ex>recubrir
+  <todo>
+  </type>
   """.
 
-v_np-pp*_e-rcp_le := v_np-pp*_e-rcp_lex.
 
-;  <type val="v_np*-pp*_e-rcp_le">
-;  <description>Verb, NP (opt) and PPsel (opt) (rcp)
-;  <ex>invitar
-;  <todo>
-;  </type>
+v_np-pp*_e-rcp_le := v_np-pp*_e-rcp_lex
+  """
+  
+  """.
+
+
 v_np*-pp*_e-rcp_native_le := v_np*-pp*_e-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp*_e-rcp_le">
+  <description>Verb, NP (opt) and PPsel (opt) (rcp)
+  <ex>invitar
+  <todo>
+  </type>
   """.
 
-v_np*-pp*_e-rcp_le := v_np*-pp*_e-rcp_lex.
 
-;  <type val="v_np-pp_e-rfx_le">
-;  <description>Verb, NP and PPsel, (rfx)
-;  <ex>me acostumbré a la buena vida
-;  <todo>
-;  </type>
+v_np*-pp*_e-rcp_le := v_np*-pp*_e-rcp_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-rfx_native_le := v_np-pp_e-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-rfx_le">
+  <description>Verb, NP and PPsel, (rfx)
+  <ex>me acostumbré a la buena vida
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-rfx_le := v_np-pp_e-rfx_lex.
 
-;  <type val="v_np*-pp_e-rfx_le">
-;  <description>Verb,  NP (opt) and PPsel, (rfx)
-;  <ex>prevenir de
-;  <todo>
-;  </type>
+v_np-pp_e-rfx_le := v_np-pp_e-rfx_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-rfx_native_le := v_np*-pp_e-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-rfx_le">
+  <description>Verb,  NP (opt) and PPsel, (rfx)
+  <ex>prevenir de
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-rfx_le := v_np*-pp_e-rfx_lex.
 
-;  <type val="v_np-pp*_e-rfx_le">
-;  <description>Verb, NP and PPsel (opt), (rfx)
-;  <ex>convencer de
-;  <todo>
-;  </type>
+v_np*-pp_e-rfx_le := v_np*-pp_e-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp*_e-rfx_native_le := v_np-pp*_e-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_e-rfx_le">
+  <description>Verb, NP and PPsel (opt), (rfx)
+  <ex>convencer de
+  <todo>
+  </type>
   """.
 
-v_np-pp*_e-rfx_le := v_np-pp*_e-rfx_lex.
 
-;  <type val="v_np*-pp*_e-rfx_le">
-;  <description>Verb, NP (opt), and PPsel (opt), (rfx) 
-;  <ex> comparar a
-;  <todo>
-;  </type>
+v_np-pp*_e-rfx_le := v_np-pp*_e-rfx_lex
+  """
+  
+  """.
+
+
 v_np*-pp*_e-rfx_native_le := v_np*-pp*_e-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp*_e-rfx_le">
+  <description>Verb, NP (opt), and PPsel (opt), (rfx)
+  <ex> comparar a
+  <todo>
+  </type>
   """.
 
-v_np*-pp*_e-rfx_le := v_np*-pp*_e-rfx_lex.
 
-;  <type val="v_np-pp_e-rfx-rcp_le">
-;  <description>Verb, NP and PPsel, (rfx, rcp)
-;  <ex> informar de
-;  <todo>
-;  </type>
+v_np*-pp*_e-rfx_le := v_np*-pp*_e-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-rfx-rcp_native_le := v_np-pp_e-rfx-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-rfx-rcp_le">
+  <description>Verb, NP and PPsel, (rfx, rcp)
+  <ex> informar de
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-rfx-rcp_le := v_np-pp_e-rfx-rcp_lex.
 
-;  <type val="v_np-pp*_e-rfx-rcp_le">
-;  <description>Verb, NP and PPsel (opt), (rfx, rcp)
-;  <ex> atar a
-;  <todo>
-;  </type>
+v_np-pp_e-rfx-rcp_le := v_np-pp_e-rfx-rcp_lex
+  """
+  
+  """.
+
+
 v_np-pp*_e-rfx-rcp_native_le := v_np-pp*_e-rfx-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_e-rfx-rcp_le">
+  <description>Verb, NP and PPsel (opt), (rfx, rcp)
+  <ex> atar a
+  <todo>
+  </type>
   """.
 
-v_np-pp*_e-rfx-rcp_le := v_np-pp*_e-rfx-rcp_lex.
 
-;  <type val="v_np-pp_e-idm_le">
-;  <description>Verb, NP and PPsel (idiom)
-;  <ex>dar de alta
-;  <todo>
-;  </type>
+v_np-pp*_e-rfx-rcp_le := v_np-pp*_e-rfx-rcp_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-idm_native_le := v_np-pp_e-idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-idm_le">
+  <description>Verb, NP and PPsel (idiom)
+  <ex>dar de alta
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-idm_le := v_np-pp_e-idm_lex.
 
-;  <type val="v_np-pp*_e-npsv-prn-idm_le">
-;  <description>Ver (pron)b, NP and PPsel (idiom)
-;  <ex>darse cuenta
-;  <todo>
-;  </type>
+v_np-pp_e-idm_le := v_np-pp_e-idm_lex
+  """
+  
+  """.
+
+
 v_np-pp*_e-npsv-prn-idm_native_le := v_np-pp*_e-npsv-prn-idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_e-npsv-prn-idm_le">
+  <description>Ver (pron)b, NP and PPsel (idiom)
+  <ex>darse cuenta
+  <todo>
+  </type>
   """.
 
-v_np-pp*_e-npsv-prn-idm_le := v_np-pp*_e-npsv-prn-idm_lex.
 
-;  <type val="v_np-pp_e-cp-p_le">
-;  <description>Verb, NP and PPsel (Sent ind/subj)
-;  <ex>reducen el problema a que los muchachos lloren/lloran
-;  <todo>
-;  </type>
+v_np-pp*_e-npsv-prn-idm_le := v_np-pp*_e-npsv-prn-idm_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-cp-p_native_le := v_np-pp_e-cp-p_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-cp-p_le">
+  <description>Verb, NP and PPsel (Sent ind/subj)
+  <ex>reducen el problema a que los muchachos lloren/lloran
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-cp-p_le := v_np-pp_e-cp-p_lex.
 
-;  <type val="v_np-pp_e-cp-p-rfx_le">
-;  <description>Verb, Verb, NP and PPsel (Sent ind/subj), (rfx)
-;  <ex>habrá que acostumbrar a esos niños a que su padre llegue/llega siempre tarde a casa
-;  <todo>
-;  </type>
+v_np-pp_e-cp-p_le := v_np-pp_e-cp-p_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-cp-p-rfx_native_le := v_np-pp_e-cp-p-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-cp-p-rfx_le">
+  <description>Verb, Verb, NP and PPsel (Sent ind/subj), (rfx)
+  <ex>habrá que acostumbrar a esos niños a que su padre llegue/llega siempre tarde a casa
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-cp-p-rfx_le := v_np-pp_e-cp-p-rfx_lex.
 
-;  <type val="v_np*-pp_e*-cp-p_le">
-;  <description>Verb, NP (opt) and PPsel (Sent ind/subj, opt marker)
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp_e-cp-p-rfx_le := v_np-pp_e-cp-p-rfx_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e*-cp-p_native_le := v_np*-pp_e*-cp-p_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e*-cp-p_le">
+  <description>Verb, NP (opt) and PPsel (Sent ind/subj, opt marker)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e*-cp-p_le := v_np*-pp_e*-cp-p_lex.
 
-;  <type val="v_np-pp_e*-cp-p-rfx-rcp_le">
-;  <description>Verb, NP (opt) and PPsel (Sent ind/subj, opt marker)
-;  <ex>
-;  <todo>
-;  </type>
+v_np*-pp_e*-cp-p_le := v_np*-pp_e*-cp-p_lex
+  """
+  
+  """.
+
+
 v_np-pp_e*-cp-p-rfx-rcp_native_le := v_np-pp_e*-cp-p-rfx-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e*-cp-p-rfx-rcp_le">
+  <description>Verb, NP (opt) and PPsel (Sent ind/subj, opt marker)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-pp_e*-cp-p-rfx-rcp_le := v_np-pp_e*-cp-p-rfx-rcp_lex.
 
-;  <type val="v_np-pp_e-cp-p-ind-rfx_le">
-;  <description>Verb, NP and PPsel (Sent ind), (rfx)
-;  <ex>basó su defensa/se basó en que no tenía testigos
-;  <todo>
-;  </type>
+v_np-pp_e*-cp-p-rfx-rcp_le := v_np-pp_e*-cp-p-rfx-rcp_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-cp-p-ind-rfx_native_le := v_np-pp_e-cp-p-ind-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-cp-p-ind-rfx_le">
+  <description>Verb, NP and PPsel (Sent ind), (rfx)
+  <ex>basó su defensa/se basó en que no tenía testigos
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-cp-p-ind-rfx_le := v_np-pp_e-cp-p-ind-rfx_lex.
 
-;  <type val="v_np-pp_npsv-e-cp-p-ind_le">
-;  <description>Verb, Verb, NP (don't passivize) and PPsel (Sent ind)
-;  <ex>apostó conmigo una cena a que entraba/*entrara en la sala sin invitación.
-;  <todo>
-;  </type>
+v_np-pp_e-cp-p-ind-rfx_le := v_np-pp_e-cp-p-ind-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp_npsv-e-cp-p-ind_native_le := v_np-pp_npsv-e-cp-p-ind_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_npsv-e-cp-p-ind_le">
+  <description>Verb, Verb, NP (don't passivize) and PPsel (Sent ind)
+  <ex>apostó conmigo una cena a que entraba/*entrara en la sala sin invitación.
+  <todo>
+  </type>
   """.
 
-v_np-pp_npsv-e-cp-p-ind_le := v_np-pp_npsv-e-cp-p-ind_lex.
 
-;  <type val="v_np*-pp_e*-cp-p-ind_le">
-;  <description>Verb, Verb, NP (opt) and PPsel (Sent ind, opt marker)
-;  <ex>(los) avisó (de) que llegarán mañana
-;  <todo>
-;  </type>
+v_np-pp_npsv-e-cp-p-ind_le := v_np-pp_npsv-e-cp-p-ind_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e*-cp-p-ind_native_le := v_np*-pp_e*-cp-p-ind_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e*-cp-p-ind_le">
+  <description>Verb, Verb, NP (opt) and PPsel (Sent ind, opt marker)
+  <ex>(los) avisó (de) que llegarán mañana
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e*-cp-p-ind_le := v_np*-pp_e*-cp-p-ind_lex.
 
-;  <type val="v_np-pp_npsv-e-cp-p-sub_le">
-;  <description>Verb, NP (don't passivize) and PPsel (Sent subj)
-;  <ex>(las) apremia a que vengan
-;  <todo>
-;  </type>
+v_np*-pp_e*-cp-p-ind_le := v_np*-pp_e*-cp-p-ind_lex
+  """
+  
+  """.
+
+
 v_np-pp_npsv-e-cp-p-sub_native_le := v_np-pp_npsv-e-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_npsv-e-cp-p-sub_le">
+  <description>Verb, NP (don't passivize) and PPsel (Sent subj)
+  <ex>(las) apremia a que vengan
+  <todo>
+  </type>
   """.
 
-v_np-pp_npsv-e-cp-p-sub_le := v_np-pp_npsv-e-cp-p-sub_lex.
 
-;  <type val="v_np*-pp_npsv-e-cp-p-sub_le">
-;  <description>Verb, NP (opt, don't passivize) and PPsel (Sent subj)
-;  <ex>(las) apremia a que vengan
-;  <todo>
-;  </type>
+v_np-pp_npsv-e-cp-p-sub_le := v_np-pp_npsv-e-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_np*-pp_npsv-e-cp-p-sub_native_le := v_np*-pp_npsv-e-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_npsv-e-cp-p-sub_le">
+  <description>Verb, NP (opt, don't passivize) and PPsel (Sent subj)
+  <ex>(las) apremia a que vengan
+  <todo>
+  </type>
   """.
 
-v_np*-pp_npsv-e-cp-p-sub_le := v_np*-pp_npsv-e-cp-p-sub_lex.
 
-;  <type val="v_np-pp_e-cp-p-sub_le">
-;  <description>Verb, NP and PPsel (Sent subj)
-;  <ex>
-;  <todo>
-;  </type>
+v_np*-pp_npsv-e-cp-p-sub_le := v_np*-pp_npsv-e-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-cp-p-sub_native_le := v_np-pp_e-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-cp-p-sub_le">
+  <description>Verb, NP and PPsel (Sent subj)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-cp-p-sub_le := v_np-pp_e-cp-p-sub_lex.
 
-;  <type val="v_np*-pp_e-cp-p-sub_le">
-;  <description>Verb, NP (opt) and PPsel (Sent subj)
-;  <ex>(los) alentó a que participaran
-;  <todo>
-;  </type>
+v_np-pp_e-cp-p-sub_le := v_np-pp_e-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-cp-p-sub_native_le := v_np*-pp_e-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-cp-p-sub_le">
+  <description>Verb, NP (opt) and PPsel (Sent subj)
+  <ex>(los) alentó a que participaran
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-cp-p-sub_le := v_np*-pp_e-cp-p-sub_lex.
 
-;  <type val="v_np-pp_e-cp-p-sub-rfx_le">
-;  <description>Verb, NP and PPsel (Sent subj), (rfx)
-;  <ex>
-;  <todo>
-;  </type>
+v_np*-pp_e-cp-p-sub_le := v_np*-pp_e-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-cp-p-sub-rfx_native_le := v_np-pp_e-cp-p-sub-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-cp-p-sub-rfx_le">
+  <description>Verb, NP and PPsel (Sent subj), (rfx)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-cp-p-sub-rfx_le := v_np-pp_e-cp-p-sub-rfx_lex.
 
-;  <type val="v_np*-pp_e-cp-p-sub-rfx_le">
-;  <description>Verb, NP (opt) and PPsel (Sent subj), (rfx)
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp_e-cp-p-sub-rfx_le := v_np-pp_e-cp-p-sub-rfx_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-cp-p-sub-rfx_native_le := v_np*-pp_e-cp-p-sub-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-cp-p-sub-rfx_le">
+  <description>Verb, NP (opt) and PPsel (Sent subj), (rfx)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-cp-p-sub-rfx_le := v_np*-pp_e-cp-p-sub-rfx_lex.
 
-;  <type val="v_np-pp_e-cp-p-sub-rcp_le">
-;  <description>Verb, NP and PPsel (Sent subj), (rcp)
-;  <ex>
-;  <todo>
-;  </type>
+v_np*-pp_e-cp-p-sub-rfx_le := v_np*-pp_e-cp-p-sub-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-cp-p-sub-rcp_native_le := v_np-pp_e-cp-p-sub-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-cp-p-sub-rcp_le">
+  <description>Verb, NP and PPsel (Sent subj), (rcp)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-cp-p-sub-rcp_le := v_np-pp_e-cp-p-sub-rcp_lex.
 
-;  <type val="v_np*-pp_e-cp-p-sub-rcp_le">
-;  <description>Verb, NP (opt) and PPsel (Sent subj), (rcp)
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp_e-cp-p-sub-rcp_le := v_np-pp_e-cp-p-sub-rcp_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-cp-p-sub-rcp_native_le := v_np*-pp_e-cp-p-sub-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-cp-p-sub-rcp_le">
+  <description>Verb, NP (opt) and PPsel (Sent subj), (rcp)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-cp-p-sub-rcp_le := v_np*-pp_e-cp-p-sub-rcp_lex.
 
-;  <type val="v_np-pp_e-cp-p-sub-rfx-rcp_le">
-;  <description>Verb, NP and PPsel (Sent subj), (rfx, rcp)
-;  <ex>
-;  <todo>
-;  </type>
+v_np*-pp_e-cp-p-sub-rcp_le := v_np*-pp_e-cp-p-sub-rcp_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-cp-p-sub-rfx-rcp_native_le := v_np-pp_e-cp-p-sub-rfx-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-cp-p-sub-rfx-rcp_le">
+  <description>Verb, NP and PPsel (Sent subj), (rfx, rcp)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-cp-p-sub-rfx-rcp_le := v_np-pp_e-cp-p-sub-rfx-rcp_lex.
 
-;  <type val="v_np*-pp_e-cp-p-sub-rfx-rcp_le">
-;  <description>Verb, NP (opt) and PPsel (Sent subj), (rfx, rcp)
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp_e-cp-p-sub-rfx-rcp_le := v_np-pp_e-cp-p-sub-rfx-rcp_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-cp-p-sub-rfx-rcp_native_le := v_np*-pp_e-cp-p-sub-rfx-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-cp-p-sub-rfx-rcp_le">
+  <description>Verb, NP (opt) and PPsel (Sent subj), (rfx, rcp)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-cp-p-sub-rfx-rcp_le := v_np*-pp_e-cp-p-sub-rfx-rcp_lex.
 
-;  <type val="v_np*-pp_e*-cp-p-sub_le">
-;  <description>Verb, NP (opt) and PPsel (Sent subj, opt marker)
-;  <ex>(la) advertí (de) que vendrían
-;  <todo>
-;  </type>
+v_np*-pp_e-cp-p-sub-rfx-rcp_le := v_np*-pp_e-cp-p-sub-rfx-rcp_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e*-cp-p-sub_native_le := v_np*-pp_e*-cp-p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e*-cp-p-sub_le">
+  <description>Verb, NP (opt) and PPsel (Sent subj, opt marker)
+  <ex>(la) advertí (de) que vendrían
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e*-cp-p-sub_le := v_np*-pp_e*-cp-p-sub_lex.
 
-;  <type val="v_np*-pp_e*-cp-p-sub-rfx_le">
-;  <description>Verb, NP (opt) and PPsel (Sent subj, opt marker), (rfx)
-;  <ex>(nos) convenció (de) que vendiesemos la casa
-;  <todo>
-;  </type>
+v_np*-pp_e*-cp-p-sub_le := v_np*-pp_e*-cp-p-sub_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e*-cp-p-sub-rfx_native_le := v_np*-pp_e*-cp-p-sub-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e*-cp-p-sub-rfx_le">
+  <description>Verb, NP (opt) and PPsel (Sent subj, opt marker), (rfx)
+  <ex>(nos) convenció (de) que vendiesemos la casa
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e*-cp-p-sub-rfx_le := v_np*-pp_e*-cp-p-sub-rfx_lex.
 
-;  <type val="v_np*-pp_e-cp-p-sub-mv_le">
-;  <description>Verb, NP (opt) and PPsel (Sent subj) (verbs of movement that may also take VPinf subject control (e.g. la amenazó con ir a la policía) and object control in the sub. clause (e.g. envía las camisas a planchar a madrid))
-;  <ex>(la) arrastra a pelear
-;  <todo>
-;  </type>
+v_np*-pp_e*-cp-p-sub-rfx_le := v_np*-pp_e*-cp-p-sub-rfx_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-cp-p-sub-mv_native_le := v_np*-pp_e-cp-p-sub-mv_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-cp-p-sub-mv_le">
+  <description>Verb, NP (opt) and PPsel (Sent subj) (verbs of movement that may also take VPinf subject control (e.g. la amenazó con ir a la policía) and object control in the sub. clause (e.g. envía las camisas a planchar a madrid))
+  <ex>(la) arrastra a pelear
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-cp-p-sub-mv_le := v_np*-pp_e-cp-p-sub-mv_lex.
 
-;  <type val="v_np*-pp_e-cp-p-sub-mv-rfx_le">
-;  <description>Verb, NP (opt) and PPsel (Sent subj), (rfx) (verbs of movement that may also take VPinf subject control (e.g. la amenazó con ir a la policía) and object control in the sub. clause (e.g. envía las camisas a planchar a madrid))
-;  <ex>se/nos encaminó a luchar
-;  <todo>
-;  </type>
+v_np*-pp_e-cp-p-sub-mv_le := v_np*-pp_e-cp-p-sub-mv_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-cp-p-sub-mv-rfx_native_le := v_np*-pp_e-cp-p-sub-mv-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-cp-p-sub-mv-rfx_le">
+  <description>Verb, NP (opt) and PPsel (Sent subj), (rfx) (verbs of movement that may also take VPinf subject control (e.g. la amenazó con ir a la policía) and object control in the sub. clause (e.g. envía las camisas a planchar a madrid))
+  <ex>se/nos encaminó a luchar
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-cp-p-sub-mv-rfx_le := v_np*-pp_e-cp-p-sub-mv-rfx_lex.
 
-;  <type val="v_np-pp_e-vp-inf-sc_le">
-;  <description>Verb, NP (don't passivize) and PPsel (Sent VPinf sbj-ctrl)
-;  <ex>
-;  <todo>
-;  </type>
+v_np*-pp_e-cp-p-sub-mv-rfx_le := v_np*-pp_e-cp-p-sub-mv-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-vp-inf-sc_native_le := v_np-pp_e-vp-inf-sc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-vp-inf-sc_le">
+  <description>Verb, NP (don't passivize) and PPsel (Sent VPinf sbj-ctrl)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-vp-inf-sc_le := v_np-pp_e-vp-inf-sc_lex.
 
-;  <type val="v_np*-pp_e-vp-inf-sc_le">
-;  <description>Verb, NP (opt) and PPsel (Sent VPinf sbj-ctrl)
-;  <ex>(la) amenazó con ir a la policía
-;  <todo>
-;  </type>
+v_np-pp_e-vp-inf-sc_le := v_np-pp_e-vp-inf-sc_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-vp-inf-sc_native_le := v_np*-pp_e-vp-inf-sc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-vp-inf-sc_le">
+  <description>Verb, NP (opt) and PPsel (Sent VPinf sbj-ctrl)
+  <ex>(la) amenazó con ir a la policía
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-vp-inf-sc_le := v_np*-pp_e-vp-inf-sc_lex.
 
-;  <type val="v_np-pp_e-vp-inf-oc_le">
-;  <description>Verb, NP and PPsel (Sent VPinf obj-ctrl)
-;  <ex>la culparon de causar el accidente 
-;  <todo>
-;  </type>
+v_np*-pp_e-vp-inf-sc_le := v_np*-pp_e-vp-inf-sc_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-vp-inf-oc_native_le := v_np-pp_e-vp-inf-oc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-vp-inf-oc_le">
+  <description>Verb, NP and PPsel (Sent VPinf obj-ctrl)
+  <ex>la culparon de causar el accidente
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-vp-inf-oc_le := v_np-pp_e-vp-inf-oc_lex.
 
-;  <type val="v_np*-pp_e-vp-inf-oc_le">
-;  <description>Verb, NP (opt) and PPsel (Sent VPinf obj-ctrl)
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp_e-vp-inf-oc_le := v_np-pp_e-vp-inf-oc_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-vp-inf-oc_native_le := v_np*-pp_e-vp-inf-oc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-vp-inf-oc_le">
+  <description>Verb, NP (opt) and PPsel (Sent VPinf obj-ctrl)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-vp-inf-oc_le := v_np*-pp_e-vp-inf-oc_lex.
 
-;  <type val="v_np*-pp_e-vp-inf-oc-rfx_le">
-;  <description>Verb, NP (opt) and PPsel (Sent VPinf obj-ctrl), (rfx)
-;  <ex>
-;  <todo>
-;  </type>
+v_np*-pp_e-vp-inf-oc_le := v_np*-pp_e-vp-inf-oc_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-vp-inf-oc-rfx_native_le := v_np*-pp_e-vp-inf-oc-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-vp-inf-oc-rfx_le">
+  <description>Verb, NP (opt) and PPsel (Sent VPinf obj-ctrl), (rfx)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-vp-inf-oc-rfx_le := v_np*-pp_e-vp-inf-oc-rfx_lex.
 
-;  <type val="v_np-pp_e-vp-inf-oc-rcp_le">
-;  <description>Verb, NP and PPsel (Sent VPinf obj-ctrl), (rcp)
-;  <ex>
-;  <todo>
-;  </type>
+v_np*-pp_e-vp-inf-oc-rfx_le := v_np*-pp_e-vp-inf-oc-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-vp-inf-oc-rcp_native_le := v_np-pp_e-vp-inf-oc-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-vp-inf-oc-rcp_le">
+  <description>Verb, NP and PPsel (Sent VPinf obj-ctrl), (rcp)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-vp-inf-oc-rcp_le := v_np-pp_e-vp-inf-oc-rcp_lex.
 
-;  <type val="v_np*-pp_e-vp-inf-oc-rcp_le">
-;  <description>Verb, NP (opt) and PPsel (Sent VPinf obj-ctrl), (rcp)
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp_e-vp-inf-oc-rcp_le := v_np-pp_e-vp-inf-oc-rcp_lex
+  """
+  
+  """.
+
+
 v_np*-pp_e-vp-inf-oc-rcp_native_le := v_np*-pp_e-vp-inf-oc-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_e-vp-inf-oc-rcp_le">
+  <description>Verb, NP (opt) and PPsel (Sent VPinf obj-ctrl), (rcp)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np*-pp_e-vp-inf-oc-rcp_le := v_np*-pp_e-vp-inf-oc-rcp_lex.
 
-;  <type val="v_np-pp_loc_le">
-;  <description>Verb, NP and PPloc 
-;  <ex>pon los libros en el cajón
-;  <todo>
-;  </type>
+v_np*-pp_e-vp-inf-oc-rcp_le := v_np*-pp_e-vp-inf-oc-rcp_lex
+  """
+  
+  """.
+
+
 v_np-pp_loc_native_le := v_np-pp_loc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_loc_le">
+  <description>Verb, NP and PPloc
+  <ex>pon los libros en el cajón
+  <todo>
+  </type>
   """.
 
-v_np-pp_loc_le := v_np-pp_loc_lex.
 
-;  <type val="v_np*-pp_loc_le">
-;  <description>Verb, NP (opt) and PPloc 
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp_loc_le := v_np-pp_loc_lex
+  """
+  
+  """.
+
+
 v_np*-pp_loc_native_le := v_np*-pp_loc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_loc_le">
+  <description>Verb, NP (opt) and PPloc
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np*-pp_loc_le := v_np*-pp_loc_lex.
 
-;  <type val="v_np-pp*_loc_le">
-;  <description>Verb, NP and PPloc (opt)
-;  <ex>colgó el cuadro (en la pared)
-;  <todo>
-;  </type>
+v_np*-pp_loc_le := v_np*-pp_loc_lex
+  """
+  
+  """.
+
+
 v_np-pp*_loc_native_le := v_np-pp*_loc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_loc_le">
+  <description>Verb, NP and PPloc (opt)
+  <ex>colgó el cuadro (en la pared)
+  <todo>
+  </type>
   """.
 
-v_np-pp*_loc_le := v_np-pp*_loc_lex.
 
-;  <type val="v_np-pp*_loc-prn_le">
-;  <description>Verb (pron), NP and PPloc 
-;  <ex>se la dejó (en el despacho)
-;  <todo>
-;  </type>
+v_np-pp*_loc_le := v_np-pp*_loc_lex
+  """
+  
+  """.
+
+
 v_np-pp*_loc-prn_native_le := v_np-pp*_loc-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_loc-prn_le">
+  <description>Verb (pron), NP and PPloc
+  <ex>se la dejó (en el despacho)
+  <todo>
+  </type>
   """.
 
-v_np-pp*_loc-prn_le := v_np-pp*_loc-prn_lex.
 
-;  <type val="v_np-pp_dir_le">
-;  <description>Verb, NP and PPdir
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp*_loc-prn_le := v_np-pp*_loc-prn_lex
+  """
+  
+  """.
+
+
 v_np-pp_dir_native_le := v_np-pp_dir_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_dir_le">
+  <description>Verb, NP and PPdir
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-pp_dir_le := v_np-pp_dir_lex.
 
-;  <type val="v_np*-pp_dir_le">
-;  <description>Verb, NP (opt) and PPdir
-;  <ex>apuntó (el arma) a la mujer
-;  <todo>
-;  </type>
+v_np-pp_dir_le := v_np-pp_dir_lex
+  """
+  
+  """.
+
+
 v_np*-pp_dir_native_le := v_np*-pp_dir_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp_dir_le">
+  <description>Verb, NP (opt) and PPdir
+  <ex>apuntó (el arma) a la mujer
+  <todo>
+  </type>
   """.
 
-v_np*-pp_dir_le := v_np*-pp_dir_lex.
 
-;  <type val="v_np-pp*_dir_le">
-;  <description>Verb, NP and PPdir (opt)
-;  <ex>deportar
-;  <todo>
-;  </type>
+v_np*-pp_dir_le := v_np*-pp_dir_lex
+  """
+  
+  """.
+
+
 v_np-pp*_dir_native_le := v_np-pp*_dir_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_dir_le">
+  <description>Verb, NP and PPdir (opt)
+  <ex>deportar
+  <todo>
+  </type>
   """.
 
-v_np-pp*_dir_le := v_np-pp*_dir_lex.
 
-;  <type val="v_np*-pp*_dir-rcp_le">
-;  <description>Verb, NP (opt) and PPdir (opt)
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp*_dir_le := v_np-pp*_dir_lex
+  """
+  
+  """.
+
+
 v_np*-pp*_dir-rcp_native_le := v_np*-pp*_dir-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-pp*_dir-rcp_le">
+  <description>Verb, NP (opt) and PPdir (opt)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np*-pp*_dir-rcp_le := v_np*-pp*_dir-rcp_lex.
 
-;  <type val="v_np-pp*_dir-prn_le">
-;  <description>Verb (pron), NP and PPdir (opt)
-;  <ex>se lo llevó al cine
-;  <todo>
-;  </type>
+v_np*-pp*_dir-rcp_le := v_np*-pp*_dir-rcp_lex
+  """
+  
+  """.
+
+
 v_np-pp*_dir-prn_native_le := v_np-pp*_dir-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_dir-prn_le">
+  <description>Verb (pron), NP and PPdir (opt)
+  <ex>se lo llevó al cine
+  <todo>
+  </type>
   """.
 
-v_np-pp*_dir-prn_le := v_np-pp*_dir-prn_lex.
 
-;  <type val="v_np-pp*_loc-rfx_le">
-;  <description>Verb, NP and PPloc (opt), rfx
-;  <ex>el niño se sentó en la trona
-;  <todo>
-;  </type>
+v_np-pp*_dir-prn_le := v_np-pp*_dir-prn_lex
+  """
+  
+  """.
+
+
 v_np-pp*_loc-rfx_native_le := v_np-pp*_loc-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_loc-rfx_le">
+  <description>Verb, NP and PPloc (opt), rfx
+  <ex>el niño se sentó en la trona
+  <todo>
+  </type>
   """.
 
-v_np-pp*_loc-rfx_le := v_np-pp*_loc-rfx_lex.
 
-;  <type val="v_np-pp*_dir-rfx_le">
-;  <description>Verb, NP and PPdir (opt), rfx
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp*_loc-rfx_le := v_np-pp*_loc-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp*_dir-rfx_native_le := v_np-pp*_dir-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_dir-rfx_le">
+  <description>Verb, NP and PPdir (opt), rfx
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-pp*_dir-rfx_le := v_np-pp*_dir-rfx_lex.
 
-;  <type val="v_np-pp*_loc-rfx-rcp_le">
-;  <description>Verb, NP and PPdir (opt), rfx, rcp
-;  <ex>
-;  <todo>
-;  </type>
+v_np-pp*_dir-rfx_le := v_np-pp*_dir-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp*_loc-rfx-rcp_native_le := v_np-pp*_loc-rfx-rcp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_loc-rfx-rcp_le">
+  <description>Verb, NP and PPdir (opt), rfx, rcp
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-pp*_loc-rfx-rcp_le := v_np-pp*_loc-rfx-rcp_lex.
 
-;  <type val="v_np-np_id_le">
-;  <description>Verb, NP and NP (id)
-;  <ex>lo tituló...
-;  <todo>
-;  </type>
+v_np-pp*_loc-rfx-rcp_le := v_np-pp*_loc-rfx-rcp_lex
+  """
+  
+  """.
+
+
 v_np-np_id_native_le := v_np-np_id_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-np_id_le">
+  <description>Verb, NP and NP (id)
+  <ex>lo tituló...
+  <todo>
+  </type>
   """.
 
-v_np-np_id_le := v_np-np_id_lex.
 
-;  <type val="v_np-ppa*_npsv_le">
-;  <description>Verb, NP and PPa (don't passivize)
-;  <ex>(le) costó 300 pesetas
-;  <todo>
-;  </type>
+v_np-np_id_le := v_np-np_id_lex
+  """
+  
+  """.
+
+
 v_np-ppa*_npsv_native_le := v_np-ppa*_npsv_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-ppa*_npsv_le">
+  <description>Verb, NP and PPa (don't passivize)
+  <ex>(le) costó 300 pesetas
+  <todo>
+  </type>
   """.
 
-v_np-ppa*_npsv_le := v_np-ppa*_npsv_lex.
 
-;  <type val="v_np-ppa_le">
-;  <description>Verb, NP and PPa
-;  <ex>¿me pasas la sal?
-;  <todo>
-;  </type>
+v_np-ppa*_npsv_le := v_np-ppa*_npsv_lex
+  """
+  
+  """.
+
+
 v_np-ppa_native_le := v_np-ppa_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-ppa_le">
+  <description>Verb, NP and PPa
+  <ex>¿me pasas la sal?
+  <todo>
+  </type>
   """.
 
-v_np-ppa_le := v_np-ppa_lex.
 
-;  <type val="v_np-ppa*_le">
-;  <description>Verb, NP and PPa (opt)
-;  <ex>(me) agradeció la propuesta
-;  <todo>
-;  </type>
+v_np-ppa_le := v_np-ppa_lex
+  """
+  
+  """.
+
+
 v_np-ppa*_native_le := v_np-ppa*_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-ppa*_le">
+  <description>Verb, NP and PPa (opt)
+  <ex>(me) agradeció la propuesta
+  <todo>
+  </type>
   """.
 
-v_np-ppa*_le := v_np-ppa*_lex.
 
-;  <type val="v_np*-ppa_le">
-;  <description>Verb, NP (opt) and PPa
-;  <ex>le disparó (un tiro)
-;  <todo>
-;  </type>
+v_np-ppa*_le := v_np-ppa*_lex
+  """
+  
+  """.
+
+
 v_np*-ppa_native_le := v_np*-ppa_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-ppa_le">
+  <description>Verb, NP (opt) and PPa
+  <ex>le disparó (un tiro)
+  <todo>
+  </type>
   """.
 
-v_np*-ppa_le := v_np*-ppa_lex.
 
-;  <type val="v_np*-ppa*_le">
-;  <description>Verb, NP (opt) and PPa (opt)
-;  <ex>(le) robó (el bolso)
-;  <todo>
-;  </type>
+v_np*-ppa_le := v_np*-ppa_lex
+  """
+  
+  """.
+
+
 v_np*-ppa*_native_le := v_np*-ppa*_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np*-ppa*_le">
+  <description>Verb, NP (opt) and PPa (opt)
+  <ex>(le) robó (el bolso)
+  <todo>
+  </type>
   """.
 
-v_np*-ppa*_le := v_np*-ppa*_lex.
 
-;  <type val="v_np-ppa_rfx_le">
-;  <description>Verb, NP and PPa, rfx
-;  <ex>
-;  <todo>
-;  </type>
+v_np*-ppa*_le := v_np*-ppa*_lex
+  """
+  
+  """.
+
+
 v_np-ppa_rfx_native_le := v_np-ppa_rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-ppa_rfx_le">
+  <description>Verb, NP and PPa, rfx
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_np-ppa_rfx_le := v_np-ppa_rfx_lex.
 
-;  <type val="v_np-ppa*_rfx_le">
-;  <description>Verb, NP and PPa (opt), rfx
-;  <ex>encomendar
-;  <todo>
-;  </type>
+v_np-ppa_rfx_le := v_np-ppa_rfx_lex
+  """
+  
+  """.
+
+
 v_np-ppa*_rfx_native_le := v_np-ppa*_rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-ppa*_rfx_le">
+  <description>Verb, NP and PPa (opt), rfx
+  <ex>encomendar
+  <todo>
+  </type>
   """.
 
-v_np-ppa*_rfx_le := v_np-ppa*_rfx_lex.
 
-;  <type val="v_np-ppa*_idm_le">
-;  <description>Verb, NP and PPa (opt), idiom
-;  <ex>hacer falta
-;  <todo>
-;  </type>
+v_np-ppa*_rfx_le := v_np-ppa*_rfx_lex
+  """
+  
+  """.
+
+
 v_np-ppa*_idm_native_le := v_np-ppa*_idm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-ppa*_idm_le">
+  <description>Verb, NP and PPa (opt), idiom
+  <ex>hacer falta
+  <todo>
+  </type>
   """.
 
-v_np-ppa*_idm_le := v_np-ppa*_idm_lex.
 
-;  <type val="v_vp_inf-sc_le">
-;  <description>Verb, VPinf (sbj_ctrl)
-;  <ex>¿has intentado hacerlo (tú)?
-;  <todo>
-;  </type>
+v_np-ppa*_idm_le := v_np-ppa*_idm_lex
+  """
+  
+  """.
+
+
 v_vp_inf-sc_native_le := v_vp_inf-sc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_inf-sc_le">
+  <description>Verb, VPinf (sbj_ctrl)
+  <ex>¿has intentado hacerlo (tú)?
+  <todo>
+  </type>
   """.
 
-v_vp_inf-sc_le := v_vp_inf-sc_lex.
 
-;  <type val="v_vp_inf-oc-prn_le">
-;  <description>Verb (pron), VPinf (obj_ctrl)
-;  <ex>se dejó querer  
-;  <todo>
-;  </type>
+v_vp_inf-sc_le := v_vp_inf-sc_lex
+  """
+  
+  """.
+
+
 v_vp_inf-oc-prn_native_le := v_vp_inf-oc-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_inf-oc-prn_le">
+  <description>Verb (pron), VPinf (obj_ctrl)
+  <ex>se dejó querer
+  <todo>
+  </type>
   """.
 
-v_vp_inf-oc-prn_le := v_vp_inf-oc-prn_lex.
 
-;  <type val="v_vp_inf-ser_le">
-;  <description>Verb (ser), VPinf (no_ctrl)
-;  <ex>El error fue haberlo comprado en rebajas.
-;  <todo>
-;  </type>
+v_vp_inf-oc-prn_le := v_vp_inf-oc-prn_lex
+  """
+  
+  """.
+
+
 v_vp_inf-ser_native_le := v_vp_inf-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_inf-ser_le">
+  <description>Verb (ser), VPinf (no_ctrl)
+  <ex>El error fue haberlo comprado en rebajas.
+  <todo>
+  </type>
   """.
 
-v_vp_inf-ser_le := v_vp_inf-ser_lex.
 
-;  <type val="v_cp_p-ser_le">
-;  <description>Verb (ser), Sent
-;  <ex>El error fue que vinieran
-;  <todo>
-;  </type>
+v_vp_inf-ser_le := v_vp_inf-ser_lex
+  """
+  
+  """.
+
+
 v_cp_p-ser_native_le := v_cp_p-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_p-ser_le">
+  <description>Verb (ser), Sent
+  <ex>El error fue que vinieran
+  <todo>
+  </type>
   """.
 
-v_cp_p-ser_le := v_cp_p-ser_lex.
 
-;  <type val="v_cp_p_le">
-;  <description>Verb, Sent
-;  <ex>no entiende que la quiero/quisiera
-;  <todo>
-;  </type>
+v_cp_p-ser_le := v_cp_p-ser_lex
+  """
+  
+  """.
+
+
 v_cp_p_native_le := v_cp_p_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_p_le">
+  <description>Verb, Sent
+  <ex>no entiende que la quiero/quisiera
+  <todo>
+  </type>
   """.
 
-v_cp_p_le := v_cp_p_lex.
 
-;  <type val="v_cp_p-ind_le">
-;  <description>Verb, Sent (ind)
-;  <ex>¿Crees que aceptará?
-;  <todo>
-;  </type>
+v_cp_p_le := v_cp_p_lex
+  """
+  
+  """.
+
+
 v_cp_p-ind_native_le := v_cp_p-ind_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_p-ind_le">
+  <description>Verb, Sent (ind)
+  <ex>¿Crees que aceptará?
+  <todo>
+  </type>
   """.
 
-v_cp_p-ind_le := v_cp_p-ind_lex.
 
-;  <type val="v_cp_p-ind-prn_le">
-;  <description>Verb (pron), Sent. (ind)
-;  <ex>se figura que vendrá
-;  <todo>
-;  </type>
+v_cp_p-ind_le := v_cp_p-ind_lex
+  """
+  
+  """.
+
+
 v_cp_p-ind-prn_native_le := v_cp_p-ind-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_p-ind-prn_le">
+  <description>Verb (pron), Sent. (ind)
+  <ex>se figura que vendrá
+  <todo>
+  </type>
   """.
 
-v_cp_p-ind-prn_le := v_cp_p-ind-prn_lex.
 
-;  <type val="v_cp_p-sub_le">
-;  <description>Verb, Sent. (subj)
-;  <ex>dudo que venga
-;  <todo>
-;  </type>
+v_cp_p-ind-prn_le := v_cp_p-ind-prn_lex
+  """
+  
+  """.
+
+
 v_cp_p-sub_native_le := v_cp_p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_p-sub_le">
+  <description>Verb, Sent. (subj)
+  <ex>dudo que venga
+  <todo>
+  </type>
   """.
 
-v_cp_p-sub_le := v_cp_p-sub_lex.
 
-;  <type val="v_cp_p-sub-optcm_le">
-;  <description>Verb, Sent. (subj, opt. complementizer)
-;  <ex>(siento (que) no hayáis recibido el paquete
-;  <todo>
-;  </type>
+v_cp_p-sub_le := v_cp_p-sub_lex
+  """
+  
+  """.
+
+
 v_cp_p-sub-optcm_native_le := v_cp_p-sub-optcm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_p-sub-optcm_le">
+  <description>Verb, Sent. (subj, opt. complementizer)
+  <ex>(siento (que) no hayáis recibido el paquete
+  <todo>
+  </type>
   """.
 
-v_cp_p-sub-optcm_le := v_cp_p-sub-optcm_lex.
 
-;  <type val="v_cp_q-optcm_le">
-;  <description>Verb, Ques (opt. complementizer)
-;  <ex>La maestra inquirió (que) por qué había estado ausente tantos días
-;  <todo>
-;  </type>
+v_cp_p-sub-optcm_le := v_cp_p-sub-optcm_lex
+  """
+  
+  """.
+
+
 v_cp_q-optcm_native_le := v_cp_q-optcm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_q-optcm_le">
+  <description>Verb, Ques (opt. complementizer)
+  <ex>La maestra inquirió (que) por qué había estado ausente tantos días
+  <todo>
+  </type>
   """.
 
-v_cp_q-optcm_le := v_cp_q-optcm_lex.
 
-;  <type val="v_cp_q-optcm-prn_le">
-;  <description>Verb (pron), Ques (opt. complementizer)
-;  <ex>se preguntó (que) dónde había ido.
-;  <todo>
-;  </type>
+v_cp_q-optcm_le := v_cp_q-optcm_lex
+  """
+  
+  """.
+
+
 v_cp_q-optcm-prn_native_le := v_cp_q-optcm-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_q-optcm-prn_le">
+  <description>Verb (pron), Ques (opt. complementizer)
+  <ex>se preguntó (que) dónde había ido.
+  <todo>
+  </type>
   """.
 
-v_cp_q-optcm-prn_le := v_cp_q-optcm-prn_lex.
 
-;  <type val="v_cp_q-cm_le">
-;  <description>Verb, Ques (oblig. complementizer)
-;  <ex>gritó que dónde habíamos puesto el dinero 
-;  <todo>
-;  </type>
+v_cp_q-optcm-prn_le := v_cp_q-optcm-prn_lex
+  """
+  
+  """.
+
+
 v_cp_q-cm_native_le := v_cp_q-cm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_q-cm_le">
+  <description>Verb, Ques (oblig. complementizer)
+  <ex>gritó que dónde habíamos puesto el dinero
+  <todo>
+  </type>
   """.
 
-v_cp_q-cm_le := v_cp_q-cm_lex.
 
-;  <type val="v_cp_q_le">
-;  <description>Verb, Ques (no complementizer)
-;  <ex>dijo quién ganaría
-;  <todo>
-;  </type>
+v_cp_q-cm_le := v_cp_q-cm_lex
+  """
+  
+  """.
+
+
 v_cp_q_native_le := v_cp_q_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_cp_q_le">
+  <description>Verb, Ques (no complementizer)
+  <ex>dijo quién ganaría
+  <todo>
+  </type>
   """.
 
-v_cp_q_le := v_cp_q_lex.
 
-;  <type val="v_ppa*-cp_p_le">
-;  <description>Verb, PPa and Sent (ind/sub)
-;  <ex>
-;  <todo>
-;  </type>
+v_cp_q_le := v_cp_q_lex
+  """
+  
+  """.
+
+
 v_ppa*-cp_p_native_le := v_ppa*-cp_p_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-cp_p_le">
+  <description>Verb, PPa and Sent (ind/sub)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_ppa*-cp_p_le := v_ppa*-cp_p_lex.
 
-;  <type val="v_ppa*-cp_p-ind_le">
-;  <description>Verb, PPa and Sent (ind)
-;  <ex>(le) prometí que lo harían
-;  <todo>
-;  </type>
+v_ppa*-cp_p_le := v_ppa*-cp_p_lex
+  """
+  
+  """.
+
+
 v_ppa*-cp_p-ind_native_le := v_ppa*-cp_p-ind_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-cp_p-ind_le">
+  <description>Verb, PPa and Sent (ind)
+  <ex>(le) prometí que lo harían
+  <todo>
+  </type>
   """.
 
-v_ppa*-cp_p-ind_le := v_ppa*-cp_p-ind_lex.
 
-;  <type val="v_ppa*-cp_p-ind-optcm_le">
-;  <description>Verb, Verb, PPa and Sent (ind, opt. complementizer)
-;  <ex>
-;  <todo>
-;  </type>
+v_ppa*-cp_p-ind_le := v_ppa*-cp_p-ind_lex
+  """
+  
+  """.
+
+
 v_ppa*-cp_p-ind-optcm_native_le := v_ppa*-cp_p-ind-optcm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-cp_p-ind-optcm_le">
+  <description>Verb, Verb, PPa and Sent (ind, opt. complementizer)
+  <ex>
+  <todo>
+  </type>
   """.
 
-v_ppa*-cp_p-ind-optcm_le := v_ppa*-cp_p-ind-optcm_lex.
 
-;  <type val="v_ppa*-cp_p-sub_le">
-;  <description>Verb, PPa and Sent (sub)
-;  <ex>le ordené que volviese temprano
-;  <todo>
-;  </type>
+v_ppa*-cp_p-ind-optcm_le := v_ppa*-cp_p-ind-optcm_lex
+  """
+  
+  """.
+
+
 v_ppa*-cp_p-sub_native_le := v_ppa*-cp_p-sub_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-cp_p-sub_le">
+  <description>Verb, PPa and Sent (sub)
+  <ex>le ordené que volviese temprano
+  <todo>
+  </type>
   """.
 
-v_ppa*-cp_p-sub_le := v_ppa*-cp_p-sub_lex.
 
-;  <type val="v_ppa*-cp_p-sub-optcm_le">
-;  <description>Verb, PPa and Sent (sub, opt complementizer)
-;  <ex>te ruego (que) me envíes
-;  <todo>
-;  </type>
+v_ppa*-cp_p-sub_le := v_ppa*-cp_p-sub_lex
+  """
+  
+  """.
+
+
 v_ppa*-cp_p-sub-optcm_native_le := v_ppa*-cp_p-sub-optcm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-cp_p-sub-optcm_le">
+  <description>Verb, PPa and Sent (sub, opt complementizer)
+  <ex>te ruego (que) me envíes
+  <todo>
+  </type>
   """.
 
-v_ppa*-cp_p-sub-optcm_le := v_ppa*-cp_p-sub-optcm_lex.
 
-;  <type val="v_ppa*-cp_q-optcm_le">
-;  <description>Verb, PPa and Ques (opt. complementizer)
-;  <ex>(me) preguntó (que) cómo lo habían hecho
-;  <todo>
-;  </type>
+v_ppa*-cp_p-sub-optcm_le := v_ppa*-cp_p-sub-optcm_lex
+  """
+  
+  """.
+
+
 v_ppa*-cp_q-optcm_native_le := v_ppa*-cp_q-optcm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-cp_q-optcm_le">
+  <description>Verb, PPa and Ques (opt. complementizer)
+  <ex>(me) preguntó (que) cómo lo habían hecho
+  <todo>
+  </type>
   """.
 
-v_ppa*-cp_q-optcm_le := v_ppa*-cp_q-optcm_lex.
 
-;  <type val="v_ppa*-cp_q-cm_le">
-;  <description>Verb, PPa and Ques (oblig. complementizer)
-;  <ex>(me) chillar que dónde lo podía
-;  <todo>
-;  </type>
+v_ppa*-cp_q-optcm_le := v_ppa*-cp_q-optcm_lex
+  """
+  
+  """.
+
+
 v_ppa*-cp_q-cm_native_le := v_ppa*-cp_q-cm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-cp_q-cm_le">
+  <description>Verb, PPa and Ques (oblig. complementizer)
+  <ex>(me) chillar que dónde lo podía
+  <todo>
+  </type>
   """.
 
-v_ppa*-cp_q-cm_le := v_ppa*-cp_q-cm_lex.
 
-;  <type val="v_ppa*-cp_q_le">
-;  <description>Verb, PPa and Ques (no complementizer)
-;  <ex>(me) declaró cómo lo había hecho
-;  <todo>
-;  </type>
+v_ppa*-cp_q-cm_le := v_ppa*-cp_q-cm_lex
+  """
+  
+  """.
+
+
 v_ppa*-cp_q_native_le := v_ppa*-cp_q_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ppa*-cp_q_le">
+  <description>Verb, PPa and Ques (no complementizer)
+  <ex>(me) declaró cómo lo había hecho
+  <todo>
+  </type>
   """.
 
-v_ppa*-cp_q_le := v_ppa*-cp_q_lex.
 
-;  <type val="v_np-vp_inf-osr_le">
-;  <description>Verb, NP and VPinf (object to subject raising, perception verbs)
-;  <ex>casi te oí decir
-;  <todo>
-;  </type>
+v_ppa*-cp_q_le := v_ppa*-cp_q_lex
+  """
+  
+  """.
+
+
 v_np-vp_inf-osr_native_le := v_np-vp_inf-osr_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-vp_inf-osr_le">
+  <description>Verb, NP and VPinf (object to subject raising, perception verbs)
+  <ex>casi te oí decir
+  <todo>
+  </type>
   """.
 
-v_np-vp_inf-osr_le := v_np-vp_inf-osr_lex.
 
-;  <type val="v_np-vp_ger-osr_le">
-;  <description>Verb, NP and VPger (object to subject raising, perception verbs)
-;  <ex>la sorprendí robando
-;  <todo>
-;  </type>
+v_np-vp_inf-osr_le := v_np-vp_inf-osr_lex
+  """
+  
+  """.
+
+
 v_np-vp_ger-osr_native_le := v_np-vp_ger-osr_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-vp_ger-osr_le">
+  <description>Verb, NP and VPger (object to subject raising, perception verbs)
+  <ex>la sorprendí robando
+  <todo>
+  </type>
   """.
 
-v_np-vp_ger-osr_le := v_np-vp_ger-osr_lex.
 
-;  <type val="v_pp_e-sym_le">
-;  <description>Verb, PPsel / plural subject (symmetric)
-;  <ex>A conversa con B/A y B conversan
-;  <todo>
-;  </type>
+v_np-vp_ger-osr_le := v_np-vp_ger-osr_lex
+  """
+  
+  """.
+
+
 v_pp_e-sym_native_le := v_pp_e-sym_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-sym_le">
+  <description>Verb, PPsel / plural subject (symmetric)
+  <ex>A conversa con B/A y B conversan
+  <todo>
+  </type>
   """.
 
-v_pp_e-sym_le := v_pp_e-sym_lex.
 
-;  <type val="v_pp*_e-sym_le">
-;  <description>Verb, PPsel (opt) / plural subject (symmetric)
-;  <ex>A colaboró (con B)/A y B colaboran
-;  <todo>
-;  </type>
+v_pp_e-sym_le := v_pp_e-sym_lex
+  """
+  
+  """.
+
+
 v_pp*_e-sym_native_le := v_pp*_e-sym_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp*_e-sym_le">
+  <description>Verb, PPsel (opt) / plural subject (symmetric)
+  <ex>A colaboró (con B)/A y B colaboran
+  <todo>
+  </type>
   """.
 
-v_pp*_e-sym_le := v_pp*_e-sym_lex.
 
-;  <type val="v_pp_e-sym-prn_le">
-;  <description>Verb (pron), PPsel / plural subject (symmetric)
-;  <ex>A se pelea con B / A y B se pelean
-;  <todo>
-;  </type>
+v_pp*_e-sym_le := v_pp*_e-sym_lex
+  """
+  
+  """.
+
+
 v_pp_e-sym-prn_native_le := v_pp_e-sym-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-sym-prn_le">
+  <description>Verb (pron), PPsel / plural subject (symmetric)
+  <ex>A se pelea con B / A y B se pelean
+  <todo>
+  </type>
   """.
 
-v_pp_e-sym-prn_le := v_pp_e-sym-prn_lex.
 
-;  <type val="v_pp-pp_e-e-cp-p-sym_le">
-;  <description>Verb, PPsel and PPsel (Sent/VPinf sbj_ctrl) /plural subject and PPsel (Sent/VPinf sbj_ctrl)
-;  <ex>quedé con ella en ir al cine / quedamos en ir al cine
-;  <todo>
-;  </type>
+v_pp_e-sym-prn_le := v_pp_e-sym-prn_lex
+  """
+  
+  """.
+
+
 v_pp-pp_e-e-cp-p-sym_native_le := v_pp-pp_e-e-cp-p-sym_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp-pp_e-e-cp-p-sym_le">
+  <description>Verb, PPsel and PPsel (Sent/VPinf sbj_ctrl) /plural subject and PPsel (Sent/VPinf sbj_ctrl)
+  <ex>quedé con ella en ir al cine / quedamos en ir al cine
+  <todo>
+  </type>
   """.
 
-v_pp-pp_e-e-cp-p-sym_le := v_pp-pp_e-e-cp-p-sym_lex.
 
-;  <type val="v_pp-cp_e-p-sym_le">
-;  <description>Verb, PPsel and Sent/VPinf (sbj_ctrl) /plural subject and Sent/VPinf (sbj_ctrl)
-;  <ex>A acordó con B no hablar/que no hablarían; A y B acordaron no hablar/que no hablarían)
-;  <todo>
-;  </type>
+v_pp-pp_e-e-cp-p-sym_le := v_pp-pp_e-e-cp-p-sym_lex
+  """
+  
+  """.
+
+
 v_pp-cp_e-p-sym_native_le := v_pp-cp_e-p-sym_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp-cp_e-p-sym_le">
+  <description>Verb, PPsel and Sent/VPinf (sbj_ctrl) /plural subject and Sent/VPinf (sbj_ctrl)
+  <ex>A acordó con B no hablar/que no hablarían; A y B acordaron no hablar/que no hablarían)
+  <todo>
+  </type>
   """.
 
-v_pp-cp_e-p-sym_le := v_pp-cp_e-p-sym_lex.
 
-;  <type val="v_np-pp*_e-sym-sbj-pl_le">
-;  <description>Verb, NP and PPsel (opt) / plural Subj and DO
-;  <ex>Ambos grupos comparten un fondo genético común.
-;  <todo>
-;  </type>
+v_pp-cp_e-p-sym_le := v_pp-cp_e-p-sym_lex
+  """
+  
+  """.
+
+
 v_np-pp*_e-sym-sbj-pl_native_le := v_np-pp*_e-sym-sbj-pl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_e-sym-sbj-pl_le">
+  <description>Verb, NP and PPsel (opt) / plural Subj and DO
+  <ex>Ambos grupos comparten un fondo genético común.
+  <todo>
+  </type>
   """.
 
-v_np-pp*_e-sym-sbj-pl_le := v_np-pp*_e-sym-sbj-pl_lex.
 
-;  <type val="v_np-pp_e-sym_le">
-;  <description>Verb, NP and PPsel / plural NP
-;  <ex>confrontará la docencia a/con la investigación/confrontará la docencia y la investigación)
-;  <todo>
-;  </type>
+v_np-pp*_e-sym-sbj-pl_le := v_np-pp*_e-sym-sbj-pl_lex
+  """
+  
+  """.
+
+
 v_np-pp_e-sym_native_le := v_np-pp_e-sym_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_e-sym_le">
+  <description>Verb, NP and PPsel / plural NP
+  <ex>confrontará la docencia a/con la investigación/confrontará la docencia y la investigación)
+  <todo>
+  </type>
   """.
 
-v_np-pp_e-sym_le := v_np-pp_e-sym_lex.
 
-;  <type val="v_np-pp*_e-sym_le">
-;  <description>Verb, NP and PPsel (opt) / plural NP
-;  <ex>compatibilizará la docencia xon la investigación/compatibilizará la docencia y la investigación)
-;  <todo>
-;  </type>
+v_np-pp_e-sym_le := v_np-pp_e-sym_lex
+  """
+  
+  """.
+
+
 v_np-pp*_e-sym_native_le := v_np-pp*_e-sym_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_e-sym_le">
+  <description>Verb, NP and PPsel (opt) / plural NP
+  <ex>compatibilizará la docencia xon la investigación/compatibilizará la docencia y la investigación)
+  <todo>
+  </type>
   """.
 
-v_np-pp*_e-sym_le := v_np-pp*_e-sym_lex.
 
-;  <type val="v_ap_seq_le">
-;  <description>Verb, AP (predicative)
-;  <ex>el anciano cayó enfermo
-;  <todo>
-;  </type>
+v_np-pp*_e-sym_le := v_np-pp*_e-sym_lex
+  """
+  
+  """.
+
+
 v_ap_seq_native_le := v_ap_seq_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ap_seq_le">
+  <description>Verb, AP (predicative)
+  <ex>el anciano cayó enfermo
+  <todo>
+  </type>
   """.
 
-v_ap_seq_le := v_ap_seq_lex.
 
-;  <type val="v_pp_seq_le">
-;  <description>Verb, PP (predicative)
-;  <ex>trabaja de/como camarera
-;  <todo>
-;  </type>
+v_ap_seq_le := v_ap_seq_lex
+  """
+  
+  """.
+
+
 v_pp_seq_native_le := v_pp_seq_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_seq_le">
+  <description>Verb, PP (predicative)
+  <ex>trabaja de/como camarera
+  <todo>
+  </type>
   """.
 
-v_pp_seq_le := v_pp_seq_lex.
 
-;  <type val="v_pp_aj-seq_le">
-;  <description>Verb, PP (Prep+AP) (predicative)
-;  <ex>alardea de listo
-;  <todo>
-;  </type>
+v_pp_seq_le := v_pp_seq_lex
+  """
+  
+  """.
+
+
 v_pp_aj-seq_native_le := v_pp_aj-seq_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_aj-seq_le">
+  <description>Verb, PP (Prep+AP) (predicative)
+  <ex>alardea de listo
+  <todo>
+  </type>
   """.
 
-v_pp_aj-seq_le := v_pp_aj-seq_lex.
 
-;  <type val="v_pp_vp-inf-seq_le">
-;  <description>Verb, PP (Prep+AP) (predicative)
-;  <ex>alardea de listo
-;  <todo>
-;  </type>
+v_pp_aj-seq_le := v_pp_aj-seq_lex
+  """
+  
+  """.
+
+
 v_pp_vp-inf-seq_native_le := v_pp_vp-inf-seq_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_vp-inf-seq_le">
+  <description>Verb, PP (Prep+AP) (predicative)
+  <ex>alardea de listo
+  <todo>
+  </type>
   """.
 
-v_pp_vp-inf-seq_le := v_pp_vp-inf-seq_lex.
 
-;  <type val="v_ap_seq-prn_le">
-;  <description>Verb (pron), AP (predicative)
-;  <ex>se cree muy listo
-;  <todo>
-;  </type>
+v_pp_vp-inf-seq_le := v_pp_vp-inf-seq_lex
+  """
+  
+  """.
+
+
 v_ap_seq-prn_native_le := v_ap_seq-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ap_seq-prn_le">
+  <description>Verb (pron), AP (predicative)
+  <ex>se cree muy listo
+  <todo>
+  </type>
   """.
 
-v_ap_seq-prn_le := v_ap_seq-prn_lex.
 
-;  <type val="v_ap*_seq-prn_le">
-;  <description>Verb (pron), AP (predicative,opt) 
-;  <ex>se mostró muy crítico
-;  <todo>
-;  </type>
+v_ap_seq-prn_le := v_ap_seq-prn_lex
+  """
+  
+  """.
+
+
 v_ap*_seq-prn_native_le := v_ap*_seq-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ap*_seq-prn_le">
+  <description>Verb (pron), AP (predicative,opt)
+  <ex>se mostró muy crítico
+  <todo>
+  </type>
   """.
 
-v_ap*_seq-prn_le := v_ap*_seq-prn_lex.
 
-;  <type val="v_pp_seq-prn_le">
-;  <description>Verb (pron), PP (predicative) 
-;  <ex>se perfila como campeón
-;  <todo>
-;  </type>
+v_ap*_seq-prn_le := v_ap*_seq-prn_lex
+  """
+  
+  """.
+
+
 v_pp_seq-prn_native_le := v_pp_seq-prn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_seq-prn_le">
+  <description>Verb (pron), PP (predicative)
+  <ex>se perfila como campeón
+  <todo>
+  </type>
   """.
 
-v_pp_seq-prn_le := v_pp_seq-prn_lex.
 
-;  <type val="v_ap-ppa*_seq_le">
-;  <description>Verb, AP and PPa (predicative) 
-;  <ex>(le) resultaba incómodo
-;  <todo>
-;  </type>
+v_pp_seq-prn_le := v_pp_seq-prn_lex
+  """
+  
+  """.
+
+
 v_ap-ppa*_seq_native_le := v_ap-ppa*_seq_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ap-ppa*_seq_le">
+  <description>Verb, AP and PPa (predicative)
+  <ex>(le) resultaba incómodo
+  <todo>
+  </type>
   """.
 
-v_ap-ppa*_seq_le := v_ap-ppa*_seq_lex.
 
-;  <type val="v_np-ppa*_seq_le">
-;  <description>Verb, NP and PPa (predicative) 
-;  <ex>(me) parece un bombazo
-;  <todo>
-;  </type>
+v_ap-ppa*_seq_le := v_ap-ppa*_seq_lex
+  """
+  
+  """.
+
+
 v_np-ppa*_seq_native_le := v_np-ppa*_seq_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-ppa*_seq_le">
+  <description>Verb, NP and PPa (predicative)
+  <ex>(me) parece un bombazo
+  <todo>
+  </type>
   """.
 
-v_np-ppa*_seq_le := v_np-ppa*_seq_lex.
 
-;  <type val="v_np-ap_sor_le">
-;  <description>Verb, NP and AP (predicative) 
-;  <ex>lo dejaron KO
-;  <todo>
-;  </type>
+v_np-ppa*_seq_le := v_np-ppa*_seq_lex
+  """
+  
+  """.
+
+
 v_np-ap_sor_native_le := v_np-ap_sor_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-ap_sor_le">
+  <description>Verb, NP and AP (predicative)
+  <ex>lo dejaron KO
+  <todo>
+  </type>
   """.
 
-v_np-ap_sor_le := v_np-ap_sor_lex.
 
-;  <type val="v_np-ap_sor-rfx_le">
-;  <description>Verb, NP and AP, rfx, (predicative) 
-;  <ex>lo declararon culpable
-;  <todo>
-;  </type>
+v_np-ap_sor_le := v_np-ap_sor_lex
+  """
+  
+  """.
+
+
 v_np-ap_sor-rfx_native_le := v_np-ap_sor-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-ap_sor-rfx_le">
+  <description>Verb, NP and AP, rfx, (predicative)
+  <ex>lo declararon culpable
+  <todo>
+  </type>
   """.
 
-v_np-ap_sor-rfx_le := v_np-ap_sor-rfx_lex.
 
-;  <type val="v_np-pp_sor_le">
-;  <description>Verb, NP and PP (predicative) 
-;  <ex>¿me tomas por tonto?
-;  <todo>
-;  </type>
+v_np-ap_sor-rfx_le := v_np-ap_sor-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp_sor_native_le := v_np-pp_sor_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_sor_le">
+  <description>Verb, NP and PP (predicative)
+  <ex>¿me tomas por tonto?
+  <todo>
+  </type>
   """.
 
-v_np-pp_sor_le := v_np-pp_sor_lex.
 
-;  <type val="v_np-pp_sor-rfx_le">
-;  <description>Verb, NP and PP (predicative), rfx 
-;  <ex>lo proclamaron como...
-;  <todo>
-;  </type>
+v_np-pp_sor_le := v_np-pp_sor_lex
+  """
+  
+  """.
+
+
 v_np-pp_sor-rfx_native_le := v_np-pp_sor-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_sor-rfx_le">
+  <description>Verb, NP and PP (predicative), rfx
+  <ex>lo proclamaron como...
+  <todo>
+  </type>
   """.
 
-v_np-pp_sor-rfx_le := v_np-pp_sor-rfx_lex.
 
-;  <type val="v_np-pp*_oeq-rfx_le">
-;  <description>Verb, NP and PP (opt), (predicative), rfx 
-;  <ex>se disfrazó (de pirata)
-;  <todo>
-;  </type>
+v_np-pp_sor-rfx_le := v_np-pp_sor-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp*_oeq-rfx_native_le := v_np-pp*_oeq-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp*_oeq-rfx_le">
+  <description>Verb, NP and PP (opt), (predicative), rfx
+  <ex>se disfrazó (de pirata)
+  <todo>
+  </type>
   """.
 
-v_np-pp*_oeq-rfx_le := v_np-pp*_oeq-rfx_lex.
 
-;  <type val="v_np-pp_aj-oeq_le">
-;  <description>Verb, NP and PP adj, (predicative), rfx 
-;  <ex>un libro que no vaciló en calificar de importante
-;  <todo>
-;  </type>
+v_np-pp*_oeq-rfx_le := v_np-pp*_oeq-rfx_lex
+  """
+  
+  """.
+
+
 v_np-pp_aj-oeq_native_le := v_np-pp_aj-oeq_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_aj-oeq_le">
+  <description>Verb, NP and PP adj, (predicative), rfx
+  <ex>un libro que no vaciló en calificar de importante
+  <todo>
+  </type>
   """.
 
-v_np-pp_aj-oeq_le := v_np-pp_aj-oeq_lex.
 
-;  <type val="v_np-pp_aj-oeq-rfx_le">
-;  <description>Verb, NP and PP adj, (predicative), rfx 
-;  <ex>un libro que no vaciló en calificar de importante
-;  <todo>
-;  </type>
+v_np-pp_aj-oeq_le := v_np-pp_aj-oeq_lex
+  """
+  
+  """.
+
+
 v_np-pp_aj-oeq-rfx_native_le := v_np-pp_aj-oeq-rfx_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_np-pp_aj-oeq-rfx_le">
+  <description>Verb, NP and PP adj, (predicative), rfx
+  <ex>un libro que no vaciló en calificar de importante
+  <todo>
+  </type>
   """.
 
-v_np-pp_aj-oeq-rfx_le := v_np-pp_aj-oeq-rfx_lex.
 
-;  <type val="v_ap_ser_le">
-;  <description>Verb (ser), AP
-;  <ex>Juan es feo
-;  <todo>
-;  </type>
+v_np-pp_aj-oeq-rfx_le := v_np-pp_aj-oeq-rfx_lex
+  """
+  
+  """.
+
+
 v_ap_ser_native_le := v_ap_ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ap_ser_le">
+  <description>Verb (ser), AP
+  <ex>Juan es feo
+  <todo>
+  </type>
   """.
 
-v_ap_ser_le := v_ap_ser_lex.
 
-;  <type val="v_pp_ser_le">
-;  <description>Verb (ser), PP
-;  <ex>Juan es de esta ciudad
-;  <todo>
-;  </type>
+v_ap_ser_le := v_ap_ser_lex
+  """
+  
+  """.
+
+
 v_pp_ser_native_le := v_pp_ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_ser_le">
+  <description>Verb (ser), PP
+  <ex>Juan es de esta ciudad
+  <todo>
+  </type>
   """.
 
-v_pp_ser_le := v_pp_ser_lex.
 
-;  <type val="v_modnp_ser_le">
-;  <description>Verb (ser), temporal NP
-;  <ex>la reunión fue la semana pasada
-;  <todo>
-;  </type>
+v_pp_ser_le := v_pp_ser_lex
+  """
+  
+  """.
+
+
 v_modnp_ser_native_le := v_modnp_ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_modnp_ser_le">
+  <description>Verb (ser), temporal NP
+  <ex>la reunión fue la semana pasada
+  <todo>
+  </type>
   """.
 
-v_modnp_ser_le := v_modnp_ser_lex.
 
-;  <type val="v_pp_e-vp-inf-ser_le">
-;  <description>Verb (ser), PPsel (VPinf)
-;  <ex>Es como pulsar una tecla de un simple vistazo.
-;  <todo>
-;  </type>
+v_modnp_ser_le := v_modnp_ser_lex
+  """
+  
+  """.
+
+
 v_pp_e-vp-inf-ser_native_le := v_pp_e-vp-inf-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-vp-inf-ser_le">
+  <description>Verb (ser), PPsel (VPinf)
+  <ex>Es como pulsar una tecla de un simple vistazo.
+  <todo>
+  </type>
   """.
 
-v_pp_e-vp-inf-ser_le := v_pp_e-vp-inf-ser_lex.
 
-;  <type val="v_vp_ppart-ser_le">
-;  <description>Verb (ser), VPppart
-;  <ex>fue atacado
-;  <todo>
-;  </type>
+v_pp_e-vp-inf-ser_le := v_pp_e-vp-inf-ser_lex
+  """
+  
+  """.
+
+
 v_vp_ppart-ser_native_le := v_vp_ppart-ser_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_ppart-ser_le">
+  <description>Verb (ser), VPppart
+  <ex>fue atacado
+  <todo>
+  </type>
   """.
 
-v_vp_ppart-ser_le := v_vp_ppart-ser_lex.
 
-;  <type val="v_vp_ppart-ser_le">
-;  <description>Verb (estar), VPppart
-;  <ex>está muerto
-;  <todo>
-;  </type>
+v_vp_ppart-ser_le := v_vp_ppart-ser_lex
+  """
+  
+  """.
+
+
 v_vp_ppart-estar_native_le := v_vp_ppart-estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_ppart-ser_le">
+  <description>Verb (estar), VPppart
+  <ex>está muerto
+  <todo>
+  </type>
   """.
 
-v_vp_ppart-estar_le := v_vp_ppart-estar_lex.
 
-;  <type val="v_ap_estar_le">
-;  <description>Verb (estar), AP
-;  <ex>Juan está guapo
-;  <todo>
-;  </type>
+v_vp_ppart-estar_le := v_vp_ppart-estar_lex
+  """
+  
+  """.
+
+
 v_ap_estar_native_le := v_ap_estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_ap_estar_le">
+  <description>Verb (estar), AP
+  <ex>Juan está guapo
+  <todo>
+  </type>
   """.
 
-v_ap_estar_le := v_ap_estar_lex.
 
-;  <type val="v_pp_estar_le">
-;  <description>Verb (estar), PP
-;  <ex>Juan está en la ciudad
-;  <todo>
-;  </type>
+v_ap_estar_le := v_ap_estar_lex
+  """
+  
+  """.
+
+
 v_pp_estar_native_le := v_pp_estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_estar_le">
+  <description>Verb (estar), PP
+  <ex>Juan está en la ciudad
+  <todo>
+  </type>
   """.
 
-v_pp_estar_le := v_pp_estar_lex.
 
-;  <type val="v_adv_estar_le">
-;  <description>Verb (estar), ADV 
-;  <ex>¿Dónde/cómo está Juan?
-;  <todo>
-;  </type>
+v_pp_estar_le := v_pp_estar_lex
+  """
+  
+  """.
+
+
 v_adv_estar_native_le := v_adv_estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_adv_estar_le">
+  <description>Verb (estar), ADV
+  <ex>¿Dónde/cómo está Juan?
+  <todo>
+  </type>
   """.
 
-v_adv_estar_le := v_adv_estar_lex.
 
-;  <type val="v_modnp_estar_le">
-;  <description>Verb (estar), MODNP
-;  <ex>Ahí está Juan
-;  <todo>
-;  </type>
+v_adv_estar_le := v_adv_estar_lex
+  """
+  
+  """.
+
+
 v_modnp_estar_native_le := v_modnp_estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_modnp_estar_le">
+  <description>Verb (estar), MODNP
+  <ex>Ahí está Juan
+  <todo>
+  </type>
   """.
 
-v_modnp_estar_le := v_modnp_estar_lex.
 
-;  <type val="v_pp_e-vp-inf-estar_le">
-;  <description>Verb (estar), PPsel (VPinf)
-;  <ex>todo está por organizar
-;  <todo>
-;  </type>
+v_modnp_estar_le := v_modnp_estar_lex
+  """
+  
+  """.
+
+
 v_pp_e-vp-inf-estar_native_le := v_pp_e-vp-inf-estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_pp_e-vp-inf-estar_le">
+  <description>Verb (estar), PPsel (VPinf)
+  <ex>todo está por organizar
+  <todo>
+  </type>
   """.
 
-v_pp_e-vp-inf-estar_le := v_pp_e-vp-inf-estar_lex.
 
-;  <type val="v_vp_ger-estar_le">
-;  <description>Verb (estar), VPger
-;  <ex>Juan está cantando
-;  <todo>
-;  </type>
+v_pp_e-vp-inf-estar_le := v_pp_e-vp-inf-estar_lex
+  """
+  
+  """.
+
+
 v_vp_ger-estar_native_le := v_vp_ger-estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_ger-estar_le">
+  <description>Verb (estar), VPger
+  <ex>Juan está cantando
+  <todo>
+  </type>
   """.
 
-v_vp_ger-estar_le := v_vp_ger-estar_lex.
 
-;  <type val="v_vp_ger-nsbj-estar_le">
-;  <description>Verb (estar), VPger, no subj 
-;  <ex>está lloviendo
-;  <todo>
-;  </type>
+v_vp_ger-estar_le := v_vp_ger-estar_lex
+  """
+  
+  """.
+
+
 v_vp_ger-nsbj-estar_native_le := v_vp_ger-nsbj-estar_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_ger-nsbj-estar_le">
+  <description>Verb (estar), VPger, no subj
+  <ex>está lloviendo
+  <todo>
+  </type>
   """.
 
-v_vp_ger-nsbj-estar_le := v_vp_ger-nsbj-estar_lex.
 
-;  <type val="v_vp_part-haber_le">
-;  <description>Verb (haber), VP
-;  <ex>ha llorado
-;  <todo>
-;  </type>
+v_vp_ger-nsbj-estar_le := v_vp_ger-nsbj-estar_lex
+  """
+  
+  """.
+
+
 v_vp_part-haber_native_le := v_vp_part-haber_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_part-haber_le">
+  <description>Verb (haber), VP
+  <ex>ha llorado
+  <todo>
+  </type>
   """.
 
-v_vp_part-haber_le := v_vp_part-haber_lex.
 
-;  <type val="v_vp_ppart-haber_le">
-;  <description>Verb (haber), VP passive 
-;  <ex>ha sido visto
-;  <todo>
-;  </type>
+v_vp_part-haber_le := v_vp_part-haber_lex
+  """
+  
+  """.
+
+
 v_vp_ppart-haber_native_le := v_vp_ppart-haber_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_ppart-haber_le">
+  <description>Verb (haber), VP passive
+  <ex>ha sido visto
+  <todo>
+  </type>
   """.
 
-v_vp_ppart-haber_le := v_vp_ppart-haber_lex.
 
-;  <type val="v_vp_part-nsbj-haber_le">
-;  <description>Verb (haber), VP, no subj 
-;  <ex>ha llovido
-;  <todo>
-;  </type>
+v_vp_ppart-haber_le := v_vp_ppart-haber_lex
+  """
+  
+  """.
+
+
 v_vp_part-nsbj-haber_native_le := v_vp_part-nsbj-haber_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="v_vp_part-nsbj-haber_le">
+  <description>Verb (haber), VP, no subj
+  <ex>ha llovido
+  <todo>
+  </type>
   """.
 
-v_vp_part-nsbj-haber_le := v_vp_part-nsbj-haber_lex.
 
-;  <type val="n_-_c_le">
-;  <description> Noun, no compl, count
-;  <ex>el/cualquier niño.
-;  <todo>
+v_vp_part-nsbj-haber_le := v_vp_part-nsbj-haber_lex
+  """
+  
+  """.
+
+
 n_-_c_native_le := n_-_c_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_c_le">
+  <description> Noun, no compl, count
+  <ex>el/cualquier niño.
+  <todo>
   """.
 
-n_-_c_le := n_-_c_lex.
 
-;  <type val="n_-_c-pl_le">
-;  <description> Noun, no compl, count, plural
-;  <ex>las/*la comillas
-;  <todo>
+n_-_c_le := n_-_c_lex
+  """
+  
+  """.
+
+
 n_-_c-pl_native_le := n_-_c-pl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_c-pl_le">
+  <description> Noun, no compl, count, plural
+  <ex>las/*la comillas
+  <todo>
   """.
 
-n_-_c-pl_le := n_-_c-pl_lex.
 
-;  <type val="n_-_m_le">
-;  <description> Noun, no compl, mass
-;  <ex>tiene (bastante/un poco de/*cualquier) acidez.
-;  <todo>
+n_-_c-pl_le := n_-_c-pl_lex
+  """
+  
+  """.
+
+
 n_-_m_native_le := n_-_m_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_m_le">
+  <description> Noun, no compl, mass
+  <ex>tiene (bastante/un poco de/*cualquier) acidez.
+  <todo>
   """.
 
-n_-_m_le := n_-_m_lex.
 
-;  <type val="n_-_m-pl_le">
-;  <description> Noun, no compl, mass, plural
-;  <ex>tiene pocos/un poco de/*tres celos
-;  <todo>
+n_-_m_le := n_-_m_lex
+  """
+  
+  """.
+
+
 n_-_m-pl_native_le := n_-_m-pl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_m-pl_le">
+  <description> Noun, no compl, mass, plural
+  <ex>tiene pocos/un poco de/*tres celos
+  <todo>
   """.
 
-n_-_m-pl_le := n_-_m-pl_lex.
 
-;  <type val="n_-_mc_le">
-;  <description> Noun, no compl, mass-count
-;  <ex> bebió (cualquier/un/un poco de/una copa de) vino
-;  <todo>
+n_-_m-pl_le := n_-_m-pl_lex
+  """
+  
+  """.
+
+
 n_-_mc_native_le := n_-_mc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_mc_le">
+  <description> Noun, no compl, mass-count
+  <ex> bebió (cualquier/un/un poco de/una copa de) vino
+  <todo>
   """.
 
-n_-_mc_le := n_-_mc_lex.
 
-;  <type val="n_-_nc_le">
-;  <description> Noun, no compl, uncount
-;  <ex>*un poco de/bastante abogacía
-;  <todo>
+n_-_mc_le := n_-_mc_lex
+  """
+  
+  """.
+
+
 n_-_nc_native_le := n_-_nc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_nc_le">
+  <description> Noun, no compl, uncount
+  <ex>*un poco de/bastante abogacía
+  <todo>
   """.
 
-n_-_nc_le := n_-_nc_lex.
 
-;  <type val="n_-_col_le">
-;  <description> Noun, no compl, collective
-;  <ex> ejército, manada
-;  <todo>
+n_-_nc_le := n_-_nc_lex
+  """
+  
+  """.
+
+
 n_-_col_native_le := n_-_col_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_col_le">
+  <description> Noun, no compl, collective
+  <ex> ejército, manada
+  <todo>
   """.
 
-n_-_col_le := n_-_col_lex.
 
-;  <type val="n_-_c-tmp_le">
-;  <description> Noun, no compl, count, temporal
-;  <ex>lo vieron ese lunes.
-;  <todo>
+n_-_col_le := n_-_col_lex
+  """
+  
+  """.
+
+
 n_-_c-tmp_native_le := n_-_c-tmp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_c-tmp_le">
+  <description> Noun, no compl, count, temporal
+  <ex>lo vieron ese lunes.
+  <todo>
   """.
 
-n_-_c-tmp_le := n_-_c-tmp_lex.
 
-;  <type val="n_pp_c_le">
-;  <description> Noun, PPde, count
-;  <ex>los amigos de Peter
-;  <todo>
+n_-_c-tmp_le := n_-_c-tmp_lex
+  """
+  
+  """.
+
+
 n_pp_c_native_le := n_pp_c_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_c_le">
+  <description> Noun, PPde, count
+  <ex>los amigos de Peter
+  <todo>
   """.
 
-n_pp_c_le := n_pp_c_lex.
 
-;  <type val="n_pp_m_le">
-;  <description> Noun, PPde, mass
-;  <ex>la lentitud del juicio
-;  <todo>
+n_pp_c_le := n_pp_c_lex
+  """
+  
+  """.
+
+
 n_pp_m_native_le := n_pp_m_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_m_le">
+  <description> Noun, PPde, mass
+  <ex>la lentitud del juicio
+  <todo>
   """.
 
-n_pp_m_le := n_pp_m_lex.
 
-;  <type val="n_pp_mc_le">
-;  <description> Noun, PPde, mass-count
-;  <ex>
-;  <todo>
+n_pp_m_le := n_pp_m_lex
+  """
+  
+  """.
+
+
 n_pp_mc_native_le := n_pp_mc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_mc_le">
+  <description> Noun, PPde, mass-count
+  <ex>
+  <todo>
   """.
 
-n_pp_mc_le := n_pp_mc_lex.
 
-;  <type val="n_pp_nc_le">
-;  <description> Noun, PPde, uncount
-;  <ex>la belleza del cuadro
-;  <todo>
+n_pp_mc_le := n_pp_mc_lex
+  """
+  
+  """.
+
+
 n_pp_nc_native_le := n_pp_nc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_nc_le">
+  <description> Noun, PPde, uncount
+  <ex>la belleza del cuadro
+  <todo>
   """.
 
-n_pp_nc_le := n_pp_nc_lex.
 
-;  <type val="n_pp-pp_de-mc_le">
-;  <description> Noun, PP comp de, PPcomp, mass-count
-;  <ex>la adicción de Juan a los caramelos de menta
-;  <todo>
+n_pp_nc_le := n_pp_nc_lex
+  """
+  
+  """.
+
+
 n_pp-pp_de-mc_native_le := n_pp-pp_de-mc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp-pp_de-mc_le">
+  <description> Noun, PP comp de, PPcomp, mass-count
+  <ex>la adicción de Juan a los caramelos de menta
+  <todo>
   """.
 
-n_pp-pp_de-mc_le := n_pp-pp_de-mc_lex.
 
-;  <type val="n_pp-pp_de-de-mc_le">
-;  <description> Noun, PPde, PPde, mass-count
-;  <ex>l descubrimiento de un científico francés del virus
-;  <todo>
+n_pp-pp_de-mc_le := n_pp-pp_de-mc_lex
+  """
+  
+  """.
+
+
 n_pp-pp_de-de-mc_native_le := n_pp-pp_de-de-mc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp-pp_de-de-mc_le">
+  <description> Noun, PPde, PPde, mass-count
+  <ex>l descubrimiento de un científico francés del virus
+  <todo>
   """.
 
-n_pp-pp_de-de-mc_le := n_pp-pp_de-de-mc_lex.
 
-;  <type val="n_cp_p-mc_le">
-;  <description>Noun, PPde (Sent), mass-count
-;  <ex>no hay duda de que vendrá
-;  <todo>
+n_pp-pp_de-de-mc_le := n_pp-pp_de-de-mc_lex
+  """
+  
+  """.
+
+
 n_cp_p-mc_native_le := n_cp_p-mc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_cp_p-mc_le">
+  <description>Noun, PPde (Sent), mass-count
+  <ex>no hay duda de que vendrá
+  <todo>
   """.
 
-n_cp_p-mc_le := n_cp_p-mc_lex.
 
-;  <type val="n_cp_p-c_le">
-;  <description>Noun, PPde (Sent), count
-;  <ex>una ventaja ((de) que no llueva es que no hay ocasión de perder el paraguas)
-;  <todo>
+n_cp_p-mc_le := n_cp_p-mc_lex
+  """
+  
+  """.
+
+
 n_cp_p-c_native_le := n_cp_p-c_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_cp_p-c_le">
+  <description>Noun, PPde (Sent), count
+  <ex>una ventaja ((de) que no llueva es que no hay ocasión de perder el paraguas)
+  <todo>
   """.
 
-n_cp_p-c_le := n_cp_p-c_lex.
 
-;  <type val="n_cp*_p-c_le">
-;  <description>Noun, PPde (Sent, opt), count
-;  <ex>
-;  <todo>
+n_cp_p-c_le := n_cp_p-c_lex
+  """
+  
+  """.
+
+
 n_cp*_p-c_native_le := n_cp*_p-c_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_cp*_p-c_le">
+  <description>Noun, PPde (Sent, opt), count
+  <ex>
+  <todo>
   """.
 
-n_cp*_p-c_le := n_cp*_p-c_lex.
 
-;  <type val="n_cp_q-c_le">
-;  <description>Noun, PPde (Quest), count
-;  <ex>la incógnita (de cómo se ha utilizado el dinero público)
-;  <todo>
+n_cp*_p-c_le := n_cp*_p-c_lex
+  """
+  
+  """.
+
+
 n_cp_q-c_native_le := n_cp_q-c_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_cp_q-c_le">
+  <description>Noun, PPde (Quest), count
+  <ex>la incógnita (de cómo se ha utilizado el dinero público)
+  <todo>
   """.
 
-n_cp_q-c_le := n_cp_q-c_lex.
 
-;  <type val="n_pp-cp_p-mc_le">
-;  <description>Noun, PPde, PPsel (Sent/VPinf), mass-count
-;  <ex>el interés (de la empresa) (en/por que lleguen a un acuerdo/llegar a un acuerdo)
-;  <todo>
+n_cp_q-c_le := n_cp_q-c_lex
+  """
+  
+  """.
+
+
 n_pp-cp_p-mc_native_le := n_pp-cp_p-mc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp-cp_p-mc_le">
+  <description>Noun, PPde, PPsel (Sent/VPinf), mass-count
+  <ex>el interés (de la empresa) (en/por que lleguen a un acuerdo/llegar a un acuerdo)
+  <todo>
   """.
 
-n_pp-cp_p-mc_le := n_pp-cp_p-mc_lex.
 
-;  <type val="n_pp-vp_mc_le">
-;  <description>Noun, PPde, PPsel (VPinf), mass-count
-;  <ex>la estupidez (de Juan) (de votar a Ernesto).
-;  <todo>
+n_pp-cp_p-mc_le := n_pp-cp_p-mc_lex
+  """
+  
+  """.
+
+
 n_pp-vp_mc_native_le := n_pp-vp_mc_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp-vp_mc_le">
+  <description>Noun, PPde, PPsel (VPinf), mass-count
+  <ex>la estupidez (de Juan) (de votar a Ernesto).
+  <todo>
   """.
 
-n_pp-vp_mc_le := n_pp-vp_mc_lex.
 
-;  <type val="n_pp_part_le">
-;  <description>Noun, PPde, partitive
-;  <ex>la mayoría de senadores votaron/votó en contra
-;  <todo>
+n_pp-vp_mc_le := n_pp-vp_mc_lex
+  """
+  
+  """.
+
+
 n_pp_part_native_le := n_pp_part_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_part_le">
+  <description>Noun, PPde, partitive
+  <ex>la mayoría de senadores votaron/votó en contra
+  <todo>
   """.
 
-n_pp_part_le := n_pp_part_lex.
 
-;  <type val="n_pp_part-nu_le">
-;  <description>Noun, PPde, partitive-numeral
-;  <ex>dos terceras partes 
-;  <todo>
+n_pp_part_le := n_pp_part_lex
+  """
+  
+  """.
+
+
 n_pp_part-nu_native_le := n_pp_part-nu_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_part-nu_le">
+  <description>Noun, PPde, partitive-numeral
+  <ex>dos terceras partes
+  <todo>
   """.
 
-n_pp_part-nu_le := n_pp_part-nu_lex.
 
-;  <type val="n_pp_grp_le">
-;  <description>Noun, PPde, group
-;  <ex>un grupo minoritario de senadores votaron en contra
-;  <todo>
+n_pp_part-nu_le := n_pp_part-nu_lex
+  """
+  
+  """.
+
+
 n_pp_grp_native_le := n_pp_grp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_grp_le">
+  <description>Noun, PPde, group
+  <ex>un grupo minoritario de senadores votaron en contra
+  <todo>
   """.
 
-n_pp_grp_le := n_pp_grp_lex.
 
-;  <type val="n_pp_psd-part_le">
-;  <description>Noun, PPde, pseudo-partitive
-;  <ex>un montón (de libros)
-;  <todo>
+n_pp_grp_le := n_pp_grp_lex
+  """
+  
+  """.
+
+
 n_pp_psd-part_native_le := n_pp_psd-part_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_psd-part_le">
+  <description>Noun, PPde, pseudo-partitive
+  <ex>un montón (de libros)
+  <todo>
   """.
 
-n_pp_psd-part_le := n_pp_psd-part_lex.
 
-;  <type val="n_pp_psd-part-nu-card_le">
-;  <description>Noun, PPde, pseudo-partitive, numeral
-;  <ex>compró tres docenas de huevos
-;  <todo>
+n_pp_psd-part_le := n_pp_psd-part_lex
+  """
+  
+  """.
+
+
 n_pp_psd-part-nu-card_native_le := n_pp_psd-part-nu-card_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_psd-part-nu-card_le">
+  <description>Noun, PPde, pseudo-partitive, numeral
+  <ex>compró tres docenas de huevos
+  <todo>
   """.
 
-n_pp_psd-part-nu-card_le := n_pp_psd-part-nu-card_lex.
 
-;  <type val="n_pp_c-tmp_le">
-;  <description>Noun, PPde, temporal measure
-;  <ex>después de años de disgustos se divorciaron
-;  <todo>
+n_pp_psd-part-nu-card_le := n_pp_psd-part-nu-card_lex
+  """
+  
+  """.
+
+
 n_pp_c-tmp_native_le := n_pp_c-tmp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_c-tmp_le">
+  <description>Noun, PPde, temporal measure
+  <ex>después de años de disgustos se divorciaron
+  <todo>
   """.
 
-n_pp_c-tmp_le := n_pp_c-tmp_lex.
 
-;  <type val="n_-_pn_le">
-;  <description>Proper Noun
-;  <ex>
-;  <todo>
+n_pp_c-tmp_le := n_pp_c-tmp_lex
+  """
+  
+  """.
+
+
 n_-_pn_native_le := n_-_pn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pn_le">
+  <description>Proper Noun
+  <ex>
+  <todo>
   """.
 
+
 foreign_le := n_-_pn_lex
-"""
-Assume for now that it is useful to treat foreign words/fragments as named entities.
-""".
+  """
+  Assume for now that it is useful to treat foreign words/fragments as named entities.
+  """.
 
-n_-_pn_le := n_-_pn_lex.
 
-;  <type val="n_-_pr-pers-n_le">
-;  <description>Pronoun, pers, nominative ("yo", "tú")
-;  <ex> tú y yo iremos por ahí.
-;  <todo>
+n_-_pn_le := n_-_pn_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-n_native_le := n_-_pr-pers-n_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-n_le">
+  <description>Pronoun, pers, nominative ("yo", "tú")
+  <ex> tú y yo iremos por ahí.
+  <todo>
   """.
 
-n_-_pr-pers-n_le := n_-_pr-pers-n_lex.
 
-;  <type val="n_-_pr-pers-no-sg_le">
-;  <description>Pronoun, pers, sing, nominative and oblique ("él", "usted", "vos")
-;  <ex>nosotros confiamos en él.
-;  <todo>
+n_-_pr-pers-n_le := n_-_pr-pers-n_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-no-sg_native_le := n_-_pr-pers-no-sg_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-no-sg_le">
+  <description>Pronoun, pers, sing, nominative and oblique ("él", "usted", "vos")
+  <ex>nosotros confiamos en él.
+  <todo>
   """.
 
-n_-_pr-pers-no-sg_le := n_-_pr-pers-no-sg_lex.
 
-;  <type val="n_-_pr-pers-no-pl_le">
-;  <description>Pronoun, pers, plural nominative and oblique ("nosotros", "vosotros", "ellos", "ustedes")
-;  <ex>nosotros confiamos en todos ellos.
-;  <todo>
+n_-_pr-pers-no-sg_le := n_-_pr-pers-no-sg_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-no-pl_native_le := n_-_pr-pers-no-pl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-no-pl_le">
+  <description>Pronoun, pers, plural nominative and oblique ("nosotros", "vosotros", "ellos", "ustedes")
+  <ex>nosotros confiamos en todos ellos.
+  <todo>
   """.
 
-n_-_pr-pers-no-pl_le := n_-_pr-pers-no-pl_lex.
 
-;  <type val="n_-_pr-pers-o_le">
-;  <description>Pronoun, pers, oblique ("mí", "tí", "sí")
-;  <ex>confía en mí.
-;  <todo>
+n_-_pr-pers-no-pl_le := n_-_pr-pers-no-pl_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-o_native_le := n_-_pr-pers-o_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-o_le">
+  <description>Pronoun, pers, oblique ("mí", "tí", "sí")
+  <ex>confía en mí.
+  <todo>
   """.
 
-n_-_pr-pers-o_le := n_-_pr-pers-o_lex.
 
-;  <type val="n_-_pr-pers-lo_le">
-;  <description>Pronoun, pers, accusative ("lo", "la", "los", "las")
-;  <ex>lo veremos
-;  <todo>
+n_-_pr-pers-o_le := n_-_pr-pers-o_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-lo_native_le := n_-_pr-pers-lo_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-lo_le">
+  <description>Pronoun, pers, accusative ("lo", "la", "los", "las")
+  <ex>lo veremos
+  <todo>
   """.
 
-n_-_pr-pers-lo_le := n_-_pr-pers-lo_lex.
 
-;  <type val="n_-_pr-pers-le_le">
-;  <description>Pronoun, pers, dative ("le", "les")
-;  <ex>le compró un regalo
-;  <todo>
+n_-_pr-pers-lo_le := n_-_pr-pers-lo_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-le_native_le := n_-_pr-pers-le_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-le_le">
+  <description>Pronoun, pers, dative ("le", "les")
+  <ex>le compró un regalo
+  <todo>
   """.
 
-n_-_pr-pers-le_le := n_-_pr-pers-le_lex.
 
-;  <type val="n_-_pr-pers-me_le">
-;  <description>Pronoun, pers, accusative/dative ("me")
-;  <ex>me lo dió
-;  <ex>me vieron
-;  <todo>
+n_-_pr-pers-le_le := n_-_pr-pers-le_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-me_native_le := n_-_pr-pers-me_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-me_le">
+  <description>Pronoun, pers, accusative/dative ("me")
+  <ex>me lo dió
+  <ex>me vieron
+  <todo>
   """.
 
-n_-_pr-pers-me_le := n_-_pr-pers-me_lex.
 
-;  <type val="n_-_pr-pers-te_le">
-;  <description>Pronoun, personal, accusative/dative ("te")
-;  <ex>te lo dió
-;  <ex>te veremos mañana
-;  <todo>
+n_-_pr-pers-me_le := n_-_pr-pers-me_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-te_native_le := n_-_pr-pers-te_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-te_le">
+  <description>Pronoun, personal, accusative/dative ("te")
+  <ex>te lo dió
+  <ex>te veremos mañana
+  <todo>
   """.
 
-n_-_pr-pers-te_le := n_-_pr-pers-te_lex.
 
-;  <type val="n_-_pr-pers-nos_le">
-;  <description>Pronoun, pers, accusative/dative ("nos")
-;  <ex>nos lo dió
-;  <ex>nos veremos mañana
-;  <todo>
+n_-_pr-pers-te_le := n_-_pr-pers-te_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-nos_native_le := n_-_pr-pers-nos_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-nos_le">
+  <description>Pronoun, pers, accusative/dative ("nos")
+  <ex>nos lo dió
+  <ex>nos veremos mañana
+  <todo>
   """.
 
-n_-_pr-pers-nos_le := n_-_pr-pers-nos_lex.
 
-;  <type val="n_-_pr-pers-os_le">
-;  <description>Pronoun, pers, accusative/dative ("os")
-;  <ex>os lo dije
-;  <ex>os veremos mañana
-;  <todo>
+n_-_pr-pers-nos_le := n_-_pr-pers-nos_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-os_native_le := n_-_pr-pers-os_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-os_le">
+  <description>Pronoun, pers, accusative/dative ("os")
+  <ex>os lo dije
+  <ex>os veremos mañana
+  <todo>
   """.
 
-n_-_pr-pers-os_le := n_-_pr-pers-os_lex.
 
-;  <type val="n_-_pr-pers-se_le">
-;  <description>Pronoun, pers, dative ("se")
-;  <ex>se la compró
-;  <todo>
+n_-_pr-pers-os_le := n_-_pr-pers-os_lex
+  """
+  
+  """.
+
+
 n_-_pr-pers-se_native_le := n_-_pr-pers-se_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-pers-se_le">
+  <description>Pronoun, pers, dative ("se")
+  <ex>se la compró
+  <todo>
   """.
 
-n_-_pr-pers-se_le := n_-_pr-pers-se_lex.
 
-;  <type val="n_-_pr-impers-se_le">
-;  <description>Pronoun, pers, impers ("se")
-;  <ex>se vende pan
-;  <todo>
+n_-_pr-pers-se_le := n_-_pr-pers-se_lex
+  """
+  
+  """.
+
+
 n_-_pr-impers-se_native_le := n_-_pr-impers-se_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-impers-se_le">
+  <description>Pronoun, pers, impers ("se")
+  <ex>se vende pan
+  <todo>
   """.
 
-n_-_pr-impers-se_le := n_-_pr-impers-se_lex.
 
-;  <type val="n_-_pr-df-ambos_le">
-;  <description>Pronoun, def ("ambos")
-;  <ex>
-;  <todo>
+n_-_pr-impers-se_le := n_-_pr-impers-se_lex
+  """
+  
+  """.
+
+
 n_-_pr-df-ambos_native_le := n_-_pr-df-ambos_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-df-ambos_le">
+  <description>Pronoun, def ("ambos")
+  <ex>
+  <todo>
   """.
 
-n_-_pr-df-ambos_le := n_-_pr-df-ambos_lex.
 
-;  <type val="n_-_pr-df-tal_le">
-;  <description>Pronoun, def ("tal")
-;  <ex>
-;  <todo>
+n_-_pr-df-ambos_le := n_-_pr-df-ambos_lex
+  """
+  
+  """.
+
+
 n_-_pr-df-tal_native_le := n_-_pr-df-tal_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-df-tal_le">
+  <description>Pronoun, def ("tal")
+  <ex>
+  <todo>
   """.
 
-n_-_pr-df-tal_le := n_-_pr-df-tal_lex.
 
-;  <type val="n_-_pr-dem-este_le">
-;  <description>Pronoun, demons ("este")
-;  <ex>
-;  <todo>
+n_-_pr-df-tal_le := n_-_pr-df-tal_lex
+  """
+  
+  """.
+
+
 n_-_pr-dem-este_native_le := n_-_pr-dem-este_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-dem-este_le">
+  <description>Pronoun, demons ("este")
+  <ex>
+  <todo>
   """.
 
-n_-_pr-dem-este_le := n_-_pr-dem-este_lex.
 
-;  <type val="n_-_pr-dem-ese_le">
-;  <description>Pronoun, demons ("ese")
-;  <ex>
-;  <todo>
+n_-_pr-dem-este_le := n_-_pr-dem-este_lex
+  """
+  
+  """.
+
+
 n_-_pr-dem-ese_native_le := n_-_pr-dem-ese_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-dem-ese_le">
+  <description>Pronoun, demons ("ese")
+  <ex>
+  <todo>
   """.
 
-n_-_pr-dem-ese_le := n_-_pr-dem-ese_lex.
 
-;  <type val="n_-_pr-dem-aquel_le">
-;  <description>Pronoun, demons ("aquel")
-;  <ex>
-;  <todo>
+n_-_pr-dem-ese_le := n_-_pr-dem-ese_lex
+  """
+  
+  """.
+
+
 n_-_pr-dem-aquel_native_le := n_-_pr-dem-aquel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-dem-aquel_le">
+  <description>Pronoun, demons ("aquel")
+  <ex>
+  <todo>
   """.
 
-n_-_pr-dem-aquel_le := n_-_pr-dem-aquel_lex.
 
-;  <type val="n_-_pr-dem-ello_le">
-;  <description>Pronoun, demons ("ello")
-;  <ex>
-;  <todo>
+n_-_pr-dem-aquel_le := n_-_pr-dem-aquel_lex
+  """
+  
+  """.
+
+
 n_-_pr-dem-ello_native_le := n_-_pr-dem-ello_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-dem-ello_le">
+  <description>Pronoun, demons ("ello")
+  <ex>
+  <todo>
   """.
 
-n_-_pr-dem-ello_le := n_-_pr-dem-ello_lex.
 
-;  <type val="n_-_pr-idf-alguien_le">
-;  <description>Pronoun, indef ("alguien")
-;  <ex>alguien llamó
-;  <todo>
+n_-_pr-dem-ello_le := n_-_pr-dem-ello_lex
+  """
+  
+  """.
+
+
 n_-_pr-idf-alguien_native_le := n_-_pr-idf-alguien_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-idf-alguien_le">
+  <description>Pronoun, indef ("alguien")
+  <ex>alguien llamó
+  <todo>
   """.
 
-n_-_pr-idf-alguien_le := n_-_pr-idf-alguien_lex.
 
-;  <type val="n_-_pr-idf-nadie_le">
-;  <description>Pronoun, indef ("nadie")
-;  <ex>(casi) nadie vino
-;  <todo>
+n_-_pr-idf-alguien_le := n_-_pr-idf-alguien_lex
+  """
+  
+  """.
+
+
 n_-_pr-idf-nadie_native_le := n_-_pr-idf-nadie_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-idf-nadie_le">
+  <description>Pronoun, indef ("nadie")
+  <ex>(casi) nadie vino
+  <todo>
   """.
 
-n_-_pr-idf-nadie_le := n_-_pr-idf-nadie_lex.
 
-;  <type val="n_-_pr-idf-todo_le">
-;  <description>Pronoun, indef ("todos")
-;  <ex>(casi) todos fueron
-;  <todo>
+n_-_pr-idf-nadie_le := n_-_pr-idf-nadie_lex
+  """
+  
+  """.
+
+
 n_-_pr-idf-todo_native_le := n_-_pr-idf-todo_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-idf-todo_le">
+  <description>Pronoun, indef ("todos")
+  <ex>(casi) todos fueron
+  <todo>
   """.
 
-n_-_pr-idf-todo_le := n_-_pr-idf-todo_lex.
 
-;  <type val="n_-_pr-idf-demas_le">
-;  <description>Pronoun, indef ("demás")
-;  <ex>vinieron Pedro, Juan y (los) demás
-;  <todo>
+n_-_pr-idf-todo_le := n_-_pr-idf-todo_lex
+  """
+  
+  """.
+
+
 n_-_pr-idf-demas_native_le := n_-_pr-idf-demas_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-idf-demas_le">
+  <description>Pronoun, indef ("demás")
+  <ex>vinieron Pedro, Juan y (los) demás
+  <todo>
   """.
 
-n_-_pr-idf-demas_le := n_-_pr-idf-demas_lex.
 
-;  <type val="n_pp_pr-part-algo_le">
-;  <description>Pronoun, part ("algo")
-;  <ex>he comido algo (de sopa)
-;  <todo>
+n_-_pr-idf-demas_le := n_-_pr-idf-demas_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-algo_native_le := n_pp_pr-part-algo_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-algo_le">
+  <description>Pronoun, part ("algo")
+  <ex>he comido algo (de sopa)
+  <todo>
   """.
 
-n_pp_pr-part-algo_le := n_pp_pr-part-algo_lex.
 
-;  <type val="n_pp_pr-part-nada_le">
-;  <description>Pronoun, part ("nada")
-;  <ex>no he comido (casi) nada (de sopa)
-;  <todo>
+n_pp_pr-part-algo_le := n_pp_pr-part-algo_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-nada_native_le := n_pp_pr-part-nada_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-nada_le">
+  <description>Pronoun, part ("nada")
+  <ex>no he comido (casi) nada (de sopa)
+  <todo>
   """.
 
-n_pp_pr-part-nada_le := n_pp_pr-part-nada_lex.
 
-;  <type val="n_pp_pr-part-un-poco_le">
-;  <description>Pronoun, part ("poco")
-;  <ex>he comido un poco de sopa
-;  <todo>
+n_pp_pr-part-nada_le := n_pp_pr-part-nada_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-un-poco_native_le := n_pp_pr-part-un-poco_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-un-poco_le">
+  <description>Pronoun, part ("poco")
+  <ex>he comido un poco de sopa
+  <todo>
   """.
 
-n_pp_pr-part-un-poco_le := n_pp_pr-part-un-poco_lex.
 
-;  <type val="n_pp_pr-part-alguno_le">
-;  <description>Pronoun, part ("alguno")
-;  <ex>alguno de los chicos
-;  <todo>
+n_pp_pr-part-un-poco_le := n_pp_pr-part-un-poco_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-alguno_native_le := n_pp_pr-part-alguno_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-alguno_le">
+  <description>Pronoun, part ("alguno")
+  <ex>alguno de los chicos
+  <todo>
   """.
 
-n_pp_pr-part-alguno_le := n_pp_pr-part-alguno_lex.
 
-;  <type val="n_pp_pr-part-bastante_le">
-;  <description>Pronoun, part ("bastante")
-;  <ex>bastantes de los chicos
-;  <todo>
+n_pp_pr-part-alguno_le := n_pp_pr-part-alguno_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-bastante_native_le := n_pp_pr-part-bastante_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-bastante_le">
+  <description>Pronoun, part ("bastante")
+  <ex>bastantes de los chicos
+  <todo>
   """.
 
-n_pp_pr-part-bastante_le := n_pp_pr-part-bastante_lex.
 
-;  <type val="n_pp_pr-part-cualquiera_le">
-;  <description>Pronoun, part ("cualquiera")
-;  <ex>cualquiera de los chicos
-;  <todo>
+n_pp_pr-part-bastante_le := n_pp_pr-part-bastante_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-cualquiera_native_le := n_pp_pr-part-cualquiera_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-cualquiera_le">
+  <description>Pronoun, part ("cualquiera")
+  <ex>cualquiera de los chicos
+  <todo>
   """.
 
-n_pp_pr-part-cualquiera_le := n_pp_pr-part-cualquiera_lex.
 
-;  <type val="n_pp_pr-part-demasiado_le">
-;  <description>Pronoun, part ("demasiado")
-;  <ex>demasiados de los chicos
-;  <todo>
+n_pp_pr-part-cualquiera_le := n_pp_pr-part-cualquiera_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-demasiado_native_le := n_pp_pr-part-demasiado_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-demasiado_le">
+  <description>Pronoun, part ("demasiado")
+  <ex>demasiados de los chicos
+  <todo>
   """.
 
-n_pp_pr-part-demasiado_le := n_pp_pr-part-demasiado_lex.
 
-;  <type val="n_pp_pr-part-mucho_le">
-;  <description>Pronoun, part ("mucho")
-;  <ex>muchos de los chicos
-;  <todo>
+n_pp_pr-part-demasiado_le := n_pp_pr-part-demasiado_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-mucho_native_le := n_pp_pr-part-mucho_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-mucho_le">
+  <description>Pronoun, part ("mucho")
+  <ex>muchos de los chicos
+  <todo>
   """.
 
-n_pp_pr-part-mucho_le := n_pp_pr-part-mucho_lex.
 
-;  <type val="n_pp_pr-part-otro_le">
-;  <description>Pronoun, part ("otro")
-;  <ex>otros de los chicos
-;  <todo>
+n_pp_pr-part-mucho_le := n_pp_pr-part-mucho_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-otro_native_le := n_pp_pr-part-otro_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-otro_le">
+  <description>Pronoun, part ("otro")
+  <ex>otros de los chicos
+  <todo>
   """.
 
-n_pp_pr-part-otro_le := n_pp_pr-part-otro_lex.
 
-;  <type val="n_pp_pr-part-poco_le">
-;  <description>Pronoun, part ("pocos")
-;  <ex>pocos de los chicos
-;  <todo>
+n_pp_pr-part-otro_le := n_pp_pr-part-otro_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-poco_native_le := n_pp_pr-part-poco_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-poco_le">
+  <description>Pronoun, part ("pocos")
+  <ex>pocos de los chicos
+  <todo>
   """.
 
-n_pp_pr-part-poco_le := n_pp_pr-part-poco_lex.
 
-;  <type val="n_pp_pr-part-quienquiera_le">
-;  <description>Pronoun, part ("quienquiera")
-;  <ex>quienesquiera de los chicos
-;  <todo>
+n_pp_pr-part-poco_le := n_pp_pr-part-poco_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-quienquiera_native_le := n_pp_pr-part-quienquiera_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-quienquiera_le">
+  <description>Pronoun, part ("quienquiera")
+  <ex>quienesquiera de los chicos
+  <todo>
   """.
 
-n_pp_pr-part-quienquiera_le := n_pp_pr-part-quienquiera_lex.
 
-;  <type val="n_pp_pr-part-varios_le">
-;  <description>Pronoun, part ("varios")
-;  <ex>varios de los chicos
-;  <todo>
+n_pp_pr-part-quienquiera_le := n_pp_pr-part-quienquiera_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-varios_native_le := n_pp_pr-part-varios_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-varios_le">
+  <description>Pronoun, part ("varios")
+  <ex>varios de los chicos
+  <todo>
   """.
 
-n_pp_pr-part-varios_le := n_pp_pr-part-varios_lex.
 
-;  <type val="n_pp_pr-part-ninguno_le">
-;  <description>Pronoun, part ("ninguno")
-;  <ex>(casi) ninguno de los chicos
-;  <todo>
+n_pp_pr-part-varios_le := n_pp_pr-part-varios_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-ninguno_native_le := n_pp_pr-part-ninguno_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-ninguno_le">
+  <description>Pronoun, part ("ninguno")
+  <ex>(casi) ninguno de los chicos
+  <todo>
   """.
 
-n_pp_pr-part-ninguno_le := n_pp_pr-part-ninguno_lex.
 
-;  <type val="n_pp_pr-part-uno_le">
-;  <description>Pronoun, part ("uno")
-;  <ex>(cada) uno (de los chicos)
-;  <todo>
+n_pp_pr-part-ninguno_le := n_pp_pr-part-ninguno_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-uno_native_le := n_pp_pr-part-uno_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-uno_le">
+  <description>Pronoun, part ("uno")
+  <ex>(cada) uno (de los chicos)
+  <todo>
   """.
 
-n_pp_pr-part-uno_le := n_pp_pr-part-uno_lex.
 
-;  <type val="n_pp_pr-part-cuantos_le">
-;  <description>Pronoun, part ("cuantos")
-;  <ex>unos cuantos (de los chicos)
-;  <todo>
+n_pp_pr-part-uno_le := n_pp_pr-part-uno_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-cuantos_native_le := n_pp_pr-part-cuantos_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-cuantos_le">
+  <description>Pronoun, part ("cuantos")
+  <ex>unos cuantos (de los chicos)
+  <todo>
   """.
 
-n_pp_pr-part-cuantos_le := n_pp_pr-part-cuantos_lex.
 
-;  <type val="n_-_pr-rel-que_le">
-;  <description>Pronoun, rel ("que")
-;  <ex>el escritor que premiaron anoche vendrá a nuestra tertulia
-;  <todo>
+n_pp_pr-part-cuantos_le := n_pp_pr-part-cuantos_lex
+  """
+  
+  """.
+
+
 n_-_pr-rel-que_native_le := n_-_pr-rel-que_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-rel-que_le">
+  <description>Pronoun, rel ("que")
+  <ex>el escritor que premiaron anoche vendrá a nuestra tertulia
+  <todo>
   """.
 
-n_-_pr-rel-que_le := n_-_pr-rel-que_lex.
 
-;  <type val="n_-_pr-rel-quien_le">
-;  <description>Pronoun, rel ("quien")
-;  <ex>los congresistas, quienes llegaron anoche, fueron alojados provisionalmente
-;  <todo>
+n_-_pr-rel-que_le := n_-_pr-rel-que_lex
+  """
+  
+  """.
+
+
 n_-_pr-rel-quien_native_le := n_-_pr-rel-quien_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-rel-quien_le">
+  <description>Pronoun, rel ("quien")
+  <ex>los congresistas, quienes llegaron anoche, fueron alojados provisionalmente
+  <todo>
   """.
 
-n_-_pr-rel-quien_le := n_-_pr-rel-quien_lex.
 
-;  <type val="n_-_pr-rel-cual_le">
-;  <description>Pronoun, rel ("cual")
-;  <ex>la columna de humo que causó la explosión, el cual se propagó a otros edificios
-;  <todo>
+n_-_pr-rel-quien_le := n_-_pr-rel-quien_lex
+  """
+  
+  """.
+
+
 n_-_pr-rel-cual_native_le := n_-_pr-rel-cual_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-rel-cual_le">
+  <description>Pronoun, rel ("cual")
+  <ex>la columna de humo que causó la explosión, el cual se propagó a otros edificios
+  <todo>
   """.
 
-n_-_pr-rel-cual_le := n_-_pr-rel-cual_lex.
 
-;  <type val="n_-_pr-frel-que_le">
-;  <description>Pronoun, free rel., ("que")
-;  <ex>los que llegaron anoche fueron alojados provisionalmente
-;  <todo>
+n_-_pr-rel-cual_le := n_-_pr-rel-cual_lex
+  """
+  
+  """.
+
+
 n_-_pr-frel-que_native_le := n_-_pr-free-rel-que_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-frel-que_le">
+  <description>Pronoun, free rel., ("que")
+  <ex>los que llegaron anoche fueron alojados provisionalmente
+  <todo>
   """.
 
-n_-_pr-frel-que_le := n_-_pr-free-rel-que_lex.
 
-;  <type val="n_-_pr-frel-quien_le">
-;  <description>Pronoun, free rel. ("quien")
-;  <ex>quienes llegaron anoche fueron alojados provisionalmente
-;  <todo>
+n_-_pr-frel-que_le := n_-_pr-free-rel-que_lex
+  """
+  
+  """.
+
+
 n_-_pr-frel-quien_native_le := n_-_pr-free-rel-quien_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-frel-quien_le">
+  <description>Pronoun, free rel. ("quien")
+  <ex>quienes llegaron anoche fueron alojados provisionalmente
+  <todo>
   """.
 
-n_-_pr-frel-quien_le := n_-_pr-free-rel-quien_lex.
 
-;  <type val="n_-_pr-wh_que_le">
-;  <description>Pronoun, int ("qué")
-;  <ex>¿qué le has comprado?
-;  <todo>
+n_-_pr-frel-quien_le := n_-_pr-free-rel-quien_lex
+  """
+  
+  """.
+
+
 n_-_pr-wh-que_native_le := n_-_pr-wh-que_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_-_pr-wh_que_le">
+  <description>Pronoun, int ("qué")
+  <ex>¿qué le has comprado?
+  <todo>
   """.
 
-n_-_pr-wh-que_le := n_-_pr-wh-que_lex.
 
-;  <type val="n_pp_pr-wh_que_le">
-;  <description>Pronoun, int ("quién")
-;  <ex>¿quién de tus amigos es diputado?
-;  <todo>
+n_-_pr-wh-que_le := n_-_pr-wh-que_lex
+  """
+  
+  """.
+
+
 n_pp_pr-wh-quien_native_le := n_pp_pr-wh-quien_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-wh_que_le">
+  <description>Pronoun, int ("quién")
+  <ex>¿quién de tus amigos es diputado?
+  <todo>
   """.
 
-n_pp_pr-wh-quien_le := n_pp_pr-wh-quien_lex.
 
-;  <type val="n_pp_pr-wh-cual_le">
-;  <description>Pronoun, int ("cuál")
-;  <ex>¿cuál de tus amigos es diputado?
-;  <todo>
+n_pp_pr-wh-quien_le := n_pp_pr-wh-quien_lex
+  """
+  
+  """.
+
+
 n_pp_pr-wh-cual_native_le := n_pp_pr-wh-cual_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-wh-cual_le">
+  <description>Pronoun, int ("cuál")
+  <ex>¿cuál de tus amigos es diputado?
+  <todo>
   """.
 
-n_pp_pr-wh-cual_le := n_pp_pr-wh-cual_lex.
 
-;  <type val="n_pp_pr-wh-cuanto_le">
-;  <description>Pronoun, int ("cuánto")
-;  <ex>¿cuántos de tus amigos es diputado?
-;  <todo>
+n_pp_pr-wh-cual_le := n_pp_pr-wh-cual_lex
+  """
+  
+  """.
+
+
 n_pp_pr-wh-cuanto_native_le := n_pp_pr-wh-cuanto_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-wh-cuanto_le">
+  <description>Pronoun, int ("cuánto")
+  <ex>¿cuántos de tus amigos es diputado?
+  <todo>
   """.
 
-n_pp_pr-wh-cuanto_le := n_pp_pr-wh-cuanto_lex.
 
-;  <type val="n_pp_nu-card_le">
-;  <description>Pronoun, part, card. num
-;  <ex>dame dos (de esos libros)
-;  <todo>
+n_pp_pr-wh-cuanto_le := n_pp_pr-wh-cuanto_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-nu-card_native_le := n_pp_pr-part-nu-card_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_nu-card_le">
+  <description>Pronoun, part, card. num
+  <ex>dame dos (de esos libros)
+  <todo>
   """.
 
-n_pp_pr-part-nu-card_le := n_pp_pr-part-nu-card_lex.
 
-;  <type val="n_pp_pr-psd-part-nu-card_le">
-;  <description>Pronoun, pseudo-part, card. num
-;  <ex>compró tres docenas (de huevos)
-;  <todo>
+n_pp_pr-part-nu-card_le := n_pp_pr-part-nu-card_lex
+  """
+  
+  """.
+
+
 n_pp_pr-psd-part-nu-card_native_le := n_pp_pr-psd-part-nu-card_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-psd-part-nu-card_le">
+  <description>Pronoun, pseudo-part, card. num
+  <ex>compró tres docenas (de huevos)
+  <todo>
   """.
 
-n_pp_pr-psd-part-nu-card_le := n_pp_pr-psd-part-nu-card_lex.
 
-;  <type val="n_pp_pr-part-nu-mult_le">
-;  <description>Pronoun, part, multipl. num 
-;  <ex>comió el doble/triple (de pan) (que su hermana)
-;  <todo>
+n_pp_pr-psd-part-nu-card_le := n_pp_pr-psd-part-nu-card_lex
+  """
+  
+  """.
+
+
 n_pp_pr-part-nu-mult_native_le := n_pp_pr-part-nu-mult_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="n_pp_pr-part-nu-mult_le">
+  <description>Pronoun, part, multipl. num
+  <ex>comió el doble/triple (de pan) (que su hermana)
+  <todo>
   """.
 
-n_pp_pr-part-nu-mult_le := n_pp_pr-part-nu-mult_lex.
 
-;  <type val="av_-_s_le">
-;  <description>Adverb, scopal, focus
-;  <ex>especialmente bajo la escalera/aquí/estos muchachos
-;  <todo>
+n_pp_pr-part-nu-mult_le := n_pp_pr-part-nu-mult_lex
+  """
+  
+  """.
+
+
 av_-_s_native_le := av_-_s_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_s_le">
+  <description>Adverb, scopal, focus
+  <ex>especialmente bajo la escalera/aquí/estos muchachos
+  <todo>
   """.
 
-av_-_s_le := av_-_s_lex.
 
-;  <type val="av_-_s-spd_le">
-;  <description>Adverb, scopal, focus
-;  <ex>especialmente bajo la escalera/aquí/estos muchachos
-;  <todo>
+av_-_s_le := av_-_s_lex
+  """
+  
+  """.
+
+
 av_-_s-spd_native_le := av_-_s-spd_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_s-spd_le">
+  <description>Adverb, scopal, focus
+  <ex>especialmente bajo la escalera/aquí/estos muchachos
+  <todo>
   """.
 
-av_-_s-spd_le := av_-_s-spd_lex.
 
-;  <type val="av_-_s-psth_le">
-;  <description>Adverb, 
-;  <ex> mañana/en la mesa mismo
-;  <todo>
+av_-_s-spd_le := av_-_s-spd_lex
+  """
+  
+  """.
+
+
 av_-_s-psth_native_le := av_-_s-psth_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_s-psth_le">
+  <description>Adverb,
+  <ex> mañana/en la mesa mismo
+  <todo>
   """.
 
-av_-_s-psth_le := av_-_s-psth_lex.
 
-;  <type val="av_-_s-psth-n_le">
-;  <description>Adverb, 
-;  <ex>usted mismo
-;  <todo>
+av_-_s-psth_le := av_-_s-psth_lex
+  """
+  
+  """.
+
+
 av_-_s-psth-n_native_le := av_-_s-psth-n_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_s-psth-n_le">
+  <description>Adverb,
+  <ex>usted mismo
+  <todo>
   """.
 
-av_-_s-psth-n_le := av_-_s-psth-n_lex.
 
-;  <type val="av_-_s-vm_le">
-;  <description>Adverb, scopal, S 
-;  <ex>
-;  <todo>
+av_-_s-psth-n_le := av_-_s-psth-n_lex
+  """
+  
+  """.
+
+
 av_-_s-vm_native_le := av_-_s-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_s-vm_le">
+  <description>Adverb, scopal, S
+  <ex>
+  <todo>
   """.
 
-av_-_s-vm_le := av_-_s-vm_lex.
 
-;  <type val="av_-_s-vm-spd_le">
-;  <description>Adverb, scopal, S 
-;  <ex>
-;  <todo>
+av_-_s-vm_le := av_-_s-vm_lex
+  """
+  
+  """.
+
+
 av_-_s-vm-spd_native_le := av_-_s-vm-spd_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_s-vm-spd_le">
+  <description>Adverb, scopal, S
+  <ex>
+  <todo>
   """.
 
-av_-_s-vm-spd_le := av_-_s-vm-spd_lex.
 
-;  <type val="av_-_s-xm_le">
-;  <description>Adverb, scopal, S 
-;  <ex>
-;  <todo>
+av_-_s-vm-spd_le := av_-_s-vm-spd_lex
+  """
+  
+  """.
+
+
 av_-_s-xm_native_le := av_-_s-xm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_s-xm_le">
+  <description>Adverb, scopal, S
+  <ex>
+  <todo>
   """.
 
-av_-_s-xm_le := av_-_s-xm_lex.
 
-;  <type val="av_-_s-xm-spd_le">
-;  <description>Adverb, scopal, X
-;  <ex>
-;  <todo>
+av_-_s-xm_le := av_-_s-xm_lex
+  """
+  
+  """.
+
+
 av_-_s-xm-spd_native_le := av_-_s-xm-spd_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_s-xm-spd_le">
+  <description>Adverb, scopal, X
+  <ex>
+  <todo>
   """.
 
-av_-_s-xm-spd_le := av_-_s-xm-spd_lex.
 
-;  <type val="av_-_i-vm_le">
-;  <description>Adverb, intersec, V mod
-;  <ex>sencillamente, simplemente, solamente
-;  <todo>
+av_-_s-xm-spd_le := av_-_s-xm-spd_lex
+  """
+  
+  """.
+
+
 av_-_i-vm_native_le := av_-_i-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_i-vm_le">
+  <description>Adverb, intersec, V mod
+  <ex>sencillamente, simplemente, solamente
+  <todo>
   """.
 
-av_-_i-vm_le := av_-_i-vm_lex.
 
-;  <type val="av_-_i-sm_le">
-;  <description>Adverb, intersec, S mod
-;  <ex>sencillamente, simplemente, solamente
-;  <todo>
+av_-_i-vm_le := av_-_i-vm_lex
+  """
+  
+  """.
+
+
 av_-_i-sm_native_le := av_-_i-sm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_i-sm_le">
+  <description>Adverb, intersec, S mod
+  <ex>sencillamente, simplemente, solamente
+  <todo>
   """.
 
-av_-_i-sm_le := av_-_i-sm_lex.
 
-;  <type val="av_-_i-vm-spd_le">
-;  <description>Adverb, intersec, Vmod
-;  <ex>le ha influido muy negativamente
-;  <todo>
+av_-_i-sm_le := av_-_i-sm_lex
+  """
+  
+  """.
+
+
 av_-_i-vm-spd_native_le := av_-_i-vm-spd_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_i-vm-spd_le">
+  <description>Adverb, intersec, Vmod
+  <ex>le ha influido muy negativamente
+  <todo>
   """.
 
-av_-_i-vm-spd_le := av_-_i-vm-spd_lex.
 
-;  <type val="av_-_i-vm-ppart_le">
-;  <description>Adverb, intersec, V (ppart) mod
-;  <ex>recien llegados
-;  <todo>
+av_-_i-vm-spd_le := av_-_i-vm-spd_lex
+  """
+  
+  """.
+
+
 av_-_i-vm-ppart_native_le := av_-_i-vm-ppart_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_i-vm-ppart_le">
+  <description>Adverb, intersec, V (ppart) mod
+  <ex>recien llegados
+  <todo>
   """.
 
-av_-_i-vm-ppart_le := av_-_i-vm-ppart_lex.
 
-;  <type val="av_-_dg-qnt_le">
-;  <description>Adverb, degree quant.
-;  <ex>mucho, bien, algo, bastante, demasiado, super, nada, medio,...
-;  <todo>
+av_-_i-vm-ppart_le := av_-_i-vm-ppart_lex
+  """
+  
+  """.
+
+
 av_-_dg-qnt_native_le := av_-_dg-qnt_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_dg-qnt_le">
+  <description>Adverb, degree quant.
+  <ex>mucho, bien, algo, bastante, demasiado, super, nada, medio,...
+  <todo>
   """.
 
-av_-_dg-qnt_le := av_-_dg-qnt_lex.
 
-;  <type val="av_-_dg-muy-and-casi_le">
-;  <description>Adverb, degree ("muy")
-;  <ex>casi todos los chicos lloran
-;  <todo>
+av_-_dg-qnt_le := av_-_dg-qnt_lex
+  """
+  
+  """.
+
+
 av_-_dg-muy-and-casi_native_le := av_-_dg-muy-and-casi_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_dg-muy-and-casi_le">
+  <description>Adverb, degree ("muy")
+  <ex>casi todos los chicos lloran
+  <todo>
   """.
 
-av_-_dg-muy-and-casi_le := av_-_dg-muy-and-casi_lex.
 
-;  <type val="av_-_dg-casi_le">
-;  <description>Adverb, degree ("casi")
-;  <ex>casi nadie
-;  <todo>
+av_-_dg-muy-and-casi_le := av_-_dg-muy-and-casi_lex
+  """
+  
+  """.
+
+
 av_-_dg-casi_native_le := av_-_dg-casi_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_dg-casi_le">
+  <description>Adverb, degree ("casi")
+  <ex>casi nadie
+  <todo>
   """.
 
-av_-_dg-casi_le := av_-_dg-casi_lex.
 
-;  <type val="av_-_dg-un-tanto_le">
-;  <description>Adverb, degree ("un tanto")
-;  <ex>
-;  <todo>
-; av_-_dg-un-tanto_le := av_-_dg-un-tanto_lex.
-;  <type val="av_-_dg_le">
-;  <description>Adverb, degree, (ending in '-mente')
-;  <ex>
-;  <todo>
+av_-_dg-casi_le := av_-_dg-casi_lex
+  """
+  
+  """.
+
+
 av_-_dg_native_le := av_-_dg_lex & native_le
   """
-  This is a native lexical entry type, for words that are in the lexicon.
+   This is a native lexical entry type, for words that are in the lexicon.
+  
+   <type val="av_-_dg-un-tanto_le">
+   <description>Adverb, degree ("un tanto")
+   <ex>
+   <todo>
+  av_-_dg-un-tanto_le := av_-_dg-un-tanto_lex.
+   <type val="av_-_dg_le">
+   <description>Adverb, degree, (ending in '-mente')
+   <ex>
+   <todo>
   """.
 
-av_-_dg_le := av_-_dg_lex.
 
-;  <type val="av_-_dg-cmp_le">
-;  <description>Adverb, degree compar
-;  <ex>más/menos guapo que 
-;  <todo>
+av_-_dg_le := av_-_dg_lex
+  """
+  
+  """.
+
+
 av_-_dg-cmp_native_le := av_-_dg-cmp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_dg-cmp_le">
+  <description>Adverb, degree compar
+  <ex>más/menos guapo que
+  <todo>
   """.
 
-av_-_dg-cmp_le := av_-_dg-cmp_lex.
 
-;  <type val="av_-_dg-cmp-eq_le">
-;  <description>Adverb, degree compar, equal
-;  <ex>tan guapo como
-;  <todo>
+av_-_dg-cmp_le := av_-_dg-cmp_lex
+  """
+  
+  """.
+
+
 av_-_dg-cmp-eq_native_le := av_-_dg-cmp-eq_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_dg-cmp-eq_le">
+  <description>Adverb, degree compar, equal
+  <ex>tan guapo como
+  <todo>
   """.
 
-av_-_dg-cmp-eq_le := av_-_dg-cmp-eq_lex.
 
-;  <type val="av_-_dg-sup_le">
-;  <description>Adverb, degree superl
-;  <ex>la más/menos guapa de 
-;  <todo>
+av_-_dg-cmp-eq_le := av_-_dg-cmp-eq_lex
+  """
+  
+  """.
+
+
 av_-_dg-sup_native_le := av_-_dg-sup_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_dg-sup_le">
+  <description>Adverb, degree superl
+  <ex>la más/menos guapa de
+  <todo>
   """.
 
-av_-_dg-sup_le := av_-_dg-sup_lex.
 
-;  <type val="av_-_pr-poco_le">
-;  <description>Adverb, quant. pron., ("poco")
-;  <ex>el muchacho corrió un poco
-;  <todo>
+av_-_dg-sup_le := av_-_dg-sup_lex
+  """
+  
+  """.
+
+
 av_-_pr-poco_native_le := av_-_pr-poco_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-poco_le">
+  <description>Adverb, quant. pron., ("poco")
+  <ex>el muchacho corrió un poco
+  <todo>
   """.
 
-av_-_pr-poco_le := av_-_pr-poco_lex.
 
-;  <type val="av_-_pr-un-poco_le">
-;  <description>Adverb, quant. pron., ("un poco")
-;  <ex>el muchacho corrió un poco
-;  <todo>
+av_-_pr-poco_le := av_-_pr-poco_lex
+  """
+  
+  """.
+
+
 av_-_pr-un-poco_native_le := av_-_pr-un-poco_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-un-poco_le">
+  <description>Adverb, quant. pron., ("un poco")
+  <ex>el muchacho corrió un poco
+  <todo>
   """.
 
-av_-_pr-un-poco_le := av_-_pr-un-poco_lex.
 
-;  <type val="av_-_pr-nada_le">
-;  <description>Adverb, quant. pron., ("nada")
-;  <ex>el muchacho no corrió nada
-;  <todo>
+av_-_pr-un-poco_le := av_-_pr-un-poco_lex
+  """
+  
+  """.
+
+
 av_-_pr-nada_native_le := av_-_pr-nada_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-nada_le">
+  <description>Adverb, quant. pron., ("nada")
+  <ex>el muchacho no corrió nada
+  <todo>
   """.
 
-av_-_pr-nada_le := av_-_pr-nada_lex.
 
-;  <type val="av_-_pr-menos_le">
-;  <description>Adverb, quant. pron., ("menos")
-;  <ex>el muchacho corrió mucho menos
-;  <todo>
+av_-_pr-nada_le := av_-_pr-nada_lex
+  """
+  
+  """.
+
+
 av_-_pr-menos_native_le := av_-_pr-menos_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-menos_le">
+  <description>Adverb, quant. pron., ("menos")
+  <ex>el muchacho corrió mucho menos
+  <todo>
   """.
 
-av_-_pr-menos_le := av_-_pr-menos_lex.
 
-;  <type val="av_-_pr-más_le">
-;  <description>Adverb, quant. pron., ("más")
-;  <ex>el muchacho corrió mucho más
-;  <todo>
+av_-_pr-menos_le := av_-_pr-menos_lex
+  """
+  
+  """.
+
+
 av_-_pr-más_native_le := av_-_pr-más_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-más_le">
+  <description>Adverb, quant. pron., ("más")
+  <ex>el muchacho corrió mucho más
+  <todo>
   """.
 
-av_-_pr-más_le := av_-_pr-más_lex.
 
-;  <type val="av_-_pr-mucho_le">
-;  <description>Adverb, quant. pron., ("mucho")
-;  <ex>el muchacho corrió mucho
-;  <todo>
+av_-_pr-más_le := av_-_pr-más_lex
+  """
+  
+  """.
+
+
 av_-_pr-mucho_native_le := av_-_pr-mucho_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-mucho_le">
+  <description>Adverb, quant. pron., ("mucho")
+  <ex>el muchacho corrió mucho
+  <todo>
   """.
 
-av_-_pr-mucho_le := av_-_pr-mucho_lex.
 
-;  <type val="av_-_pr-bastante_le">
-;  <description>Adverb, quant. pron., ("bastante")
-;  <ex>el muchacho corrió bastante
-;  <todo>
+av_-_pr-mucho_le := av_-_pr-mucho_lex
+  """
+  
+  """.
+
+
 av_-_pr-bastante_native_le := av_-_pr-bastante_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-bastante_le">
+  <description>Adverb, quant. pron., ("bastante")
+  <ex>el muchacho corrió bastante
+  <todo>
   """.
 
-av_-_pr-bastante_le := av_-_pr-bastante_lex.
 
-;  <type val="av_-_pr-demasiado_le">
-;  <description>Adverb, quant. pron., ("demasiado")
-;  <ex>el muchacho corrió demasiado.
-;  <todo>
+av_-_pr-bastante_le := av_-_pr-bastante_lex
+  """
+  
+  """.
+
+
 av_-_pr-demasiado_native_le := av_-_pr-demasiado_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-demasiado_le">
+  <description>Adverb, quant. pron., ("demasiado")
+  <ex>el muchacho corrió demasiado.
+  <todo>
   """.
 
-av_-_pr-demasiado_le := av_-_pr-demasiado_lex.
 
-;  <type val="av_-_pr-tanto_le">
-;  <description>Adverb, quant. pron., ("tanto")
-;  <ex>el muchacho corrió tanto
-;  <todo>
+av_-_pr-demasiado_le := av_-_pr-demasiado_lex
+  """
+  
+  """.
+
+
 av_-_pr-tanto_native_le := av_-_pr-tanto_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-tanto_le">
+  <description>Adverb, quant. pron., ("tanto")
+  <ex>el muchacho corrió tanto
+  <todo>
   """.
 
-av_-_pr-tanto_le := av_-_pr-tanto_lex.
 
-;  <type val="av_-_pr-algo_le">
-;  <description>Adverb, quant. pron., ("algo")
-;  <ex>el muchacho corrió algo
-;  <todo>
+av_-_pr-tanto_le := av_-_pr-tanto_lex
+  """
+  
+  """.
+
+
 av_-_pr-algo_native_le := av_-_pr-algo_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-algo_le">
+  <description>Adverb, quant. pron., ("algo")
+  <ex>el muchacho corrió algo
+  <todo>
   """.
 
-av_-_pr-algo_le := av_-_pr-algo_lex.
 
-;  <type val="av_-_pr-mea_le">
-;  <description>Adverb, quant. pron., measure
-;  <ex>las ventas aumentaron el 20% 
-;  <todo>
+av_-_pr-algo_le := av_-_pr-algo_lex
+  """
+  
+  """.
+
+
 av_-_pr-mea_native_le := av_-_pr-mea_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_pr-mea_le">
+  <description>Adverb, quant. pron., measure
+  <ex>las ventas aumentaron el 20%
+  <todo>
   """.
 
-av_-_pr-mea_le := av_-_pr-mea_lex.
 
-;  <type val="av_-_deic-place_le">
-;  <description>Adverb, deictic, place
-;  <ex>aquí, allí, ahí, acá, allá, acullá, aquende, allende
-;  <todo>
+av_-_pr-mea_le := av_-_pr-mea_lex
+  """
+  
+  """.
+
+
 av_-_deic-place_native_le := av_-_deic-place_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_deic-place_le">
+  <description>Adverb, deictic, place
+  <ex>aquí, allí, ahí, acá, allá, acullá, aquende, allende
+  <todo>
   """.
 
-av_-_deic-place_le := av_-_deic-place_lex.
 
-;  <type val="av_-_deic-tmp_le">
-;  <description>Adverb, deictic, temp
-;  <ex>ahora, entonces, hoy, ayer, anteayer, mañana, anoche, anteanoche, anteayer, anteanteayer, ...
-;  <todo>
+av_-_deic-place_le := av_-_deic-place_lex
+  """
+  
+  """.
+
+
 av_-_deic-tmp_native_le := av_-_deic-tmp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_deic-tmp_le">
+  <description>Adverb, deictic, temp
+  <ex>ahora, entonces, hoy, ayer, anteayer, mañana, anoche, anteanoche, anteayer, anteanteayer, ...
+  <todo>
   """.
 
-av_-_deic-tmp_le := av_-_deic-tmp_lex.
 
-;  <type val="av_-_deic-mann_le">
-;  <description>Adverb, deictic, mann
-;  <ex>así
-;  <todo>
+av_-_deic-tmp_le := av_-_deic-tmp_lex
+  """
+  
+  """.
+
+
 av_-_deic-mann_native_le := av_-_deic-mann_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_deic-mann_le">
+  <description>Adverb, deictic, mann
+  <ex>así
+  <todo>
   """.
 
-av_-_deic-mann_le := av_-_deic-mann_lex.
 
-;  <type val="av_-_rel-place_le">
-;  <description>Adverb, rel., place ("donde", "adonde")
-;  <ex>la casa donde vivía
-;  <todo>
+av_-_deic-mann_le := av_-_deic-mann_lex
+  """
+  
+  """.
+
+
 av_-_rel-place_native_le := av_-_rel-place_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_rel-place_le">
+  <description>Adverb, rel., place ("donde", "adonde")
+  <ex>la casa donde vivía
+  <todo>
   """.
 
-av_-_rel-place_le := av_-_rel-place_lex.
 
-;  <type val="av_-_rel-tmp_le">
-;  <description>Adverb, rel., temp ("cuando")
-;  <ex>recuerdo el día cuando dimitió
-;  <todo>
+av_-_rel-place_le := av_-_rel-place_lex
+  """
+  
+  """.
+
+
 av_-_rel-tmp_native_le := av_-_rel-tmp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_rel-tmp_le">
+  <description>Adverb, rel., temp ("cuando")
+  <ex>recuerdo el día cuando dimitió
+  <todo>
   """.
 
-av_-_rel-tmp_le := av_-_rel-tmp_lex.
 
-;  <type val="av_-_rel-mann_le">
-;  <description>Adverb, rel., mann ("como")
-;  <ex>lo hice distretamente/con precaución, como me había recomendado
-;  <todo>
+av_-_rel-tmp_le := av_-_rel-tmp_lex
+  """
+  
+  """.
+
+
 av_-_rel-mann_native_le := av_-_rel-mann_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_rel-mann_le">
+  <description>Adverb, rel., mann ("como")
+  <ex>lo hice distretamente/con precaución, como me había recomendado
+  <todo>
   """.
 
-av_-_rel-mann_le := av_-_rel-mann_lex.
 
-;  <type val="av_-_frel-place_le">
-;  <description>Adverb, free rel., place ("donde")
-;  <ex>donde vive tu hermano es demasiado lejos para ir de vacaciones
-;  <todo>
+av_-_rel-mann_le := av_-_rel-mann_lex
+  """
+  
+  """.
+
+
 av_-_frel-place_native_le := av_-_free-rel-place_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_frel-place_le">
+  <description>Adverb, free rel., place ("donde")
+  <ex>donde vive tu hermano es demasiado lejos para ir de vacaciones
+  <todo>
   """.
 
-av_-_frel-place_le := av_-_free-rel-place_lex.
 
-;  <type val="av_-_frel-tmp_le">
-;  <description>Adverb, free rel., temp. ("cuando")
-;  <ex>la ví cuando salía del metro
-;  <todo>
+av_-_frel-place_le := av_-_free-rel-place_lex
+  """
+  
+  """.
+
+
 av_-_frel-tmp_native_le := av_-_free-rel-tmp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_frel-tmp_le">
+  <description>Adverb, free rel., temp. ("cuando")
+  <ex>la ví cuando salía del metro
+  <todo>
   """.
 
-av_-_frel-tmp_le := av_-_free-rel-tmp_lex.
 
-;  <type val="av_-_frel-mann_le">
-;  <description>Adverb, free rel., mann ("como")
-;  <ex>los niños dejaron la sala como ya os podéis imaginar
-;  <todo>
+av_-_frel-tmp_le := av_-_free-rel-tmp_lex
+  """
+  
+  """.
+
+
 av_-_frel-mann_native_le := av_-_free-rel-mann_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_frel-mann_le">
+  <description>Adverb, free rel., mann ("como")
+  <ex>los niños dejaron la sala como ya os podéis imaginar
+  <todo>
   """.
 
-av_-_frel-mann_le := av_-_free-rel-mann_lex.
 
-;  <type val="av_-_wh-place_le">
-;  <description>Adverb, int., place ("dónde", "adónde")
-;  <ex>
-;  <todo>
+av_-_frel-mann_le := av_-_free-rel-mann_lex
+  """
+  
+  """.
+
+
 av_-_wh-place_native_le := av_-_wh-place_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_wh-place_le">
+  <description>Adverb, int., place ("dónde", "adónde")
+  <ex>
+  <todo>
   """.
 
-av_-_wh-place_le := av_-_wh-place_lex.
 
-;  <type val="av_-_wh-tmp_le">
-;  <description>Adverb, int., temp ("cuándo")
-;  <ex>
-;  <todo>
+av_-_wh-place_le := av_-_wh-place_lex
+  """
+  
+  """.
+
+
 av_-_wh-tmp_native_le := av_-_wh-tmp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_wh-tmp_le">
+  <description>Adverb, int., temp ("cuándo")
+  <ex>
+  <todo>
   """.
 
-av_-_wh-tmp_le := av_-_wh-tmp_lex.
 
-;  <type val="av_-_wh-mann_le">
-;  <description>Adverb, int., mann ("cómo")
-;  <ex>
-;  <todo>
+av_-_wh-tmp_le := av_-_wh-tmp_lex
+  """
+  
+  """.
+
+
 av_-_wh-mann_native_le := av_-_wh-mann_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_wh-mann_le">
+  <description>Adverb, int., mann ("cómo")
+  <ex>
+  <todo>
   """.
 
-av_-_wh-mann_le := av_-_wh-mann_lex.
 
-;  <type val="av_-_wh-mann_le">
-;  <description>Adverb, int., cause ("por qué")
-;  <ex>
-;  <todo>
+av_-_wh-mann_le := av_-_wh-mann_lex
+  """
+  
+  """.
+
+
 av_-_wh-caus_native_le := av_-_wh-caus_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="av_-_wh-mann_le">
+  <description>Adverb, int., cause ("por qué")
+  <ex>
+  <todo>
   """.
 
-av_-_wh-caus_le := av_-_wh-caus_lex.
 
-;  <type val="aj_-_s-nprd_le">
-;  <description>(Adv. aspec.) Adjective, scopal, no comp, non-spr, non-prd
-;  <ex>periódicas revisiones
-;  <todo>
+av_-_wh-caus_le := av_-_wh-caus_lex
+  """
+  
+  """.
+
+
 aj_-_s-nprd_native_le := aj_-_s-nprd_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_s-nprd_le">
+  <description>(Adv. aspec.) Adjective, scopal, no comp, non-spr, non-prd
+  <ex>periódicas revisiones
+  <todo>
   """.
 
-aj_-_s-nprd_le := aj_-_s-nprd_lex.
 
-;  <type val="aj_-_s-nprd-prh_le">
-;  <description>(Adv. int.) Adjective, scopal, no comp, non-spr, non-prd, pre-noun
-;  <ex>el presunto asesino
-;  <todo>
+aj_-_s-nprd_le := aj_-_s-nprd_lex
+  """
+  
+  """.
+
+
 aj_-_s-nprd-prh_native_le := aj_-_s-nprd-prh_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_s-nprd-prh_le">
+  <description>(Adv. int.) Adjective, scopal, no comp, non-spr, non-prd, pre-noun
+  <ex>el presunto asesino
+  <todo>
   """.
 
-aj_-_s-nprd-prh_le := aj_-_s-nprd-prh_lex.
 
-;  <type val="aj_-_i-nspd_le">
-;  <description>(Rel.) Adjective, inters, no comp, non-spr, ser 
-;  <ex>la revista muy* mensual
-;  <todo>
+aj_-_s-nprd-prh_le := aj_-_s-nprd-prh_lex
+  """
+  
+  """.
+
+
 aj_-_i-nspd_native_le := aj_-_i-nspd_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i-nspd_le">
+  <description>(Rel.) Adjective, inters, no comp, non-spr, ser
+  <ex>la revista muy* mensual
+  <todo>
   """.
 
-aj_-_i-nspd_le := aj_-_i-nspd_lex.
 
-;  <type val="aj_-_i-nprd_le">
-;  <description>(Rel.) Adjective, inters, no comp, non-prd
-;  <ex>una actuación muy policial
-;  <todo>
+aj_-_i-nspd_le := aj_-_i-nspd_lex
+  """
+  
+  """.
+
+
 aj_-_i-nprd_native_le := aj_-_i-nprd_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i-nprd_le">
+  <description>(Rel.) Adjective, inters, no comp, non-prd
+  <ex>una actuación muy policial
+  <todo>
   """.
 
-aj_-_i-nprd_le := aj_-_i-nprd_lex.
 
-;  <type val="aj_-_i-nprd-cualquiera_le">
-;  <description>(Rel.) Adjective, inters, no comp, non-prd (only for "cualquiera")
-;  <ex>un hombre cualquiera
-;  <todo>
+aj_-_i-nprd_le := aj_-_i-nprd_lex
+  """
+  
+  """.
+
+
 aj_-_i-nprd-cualquiera_native_le := aj_-_i-nprd-cualquiera_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i-nprd-cualquiera_le">
+  <description>(Rel.) Adjective, inters, no comp, non-prd (only for "cualquiera")
+  <ex>un hombre cualquiera
+  <todo>
   """.
 
-aj_-_i-nprd-cualquiera_le := aj_-_i-nprd-cualquiera_lex.
 
-;  <type val="aj_pp_i-nprd_le">
-;  <description>(Rel.) Adjective, inters, PPsel, non-prd 
-;  <ex>consistente en tres pasos
-;  <todo>
+aj_-_i-nprd-cualquiera_le := aj_-_i-nprd-cualquiera_lex
+  """
+  
+  """.
+
+
 aj_pp_i-nprd_native_le := aj_pp_i-nprd_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_pp_i-nprd_le">
+  <description>(Rel.) Adjective, inters, PPsel, non-prd
+  <ex>consistente en tres pasos
+  <todo>
   """.
 
-aj_pp_i-nprd_le := aj_pp_i-nprd_lex.
 
-;  <type val="aj_cp_p-i-nprd_le">
-;  <description>(Rel.) Adjective, inters, PPsel (Sent), non-prd
-;  <ex>consistente en estar alerta/que estén alerta
-;  <todo>
+aj_pp_i-nprd_le := aj_pp_i-nprd_lex
+  """
+  
+  """.
+
+
 aj_cp_p-i-nprd_native_le := aj_cp_p-i-nprd_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_cp_p-i-nprd_le">
+  <description>(Rel.) Adjective, inters, PPsel (Sent), non-prd
+  <ex>consistente en estar alerta/que estén alerta
+  <todo>
   """.
 
-aj_cp_p-i-nprd_le := aj_cp_p-i-nprd_lex.
 
-;  <type val="aj_cp_q-i-nprd_le">
-;  <description>(Rel.) Adjective, inters, PPsel (Ques), non-prd
-;  <ex>consistente en cómo se ha ejercido...
-;  <todo>
+aj_cp_p-i-nprd_le := aj_cp_p-i-nprd_lex
+  """
+  
+  """.
+
+
 aj_cp_q-i-nprd_native_le := aj_cp_q-i-nprd_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_cp_q-i-nprd_le">
+  <description>(Rel.) Adjective, inters, PPsel (Ques), non-prd
+  <ex>consistente en cómo se ha ejercido...
+  <todo>
   """.
 
-aj_cp_q-i-nprd_le := aj_cp_q-i-nprd_lex.
 
-;  <type val="aj_-_s_le">
-;  <description>(Qual.) Adjective, scopal, no comp, ser/estar
-;  <ex>ésto es/está alto
-;  <todo>
+aj_cp_q-i-nprd_le := aj_cp_q-i-nprd_lex
+  """
+  
+  """.
+
+
 aj_-_s_native_le := aj_-_s_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_s_le">
+  <description>(Qual.) Adjective, scopal, no comp, ser/estar
+  <ex>ésto es/está alto
+  <todo>
   """.
 
-aj_-_s_le := aj_-_s_lex.
 
-;  <type val="aj_-_i_le">
-;  <description>(Qual.) Adjective, inters, no comp, ser/estar
-;  <ex>el cielo es/está azul
-;  <todo>
+aj_-_s_le := aj_-_s_lex
+  """
+  
+  """.
+
+
 aj_-_i_native_le := aj_-_i_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i_le">
+  <description>(Qual.) Adjective, inters, no comp, ser/estar
+  <ex>el cielo es/está azul
+  <todo>
   """.
 
-aj_-_i_le := aj_-_i_lex.
 
-;  <type val="aj_-_i-psth_le">
-;  <description>(Qual.) Adjective, inters, no comp, ser/estar, post-noun
-;  <ex>
-;  <todo>
+aj_-_i_le := aj_-_i_lex
+  """
+  
+  """.
+
+
 aj_-_i-psth_native_le := aj_-_i-psth_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i-psth_le">
+  <description>(Qual.) Adjective, inters, no comp, ser/estar, post-noun
+  <ex>
+  <todo>
   """.
 
-aj_-_i-psth_le := aj_-_i-psth_lex.
 
-;  <type val="aj_-_i-e_le">
-;  <description>(Qual.) Adjective, inters, no comp, estar
-;  <ex>está seco
-;  <todo>
+aj_-_i-psth_le := aj_-_i-psth_lex
+  """
+  
+  """.
+
+
 aj_-_i-e_native_le := aj_-_i-e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i-e_le">
+  <description>(Qual.) Adjective, inters, no comp, estar
+  <ex>está seco
+  <todo>
   """.
 
-aj_-_i-e_le := aj_-_i-e_lex.
 
-;  <type val="aj_pp_i_le">
-;  <description>(Qual.) Adjective, inters, PPsel, ser/estar
-;  <ex>es/está muy atento con sus compañeros
-;  <todo>
+aj_-_i-e_le := aj_-_i-e_lex
+  """
+  
+  """.
+
+
 aj_pp_i_native_le := aj_pp_i_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_pp_i_le">
+  <description>(Qual.) Adjective, inters, PPsel, ser/estar
+  <ex>es/está muy atento con sus compañeros
+  <todo>
   """.
 
-aj_pp_i_le := aj_pp_i_lex.
 
-;  <type val="aj_pp*_i_le">
-;  <description>(Qual.) Adjective, inters, PPsel (opt), ser/estar
-;  <ex>es/está muy vulnerable (a todo)
-;  <todo>
+aj_pp_i_le := aj_pp_i_lex
+  """
+  
+  """.
+
+
 aj_pp*_i_native_le := aj_pp*_i_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_pp*_i_le">
+  <description>(Qual.) Adjective, inters, PPsel (opt), ser/estar
+  <ex>es/está muy vulnerable (a todo)
+  <todo>
   """.
 
-aj_pp*_i_le := aj_pp*_i_lex.
 
-;  <type val="aj_pp_i-e_le">
-;  <description>(Qual.) Adjective, inters, PPsel, estar
-;  <ex>está atento a las notícias
-;  <todo>
+aj_pp*_i_le := aj_pp*_i_lex
+  """
+  
+  """.
+
+
 aj_pp_i-e_native_le := aj_pp_i-e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_pp_i-e_le">
+  <description>(Qual.) Adjective, inters, PPsel, estar
+  <ex>está atento a las notícias
+  <todo>
   """.
 
-aj_pp_i-e_le := aj_pp_i-e_lex.
 
-;  <type val="aj_pp*_i-e_le">
-;  <description>(Qual.) Adjective, inters, PPsel (opt), estar
-;  <ex>estoy harto (de tí)
-;  <todo>
+aj_pp_i-e_le := aj_pp_i-e_lex
+  """
+  
+  """.
+
+
 aj_pp*_i-e_native_le := aj_pp*_i-e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_pp*_i-e_le">
+  <description>(Qual.) Adjective, inters, PPsel (opt), estar
+  <ex>estoy harto (de tí)
+  <todo>
   """.
 
-aj_pp*_i-e_le := aj_pp*_i-e_lex.
 
-;  <type val="aj_cp_p-i-s_le">
-;  <description>(Qual.) Adjective, inters, PPsel (Sent/VPinf), ser
-;  <ex>es partidaria (de) que legalizen la droga/de legalizar la droga
-;  <todo>
+aj_pp*_i-e_le := aj_pp*_i-e_lex
+  """
+  
+  """.
+
+
 aj_cp_p-i-s_native_le := aj_cp_p-i-s_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_cp_p-i-s_le">
+  <description>(Qual.) Adjective, inters, PPsel (Sent/VPinf), ser
+  <ex>es partidaria (de) que legalizen la droga/de legalizar la droga
+  <todo>
   """.
 
-aj_cp_p-i-s_le := aj_cp_p-i-s_lex.
 
-;  <type val="aj_cp_p-i-e_le">
-;  <description>(Qual.) Adjective, inters, PPsel (Sent/VPinf), estar
-;  <ex>estoy segura (de) que vendrá/de cambiarlo
-;  <todo>
+aj_cp_p-i-s_le := aj_cp_p-i-s_lex
+  """
+  
+  """.
+
+
 aj_cp_p-i-e_native_le := aj_cp_p-i-e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_cp_p-i-e_le">
+  <description>(Qual.) Adjective, inters, PPsel (Sent/VPinf), estar
+  <ex>estoy segura (de) que vendrá/de cambiarlo
+  <todo>
   """.
 
-aj_cp_p-i-e_le := aj_cp_p-i-e_lex.
 
-;  <type val="aj_q_i-s_le">
-;  <description>(Qual.) Adjective, inters, PPsel (Ques), ser
-;  <ex>es muy revelador de cómo actuan
-;  <todo>
+aj_cp_p-i-e_le := aj_cp_p-i-e_lex
+  """
+  
+  """.
+
+
 aj_q_i-s_native_le := aj_q_i-s_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_q_i-s_le">
+  <description>(Qual.) Adjective, inters, PPsel (Ques), ser
+  <ex>es muy revelador de cómo actuan
+  <todo>
   """.
 
-aj_q_i-s_le := aj_q_i-s_lex.
 
-;  <type val="aj_q_i-e_le">
-;  <description>(Qual.) Adjective, inters, PPsel (Ques), estar
-;  <ex>no estoy muy seguro de cuándo/de si vendrá
-;  <todo>
+aj_q_i-s_le := aj_q_i-s_lex
+  """
+  
+  """.
+
+
 aj_q_i-e_native_le := aj_q_i-e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_q_i-e_le">
+  <description>(Qual.) Adjective, inters, PPsel (Ques), estar
+  <ex>no estoy muy seguro de cuándo/de si vendrá
+  <todo>
   """.
 
-aj_q_i-e_le := aj_q_i-e_lex.
 
-;  <type val="aj_vp_sr-i-s_le">
-;  <description>(Qual.) Adjective, inters, PPsel (VPinf, sbj-raising), ser
-;  <ex>soy muy libre de pensarlo
-;  <todo>
+aj_q_i-e_le := aj_q_i-e_lex
+  """
+  
+  """.
+
+
 aj_vp_sr-i-s_native_le := aj_vp_sr-i-s_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_vp_sr-i-s_le">
+  <description>(Qual.) Adjective, inters, PPsel (VPinf, sbj-raising), ser
+  <ex>soy muy libre de pensarlo
+  <todo>
   """.
 
-aj_vp_sr-i-s_le := aj_vp_sr-i-s_lex.
 
-;  <type val="aj_vp_sc-i-s_le">
-;  <description>(Qual.) Adjective, inters, PPsel (VPinf, sbj-ctrl), ser
-;  <ex>es aficionado a jugar a tenis
-;  <todo>
+aj_vp_sr-i-s_le := aj_vp_sr-i-s_lex
+  """
+  
+  """.
+
+
 aj_vp_sc-i-s_native_le := aj_vp_sc-i-s_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_vp_sc-i-s_le">
+  <description>(Qual.) Adjective, inters, PPsel (VPinf, sbj-ctrl), ser
+  <ex>es aficionado a jugar a tenis
+  <todo>
   """.
 
-aj_vp_sc-i-s_le := aj_vp_sc-i-s_lex.
 
-;  <type val="aj_vp_sc-i-e_le">
-;  <description>(Qual.) Adjective, inters, PPsel (VPinf, sbj-ctrl), estar
-;  <ex>no estoy seguro de poder hacerlo
-;  <todo>
+aj_vp_sc-i-s_le := aj_vp_sc-i-s_lex
+  """
+  
+  """.
+
+
 aj_vp_sc-i-e_native_le := aj_vp_sc-i-e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_vp_sc-i-e_le">
+  <description>(Qual.) Adjective, inters, PPsel (VPinf, sbj-ctrl), estar
+  <ex>no estoy seguro de poder hacerlo
+  <todo>
   """.
 
-aj_vp_sc-i-e_le := aj_vp_sc-i-e_lex.
 
-;  <type val="aj_vp_or-i-s_le">
-;  <description>(Qual.) Adjective, inters, PPsel (VPinf, obj-raising), ser
-;  <ex>el violín es muy difícil de tocar
-;  <todo>
+aj_vp_sc-i-e_le := aj_vp_sc-i-e_lex
+  """
+  
+  """.
+
+
 aj_vp_or-i-s_native_le := aj_vp_or-i-s_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_vp_or-i-s_le">
+  <description>(Qual.) Adjective, inters, PPsel (VPinf, obj-raising), ser
+  <ex>el violín es muy difícil de tocar
+  <todo>
   """.
 
-aj_vp_or-i-s_le := aj_vp_or-i-s_lex.
 
-;  <type val="aj_vp_oc-i-s_le">
-;  <description>(Qual.) Adjective, inters, PPsel (VPinf, obj-ctrl), estar
-;  <ex>está pendiente de firmar
-;  <todo>
-aj_vp_oc-i-s_le := aj_vp_oc-i-s_lex.
+aj_vp_or-i-s_le := aj_vp_or-i-s_lex
+  """
+  
+  """.
 
-;  <type val="aj_pp_i-cmp_le">
-;  <description>Adjective, Comparative, 
-;  <ex>A es mejor que B
-;  <todo>
+
+aj_vp_oc-i-s_le := aj_vp_oc-i-s_lex
+  """
+  <type val="aj_vp_oc-i-s_le">
+  <description>(Qual.) Adjective, inters, PPsel (VPinf, obj-ctrl), estar
+  <ex>está pendiente de firmar
+  <todo>
+  """.
+
+
 aj_pp_i-cmp_native_le := aj_pp_i-cmp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_pp_i-cmp_le">
+  <description>Adjective, Comparative,
+  <ex>A es mejor que B
+  <todo>
   """.
 
-aj_pp_i-cmp_le := aj_pp_i-cmp_lex.
 
-;  <type val="aj_pp_i-cmp-altp_le">
-;  <description>Adjective, Comparative
-;  <ex>A es anterior a/que B.
-;  <todo>
+aj_pp_i-cmp_le := aj_pp_i-cmp_lex
+  """
+  
+  """.
+
+
 aj_pp_i-cmp-altp_native_le := aj_pp_i-cmp-altp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_pp_i-cmp-altp_le">
+  <description>Adjective, Comparative
+  <ex>A es anterior a/que B.
+  <todo>
   """.
 
-aj_pp_i-cmp-altp_le := aj_pp_i-cmp-altp_lex.
 
-;  <type val="aj_pp_i-cmp-mas_le">
-;  <description>
-;  <ex>más de tres niños
-;  <todo>
+aj_pp_i-cmp-altp_le := aj_pp_i-cmp-altp_lex
+  """
+  
+  """.
+
+
 aj_pp_i-cmp-mas_native_le := aj_pp_i-cmp-mas_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_pp_i-cmp-mas_le">
+  <description>
+  <ex>más de tres niños
+  <todo>
   """.
 
-aj_pp_i-cmp-mas_le := aj_pp_i-cmp-mas_lex.
 
-;  <type val="aj_pp_i-cmp-menos_le">
-;  <description>
-;  <ex>menos de tres niños
-;  <todo>
+aj_pp_i-cmp-mas_le := aj_pp_i-cmp-mas_lex
+  """
+  
+  """.
+
+
 aj_pp_i-cmp-menos_native_le := aj_pp_i-cmp-menos_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_pp_i-cmp-menos_le">
+  <description>
+  <ex>menos de tres niños
+  <todo>
   """.
 
-aj_pp_i-cmp-menos_le := aj_pp_i-cmp-menos_lex.
 
-;  <type val="aj_pp_i-sup_le">
-;  <description>Adjective, Superlative
-;  <ex>A es el mejor.
-;  <todo>
+aj_pp_i-cmp-menos_le := aj_pp_i-cmp-menos_lex
+  """
+  
+  """.
+
+
 aj_pp_i-sup_native_le := aj_pp_i-sup_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_pp_i-sup_le">
+  <description>Adjective, Superlative
+  <ex>A es el mejor.
+  <todo>
   """.
 
-aj_pp_i-sup_le := aj_pp_i-sup_lex.
 
-;  <type val="aj_-_i-poss_le">
-;  <description>Adjective, possessives
-;  <ex>la canción tuya me gustó
-;  <todo>
+aj_pp_i-sup_le := aj_pp_i-sup_lex
+  """
+  
+  """.
+
+
 aj_-_i-poss_native_le := aj_-_i-poss_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i-poss_le">
+  <description>Adjective, possessives
+  <ex>la canción tuya me gustó
+  <todo>
   """.
 
-aj_-_i-poss_le := aj_-_i-poss_lex.
 
-;  <type val="aj_-_i-nu-ord_le">
-;  <description>Adjective, ordinal num
-;  <ex>los primeros pasos
-;  <todo>
+aj_-_i-poss_le := aj_-_i-poss_lex
+  """
+  
+  """.
+
+
 aj_-_i-nu-ord_native_le := aj_-_i-nu-ord_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i-nu-ord_le">
+  <description>Adjective, ordinal num
+  <ex>los primeros pasos
+  <todo>
   """.
 
-aj_-_i-nu-ord_le := aj_-_i-nu-ord_lex.
 
-;  <type val="aj_-_i-nu-ord-ms_le">
-;  <description>Adjective, ordinal num, masc sing
-;  <ex>el primer paso
-;  <todo>
+aj_-_i-nu-ord_le := aj_-_i-nu-ord_lex
+  """
+  
+  """.
+
+
 aj_-_i-nu-ord-ms_native_le := aj_-_i-nu-ord-ms_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i-nu-ord-ms_le">
+  <description>Adjective, ordinal num, masc sing
+  <ex>el primer paso
+  <todo>
   """.
 
-aj_-_i-nu-ord-ms_le := aj_-_i-nu-ord-ms_lex.
 
-;  <type val="aj_-_i-nu-part_le">
-;  <description>Adjective, partitive num
-;  <ex>
-;  <todo>
+aj_-_i-nu-ord-ms_le := aj_-_i-nu-ord-ms_lex
+  """
+  
+  """.
+
+
 aj_-_i-nu-part_native_le := aj_-_i-nu-part_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i-nu-part_le">
+  <description>Adjective, partitive num
+  <ex>
+  <todo>
   """.
 
-aj_-_i-nu-part_le := aj_-_i-nu-part_lex.
 
-;  <type val="aj_-_i-nu_mult_le">
-;  <description>Adjective, multiplicative num
-;  <ex>tiene (una) doble personalidad
-;  <todo>
+aj_-_i-nu-part_le := aj_-_i-nu-part_lex
+  """
+  
+  """.
+
+
 aj_-_i-nu-mult_native_le := aj_-_i-nu-mult_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="aj_-_i-nu_mult_le">
+  <description>Adjective, multiplicative num
+  <ex>tiene (una) doble personalidad
+  <todo>
   """.
 
-aj_-_i-nu-mult_le := aj_-_i-nu-mult_lex.
 
-;  <type val="p_np_ptcl_le">
-;  <description>Preposition, NP, sem empty
-;  <ex>cumple con su deber
-;  <todo>
+aj_-_i-nu-mult_le := aj_-_i-nu-mult_lex
+  """
+  
+  """.
+
+
 p_np_ptcl_native_le := p_np_ptcl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_ptcl_le">
+  <description>Preposition, NP, sem empty
+  <ex>cumple con su deber
+  <todo>
   """.
 
-p_np_ptcl_le := p_np_ptcl_lex.
 
-;  <type val="p_nb_ptcl_le">
-;  <description>Preposition, Nbar, sem empty
-;  <ex>
-;  <todo>
+p_np_ptcl_le := p_np_ptcl_lex
+  """
+  
+  """.
+
+
 p_nb_ptcl_native_le := p_nb_ptcl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_nb_ptcl_le">
+  <description>Preposition, Nbar, sem empty
+  <ex>
+  <todo>
   """.
 
-p_nb_ptcl_le := p_nb_ptcl_lex.
 
-;  <type val="p_np_ptcl-spd_le">
-;  <description>Preposition, NP, sem empty, spr (de)
-;  <ex>más de tres niños
-;  <todo>
-p_np_ptcl-spd_le := p_np_ptcl-spd_lex.
+p_nb_ptcl_le := p_nb_ptcl_lex
+  """
+  
+  """.
 
-;  <type val="p_cp_ptcl_le">
-;  <description>Preposition, Sfin, sem empty
-;  <ex>esperó a que llegase
-;  <todo>
+
+p_np_ptcl-spd_le := p_np_ptcl-spd_lex
+  """
+  <type val="p_np_ptcl-spd_le">
+  <description>Preposition, NP, sem empty, spr (de)
+  <ex>más de tres niños
+  <todo>
+  """.
+
+
 p_cp_ptcl_native_le := p_cp_ptcl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_cp_ptcl_le">
+  <description>Preposition, Sfin, sem empty
+  <ex>esperó a que llegase
+  <todo>
   """.
 
-p_cp_ptcl_le := p_cp_ptcl_lex.
 
-;  <type val="p_vp_ptcl_le">
-;  <description>Preposition, VPinf, sem empty
-;  <ex>confío en ganar
-;  <todo>
+p_cp_ptcl_le := p_cp_ptcl_lex
+  """
+  
+  """.
+
+
 p_vp_ptcl_native_le := p_vp_ptcl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_vp_ptcl_le">
+  <description>Preposition, VPinf, sem empty
+  <ex>confío en ganar
+  <todo>
   """.
 
-p_vp_ptcl_le := p_vp_ptcl_lex.
 
-;  <type val="p_nb_i-nm_le">
-;  <description>Prep, Nbar, N mod
-;  <ex>
-;  <todo>
+p_vp_ptcl_le := p_vp_ptcl_lex
+  """
+  
+  """.
+
+
 p_nb_i-nm_native_le := p_nb_i-nm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_nb_i-nm_le">
+  <description>Prep, Nbar, N mod
+  <ex>
+  <todo>
   """.
 
-p_nb_i-nm_le := p_nb_i-nm_lex.
 
-;  <type val="p_np_i-nm_le">
-;  <description>Preposition, NP, N mod
-;  <ex>
-;  <todo>
+p_nb_i-nm_le := p_nb_i-nm_lex
+  """
+  
+  """.
+
+
 p_np_i-nm_native_le := p_np_i-nm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-nm_le">
+  <description>Preposition, NP, N mod
+  <ex>
+  <todo>
   """.
 
-p_np_i-nm_le := p_np_i-nm_lex.
 
-;  <type val="p_np_i-pn-nm_le">
-;  <description>Preposition, NE, N mod
-;  <ex>
-;  <todo>
+p_np_i-nm_le := p_np_i-nm_lex
+  """
+  
+  """.
+
+
 p_np_i-pn-nm_native_le := p_np_i-pn-nm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-pn-nm_le">
+  <description>Preposition, NE, N mod
+  <ex>
+  <todo>
   """.
 
-p_np_i-pn-nm_le := p_np_i-pn-nm_lex.
 
-;  <type val="p_np_i-tmp-nm_le">
-;  <description>Preposition, temp NP, N mod
-;  <ex>el concierto del otro día
-;  <todo>
+p_np_i-pn-nm_le := p_np_i-pn-nm_lex
+  """
+  
+  """.
+
+
 p_np_i-tmp-nm_native_le := p_np_i-tmp-nm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-tmp-nm_le">
+  <description>Preposition, temp NP, N mod
+  <ex>el concierto del otro día
+  <todo>
   """.
 
-p_np_i-tmp-nm_le := p_np_i-tmp-nm_lex.
 
-;  <type val="p_vp_i-ctrl-nm_le">
-;  <description>Preposition, VPinf ctrl, N mod
-;  <ex>pan por cocer
-;  <todo>
+p_np_i-tmp-nm_le := p_np_i-tmp-nm_lex
+  """
+  
+  """.
+
+
 p_vp_i-ctrl-nm_native_le := p_vp_i-ctrl-nm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_vp_i-ctrl-nm_le">
+  <description>Preposition, VPinf ctrl, N mod
+  <ex>pan por cocer
+  <todo>
   """.
 
-p_vp_i-ctrl-nm_le := p_vp_i-ctrl-nm_lex.
 
-;  <type val="p_vp_i-nm_le">
-;  <description>Preposition, VPinf, N mod
-;  <ex>pan por cocer
-;  <todo>
+p_vp_i-ctrl-nm_le := p_vp_i-ctrl-nm_lex
+  """
+  
+  """.
+
+
 p_vp_i-nm_native_le := p_vp_i-nm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_vp_i-nm_le">
+  <description>Preposition, VPinf, N mod
+  <ex>pan por cocer
+  <todo>
   """.
 
-p_vp_i-nm_le := p_vp_i-nm_lex.
 
-;  <type val="p_pp_i-nm_le">
-;  <description>Preposition, PP, N mod
-;  <ex>el libro de sobre la mesa
-;  <todo>
+p_vp_i-nm_le := p_vp_i-nm_lex
+  """
+  
+  """.
+
+
 p_pp_i-nm_native_le := p_pp_i-nm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_pp_i-nm_le">
+  <description>Preposition, PP, N mod
+  <ex>el libro de sobre la mesa
+  <todo>
   """.
 
-p_pp_i-nm_le := p_pp_i-nm_lex.
 
-;  <type val="p_adv_i-nm_le">
-;  <description>Preposition, ADV, N mod
-;  <ex>las ganas de siempre
-;  <todo>
+p_pp_i-nm_le := p_pp_i-nm_lex
+  """
+  
+  """.
+
+
 p_adv_i-nm_native_le := p_adv_i-nm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_adv_i-nm_le">
+  <description>Preposition, ADV, N mod
+  <ex>las ganas de siempre
+  <todo>
   """.
 
-p_adv_i-nm_le := p_adv_i-nm_lex.
 
-;  <type val="pp_-_i-nm_le">
-;  <description>PP, N mod 
-;  <ex>un nombre así
-;  <todo>
+p_adv_i-nm_le := p_adv_i-nm_lex
+  """
+  
+  """.
+
+
 pp_-_i-nm_native_le := pp_-_i-nm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pp_-_i-nm_le">
+  <description>PP, N mod
+  <ex>un nombre así
+  <todo>
   """.
 
-pp_-_i-nm_le := pp_-_i-nm_lex.
 
-;  <type val="pp_-_i-nm-tmp_le">
-;  <description>PP, Ntemp mod 
-;  <ex>nueve horas después
-;  <todo>
+pp_-_i-nm_le := pp_-_i-nm_lex
+  """
+  
+  """.
+
+
 pp_-_i-nm-tmp_native_le := pp_-_i-nm-tmp_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pp_-_i-nm-tmp_le">
+  <description>PP, Ntemp mod
+  <ex>nueve horas después
+  <todo>
   """.
 
-pp_-_i-nm-tmp_le := pp_-_i-nm-tmp_lex.
 
-;  <type val="p_ap_i-nm_le">
-;  <description>Preposition, AP, V mod
-;  <ex>
-;  <todo>
+pp_-_i-nm-tmp_le := pp_-_i-nm-tmp_lex
+  """
+  
+  """.
+
+
 p_ap_i-nm_native_le := p_ap_i-nm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_ap_i-nm_le">
+  <description>Preposition, AP, V mod
+  <ex>
+  <todo>
   """.
 
-p_ap_i-nm_le := p_ap_i-nm_lex.
 
-;  <type val="p_nb_i-vm_le">
-;  <description>Preposition, Nbar, V mod
-;  <ex>
-;  <todo>
+p_ap_i-nm_le := p_ap_i-nm_lex
+  """
+  
+  """.
+
+
 p_nb_i-vm_native_le := p_nb_i-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_nb_i-vm_le">
+  <description>Preposition, Nbar, V mod
+  <ex>
+  <todo>
   """.
 
-p_nb_i-vm_le := p_nb_i-vm_lex.
 
-; 
-;  <type val="p_np_i-vm_le">
-;  <description>Preposition, NP, V mod
-;  <ex>
-;  <todo>
+p_nb_i-vm_le := p_nb_i-vm_lex
+  """
+  
+  """.
+
+
 p_np_i-vm_native_le := p_np_i-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-vm_le">
+  <description>Preposition, NP, V mod
+  <ex>
+  <todo>
   """.
 
-p_np_i-vm_le := p_np_i-vm_lex.
 
-;  <type val="p_np_i-pn-vm_le">
-;  <description>Preposition, NE, V mod
-;  <ex>
-;  <todo>
+p_np_i-vm_le := p_np_i-vm_lex
+  """
+  
+  """.
+
+
 p_np_i-pn-vm_native_le := p_np_i-pn-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-pn-vm_le">
+  <description>Preposition, NE, V mod
+  <ex>
+  <todo>
   """.
 
-p_np_i-pn-vm_le := p_np_i-pn-vm_lex.
 
-;  <type val="p_np_i-tmp-vm_le">
-;  <description>Preposition, temp NP, V mod
-;  <ex>te espero a las cinco
-;  <todo>
+p_np_i-pn-vm_le := p_np_i-pn-vm_lex
+  """
+  
+  """.
+
+
 p_np_i-tmp-vm_native_le := p_np_i-tmp-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-tmp-vm_le">
+  <description>Preposition, temp NP, V mod
+  <ex>te espero a las cinco
+  <todo>
   """.
 
-p_np_i-tmp-vm_le := p_np_i-tmp-vm_lex.
 
-;  <type val="p_np_i-tmp-durante-vm_le">
-;  <description>Preposition, temp NP, V mod (only for "durante")
-;  <ex>
-;  <todo>
+p_np_i-tmp-vm_le := p_np_i-tmp-vm_lex
+  """
+  
+  """.
+
+
 p_np_i-tmp-durante-vm_native_le := p_np_i-tmp-durante-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-tmp-durante-vm_le">
+  <description>Preposition, temp NP, V mod (only for "durante")
+  <ex>
+  <todo>
   """.
 
-p_np_i-tmp-durante-vm_le := p_np_i-tmp-durante-vm_lex.
 
-;  <type val="p_np-pp_i-vm_le">
-;  <description>Preposition, NP and PP, V mod
-;  <ex>Juan vive a 3km de Madrid
-;  <todo>
+p_np_i-tmp-durante-vm_le := p_np_i-tmp-durante-vm_lex
+  """
+  
+  """.
+
+
 p_np-pp_i-vm_native_le := p_np-pp_i-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np-pp_i-vm_le">
+  <description>Preposition, NP and PP, V mod
+  <ex>Juan vive a 3km de Madrid
+  <todo>
   """.
 
-p_np-pp_i-vm_le := p_np-pp_i-vm_lex.
 
-;  <type val="p_ap_i-vm_le">
-;  <description>Preposition, AP, V mod
-;  <ex>lloró por tonto
-;  <todo>
+p_np-pp_i-vm_le := p_np-pp_i-vm_lex
+  """
+  
+  """.
+
+
 p_ap_i-vm_native_le := p_ap_i-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_ap_i-vm_le">
+  <description>Preposition, AP, V mod
+  <ex>lloró por tonto
+  <todo>
   """.
 
-p_ap_i-vm_le := p_ap_i-vm_lex.
 
-;  <type val="p_adv_i-vm_le">
-;  <description>Preposition, ADV, V mod
-;  <ex>mira hacia atrás
-;  <todo>
+p_ap_i-vm_le := p_ap_i-vm_lex
+  """
+  
+  """.
+
+
 p_adv_i-vm_native_le := p_adv_i-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_adv_i-vm_le">
+  <description>Preposition, ADV, V mod
+  <ex>mira hacia atrás
+  <todo>
   """.
 
-p_adv_i-vm_le := p_adv_i-vm_lex.
 
-;  <type val="p_pp_i-vm_le">
-;  <description>Preposition, PP, V mod
-;  <ex>se lanzó desde sobre el tejado
-;  <todo>
+p_adv_i-vm_le := p_adv_i-vm_lex
+  """
+  
+  """.
+
+
 p_pp_i-vm_native_le := p_pp_i-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_pp_i-vm_le">
+  <description>Preposition, PP, V mod
+  <ex>se lanzó desde sobre el tejado
+  <todo>
   """.
 
-p_pp_i-vm_le := p_pp_i-vm_lex.
 
-;  <type val="p_pp_i-e-vm_le">
-;  <description>Preposition, PP (empty sem), V mod
-;  <ex>vengo a por agua
-;  <todo>
+p_pp_i-vm_le := p_pp_i-vm_lex
+  """
+  
+  """.
+
+
 p_pp_i-e-vm_native_le := p_pp_i-e-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_pp_i-e-vm_le">
+  <description>Preposition, PP (empty sem), V mod
+  <ex>vengo a por agua
+  <todo>
   """.
 
-p_pp_i-e-vm_le := p_pp_i-e-vm_lex.
 
-;  <type val="p_cl_vm_le">
-;  <description>Preposition, Sent, V mod 
-;  <ex>aunque se disculpe, no volveré
-;  <todo>
+p_pp_i-e-vm_le := p_pp_i-e-vm_lex
+  """
+  
+  """.
+
+
 p_cl_vm_native_le := p_cl_vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_cl_vm_le">
+  <description>Preposition, Sent, V mod
+  <ex>aunque se disculpe, no volveré
+  <todo>
   """.
 
-p_cl_vm_le := p_cl_vm_lex.
 
-;  <type val="p_cp_vm_le">
-;  <description>Preposition, Sent subord (complementizer), V mod
-;  <ex>con que vengan, no arreglas nada
-;  <todo>
+p_cl_vm_le := p_cl_vm_lex
+  """
+  
+  """.
+
+
 p_cp_vm_native_le := p_cp_vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_cp_vm_le">
+  <description>Preposition, Sent subord (complementizer), V mod
+  <ex>con que vengan, no arreglas nada
+  <todo>
   """.
 
-p_cp_vm_le := p_cp_vm_lex.
 
-;  <type val="p_vp_vm_le">
-;  <description>Preposition, VPinf, V mod
-;  <ex>al terminar la función, nos despedimos
-;  <todo>
+p_cp_vm_le := p_cp_vm_lex
+  """
+  
+  """.
+
+
 p_vp_vm_native_le := p_vp_vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_vp_vm_le">
+  <description>Preposition, VPinf, V mod
+  <ex>al terminar la función, nos despedimos
+  <todo>
   """.
 
-p_vp_vm_le := p_vp_vm_lex.
 
-;  <type val="p_vp_ctrl-vm_le">
-;  <description>Preposition, VPinf (control), V mod
-;  <ex>disparaban a matar
-;  <todo>
+p_vp_vm_le := p_vp_vm_lex
+  """
+  
+  """.
+
+
 p_vp_ctrl-vm_native_le := p_vp_ctrl-vm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_vp_ctrl-vm_le">
+  <description>Preposition, VPinf (control), V mod
+  <ex>disparaban a matar
+  <todo>
   """.
 
-p_vp_ctrl-vm_le := p_vp_ctrl-vm_lex.
 
-;  <type val="p_np_i-am_le">
-;  <description>Preposition, NP, A mod
-;  <ex>irritante al máximo
-;  <todo>
+p_vp_ctrl-vm_le := p_vp_ctrl-vm_lex
+  """
+  
+  """.
+
+
 p_np_i-am_native_le := p_np_i-am_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-am_le">
+  <description>Preposition, NP, A mod
+  <ex>irritante al máximo
+  <todo>
   """.
 
-p_np_i-am_le := p_np_i-am_lex.
 
-;  <type val="p_np_i-tmp-am_le">
-;  <description>Preposition, NP, A mod
-;  <ex>irritante al máximo
-;  <todo>
+p_np_i-am_le := p_np_i-am_lex
+  """
+  
+  """.
+
+
 p_np_i-tmp-am_native_le := p_np_i-tmp-am_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-tmp-am_le">
+  <description>Preposition, NP, A mod
+  <ex>irritante al máximo
+  <todo>
   """.
 
-p_np_i-tmp-am_le := p_np_i-tmp-am_lex.
 
-;  <type val="p_nb_i-am_le">
-;  <description>Preposition, Nbar, A mod
-;  <ex>
-;  <todo>
+p_np_i-tmp-am_le := p_np_i-tmp-am_lex
+  """
+  
+  """.
+
+
 p_nb_i-am_native_le := p_nb_i-am_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_nb_i-am_le">
+  <description>Preposition, Nbar, A mod
+  <ex>
+  <todo>
   """.
 
-p_nb_i-am_le := p_nb_i-am_lex.
 
-;  <type val="p_np_i-np-am_le">
-;  <description>Preposition, Nbar, A mod
-;  <ex>
-;  <todo>
+p_nb_i-am_le := p_nb_i-am_lex
+  """
+  
+  """.
+
+
 p_np_i-pn-am_native_le := p_np_i-pn-am_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-np-am_le">
+  <description>Preposition, Nbar, A mod
+  <ex>
+  <todo>
   """.
 
-p_np_i-pn-am_le := p_np_i-pn-am_lex.
 
-;  <type val="p_vp_i-ctrl-am_le">
-;  <description>Preposition, VPinf (ctrl), A mod
-;  <ex>llenas a reventar
-;  <todo>
+p_np_i-pn-am_le := p_np_i-pn-am_lex
+  """
+  
+  """.
+
+
 p_vp_i-ctrl-am_native_le := p_vp_i-ctrl-am_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_vp_i-ctrl-am_le">
+  <description>Preposition, VPinf (ctrl), A mod
+  <ex>llenas a reventar
+  <todo>
   """.
 
-p_vp_i-ctrl-am_le := p_vp_i-ctrl-am_lex.
 
-;  <type val="p_np_i-num_le">
-;  <description>Preposition, NP, A mod
-;  <ex>irritante al máximo
-;  <todo>
+p_vp_i-ctrl-am_le := p_vp_i-ctrl-am_lex
+  """
+  
+  """.
+
+
 p_np_i-num_native_le := p_np_i-num_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-num_le">
+  <description>Preposition, NP, A mod
+  <ex>irritante al máximo
+  <todo>
   """.
 
-p_np_i-num_le := p_np_i-num_lex.
 
-;  <type val="p_np_i-pm_le">
-;  <description>Preposition, NP, P mod
-;  <ex>a 20 metros sobre el nivel del mar
-;  <todo>
+p_np_i-num_le := p_np_i-num_lex
+  """
+  
+  """.
+
+
 p_np_i-pm_native_le := p_np_i-pm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-pm_le">
+  <description>Preposition, NP, P mod
+  <ex>a 20 metros sobre el nivel del mar
+  <todo>
   """.
 
-p_np_i-pm_le := p_np_i-pm_lex.
 
-;  <type val="p_np_i-orig-pm_le">
-;  <description>Preposition (orig), NP, P mod
-;  <ex>corrió de un extremo al otro
-;  <todo>
+p_np_i-pm_le := p_np_i-pm_lex
+  """
+  
+  """.
+
+
 p_np_i-orig-pm_native_le := p_np_i-orig-pm_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="p_np_i-orig-pm_le">
+  <description>Preposition (orig), NP, P mod
+  <ex>corrió de un extremo al otro
+  <todo>
   """.
 
-p_np_i-orig-pm_le := p_np_i-orig-pm_lex.
 
-;  <type val="d_-_art-d_le">
-;  <description>Determiner, def article
-;  <ex>los muchachos
-;  <todo>
+p_np_i-orig-pm_le := p_np_i-orig-pm_lex
+  """
+  
+  """.
+
+
 d_-_art-d_native_le := d_-_art-d_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_art-d_le">
+  <description>Determiner, def article
+  <ex>los muchachos
+  <todo>
   """.
 
-d_-_art-d_le := d_-_art-d_lex.
 
-;  <type val="d_-_art-i_le">
-;  <description>Determiner, indef article
-;  <ex>un muchacho
-;  <todo>
+d_-_art-d_le := d_-_art-d_lex
+  """
+  
+  """.
+
+
 d_-_art-i_native_le := d_-_art-i_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_art-i_le">
+  <description>Determiner, indef article
+  <ex>un muchacho
+  <todo>
   """.
 
-d_-_art-i_le := d_-_art-i_lex.
 
-;  <type val="d_-_poss-mi_le">
-;  <description>Determiner, poss, ("mi")
-;  <ex>mis amigos.
-;  <todo>
+d_-_art-i_le := d_-_art-i_lex
+  """
+  
+  """.
+
+
 d_-_poss-mi_native_le := d_-_poss-mi_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_poss-mi_le">
+  <description>Determiner, poss, ("mi")
+  <ex>mis amigos.
+  <todo>
   """.
 
-d_-_poss-mi_le := d_-_poss-mi_lex.
 
-;  <type val="d_-_poss-tu_le">
-;  <description>Determiner, poss, ("tu")
-;  <ex>tus amigos.
-;  <todo>
+d_-_poss-mi_le := d_-_poss-mi_lex
+  """
+  
+  """.
+
+
 d_-_poss-tu_native_le := d_-_poss-tu_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_poss-tu_le">
+  <description>Determiner, poss, ("tu")
+  <ex>tus amigos.
+  <todo>
   """.
 
-d_-_poss-tu_le := d_-_poss-tu_lex.
 
-;  <type val="d_-_poss-su_le">
-;  <description>Determiner, poss, ("su")
-;  <ex>sus amigos.
-;  <todo>
+d_-_poss-tu_le := d_-_poss-tu_lex
+  """
+  
+  """.
+
+
 d_-_poss-su_native_le := d_-_poss-su_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_poss-su_le">
+  <description>Determiner, poss, ("su")
+  <ex>sus amigos.
+  <todo>
   """.
 
-d_-_poss-su_le := d_-_poss-su_lex.
 
-;  <type val="d_-_poss-nuestro_le">
-;  <description>Determiner, poss, ("nuestro")
-;  <ex>nuestros amigos.
-;  <todo>
+d_-_poss-su_le := d_-_poss-su_lex
+  """
+  
+  """.
+
+
 d_-_poss-nuestro_native_le := d_-_poss-nuestro_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_poss-nuestro_le">
+  <description>Determiner, poss, ("nuestro")
+  <ex>nuestros amigos.
+  <todo>
   """.
 
-d_-_poss-nuestro_le := d_-_poss-nuestro_lex.
 
-;  <type val="d_-_poss-vuestro_le">
-;  <description>Determiner, poss, ("vuestro")
-;  <ex>vuestros amigos
-;  <todo>
+d_-_poss-nuestro_le := d_-_poss-nuestro_lex
+  """
+  
+  """.
+
+
 d_-_poss-vuestro_native_le := d_-_poss-vuestro_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_poss-vuestro_le">
+  <description>Determiner, poss, ("vuestro")
+  <ex>vuestros amigos
+  <todo>
   """.
 
-d_-_poss-vuestro_le := d_-_poss-vuestro_lex.
 
-;  <type val="d_-_dem-este_le">
-;  <description>Determiner, demons, ("este")
-;  <ex>este libro
-;  <todo>
+d_-_poss-vuestro_le := d_-_poss-vuestro_lex
+  """
+  
+  """.
+
+
 d_-_dem-este_native_le := d_-_dem-este_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_dem-este_le">
+  <description>Determiner, demons, ("este")
+  <ex>este libro
+  <todo>
   """.
 
-d_-_dem-este_le := d_-_dem-este_lex.
 
-;  <type val="d_-_dem-ese_le">
-;  <description>Determiner, demons, ("este")
-;  <ex>ese libro
-;  <todo>
+d_-_dem-este_le := d_-_dem-este_lex
+  """
+  
+  """.
+
+
 d_-_dem-ese_native_le := d_-_dem-ese_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_dem-ese_le">
+  <description>Determiner, demons, ("este")
+  <ex>ese libro
+  <todo>
   """.
 
-d_-_dem-ese_le := d_-_dem-ese_lex.
 
-;  <type val="d_-_dem-aquel_le">
-;  <description>Determiner, demons, ("aquel")
-;  <ex>aquel libro.
-;  <todo>
+d_-_dem-ese_le := d_-_dem-ese_lex
+  """
+  
+  """.
+
+
 d_-_dem-aquel_native_le := d_-_dem-aquel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_dem-aquel_le">
+  <description>Determiner, demons, ("aquel")
+  <ex>aquel libro.
+  <todo>
   """.
 
-d_-_dem-aquel_le := d_-_dem-aquel_lex.
 
-;  <type val="d_-_tal_le">
-;  <description>Determiner ("tal")
-;  <ex>tal ocasión
-;  <todo>
+d_-_dem-aquel_le := d_-_dem-aquel_lex
+  """
+  
+  """.
+
+
 d_-_tal_native_le := d_-_tal_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_tal_le">
+  <description>Determiner ("tal")
+  <ex>tal ocasión
+  <todo>
   """.
 
-d_-_tal_le := d_-_tal_lex.
 
-;  <type val="d_-_semejante_le">
-;  <description>Determiner ("semejante")
-;  <ex>semenjante persona
-;  <todo>
+d_-_tal_le := d_-_tal_lex
+  """
+  
+  """.
+
+
 d_-_semejante_native_le := d_-_semejante_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_semejante_le">
+  <description>Determiner ("semejante")
+  <ex>semenjante persona
+  <todo>
   """.
 
-d_-_semejante_le := d_-_semejante_lex.
 
-;  <type val="d_-_q-cualquier_le">
-;  <description>Determiner, quant., ("cualquier")
-;  <ex>cualquier muchacho
-;  <todo>
+d_-_semejante_le := d_-_semejante_lex
+  """
+  
+  """.
+
+
 d_-_q-cualquier_native_le := d_-_q-cualquier_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-cualquier_le">
+  <description>Determiner, quant., ("cualquier")
+  <ex>cualquier muchacho
+  <todo>
   """.
 
-d_-_q-cualquier_le := d_-_q-cualquier_lex.
 
-;  <type val="d_-_q-ambos_le">
-;  <description>Determiner, quant., ("ambos")
-;  <ex>ambos muchachos.
-;  <todo>
+d_-_q-cualquier_le := d_-_q-cualquier_lex
+  """
+  
+  """.
+
+
 d_-_q-ambos_native_le := d_-_q-ambos_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-ambos_le">
+  <description>Determiner, quant., ("ambos")
+  <ex>ambos muchachos.
+  <todo>
   """.
 
-d_-_q-ambos_le := d_-_q-ambos_lex.
 
-;  <type val="d_-_q-sendos_le">
-;  <description>Determiner, quant., ("sendos")
-;  <ex>sendos muchachos.
-;  <todo>
+d_-_q-ambos_le := d_-_q-ambos_lex
+  """
+  
+  """.
+
+
 d_-_q-sendos_native_le := d_-_q-sendos_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-sendos_le">
+  <description>Determiner, quant., ("sendos")
+  <ex>sendos muchachos.
+  <todo>
   """.
 
-d_-_q-sendos_le := d_-_q-sendos_lex.
 
-;  <type val="d_-_q-cada_le">
-;  <description>Determiner, quant., ("cada") 
-;  <ex>cada muchacho.
-;  <todo>
+d_-_q-sendos_le := d_-_q-sendos_lex
+  """
+  
+  """.
+
+
 d_-_q-cada_native_le := d_-_q-cada_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-cada_le">
+  <description>Determiner, quant., ("cada")
+  <ex>cada muchacho.
+  <todo>
   """.
 
-d_-_q-cada_le := d_-_q-cada_lex.
 
-;  <type val="d_-_q-todo_le">
-;  <description>Determiner, quant., ("todo")
-;  <ex>todos los muchachos.
-;  <todo>
+d_-_q-cada_le := d_-_q-cada_lex
+  """
+  
+  """.
+
+
 d_-_q-todo_native_le := d_-_q-todo_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-todo_le">
+  <description>Determiner, quant., ("todo")
+  <ex>todos los muchachos.
+  <todo>
   """.
 
-d_-_q-todo_le := d_-_q-todo_lex.
 
-;  <type val="d_-_q-prn-todo_le">
-;  <description>Determiner, quant., ("todo")
-;  <ex>todos esto
-;  <todo>
+d_-_q-todo_le := d_-_q-todo_lex
+  """
+  
+  """.
+
+
 d_-_q-prn-todo_native_le := d_-_q-prn-todo_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-prn-todo_le">
+  <description>Determiner, quant., ("todo")
+  <ex>todos esto
+  <todo>
   """.
 
-d_-_q-prn-todo_le := d_-_q-prn-todo_lex.
 
-;  <type val="d_-_q-algun_le">
-;  <description>Determiner, quant., ("algún")
-;  <ex>algún muchacho.
-;  <todo>
+d_-_q-prn-todo_le := d_-_q-prn-todo_lex
+  """
+  
+  """.
+
+
 d_-_q-algun_native_le := d_-_q-algun_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-algun_le">
+  <description>Determiner, quant., ("algún")
+  <ex>algún muchacho.
+  <todo>
   """.
 
-d_-_q-algun_le := d_-_q-algun_lex.
 
-;  <type val="d_-_q-ningun_le">
-;  <description>Determiner, quant., ("ningún")
-;  <ex>ningún muchacho.
-;  <todo>
+d_-_q-algun_le := d_-_q-algun_lex
+  """
+  
+  """.
+
+
 d_-_q-ningun_native_le := d_-_q-ningun_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-ningun_le">
+  <description>Determiner, quant., ("ningún")
+  <ex>ningún muchacho.
+  <todo>
   """.
 
-d_-_q-ningun_le := d_-_q-ningun_lex.
 
-;  <type val="d_-_q-cuantos_le">
-;  <description>Determiner, quant., "((unos) cuantos") 
-;  <ex>unos cuantos muchachos.
-;  <todo>
+d_-_q-ningun_le := d_-_q-ningun_lex
+  """
+  
+  """.
+
+
 d_-_q-cuantos_native_le := d_-_q-cuantos_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-cuantos_le">
+  <description>Determiner, quant., "((unos) cuantos")
+  <ex>unos cuantos muchachos.
+  <todo>
   """.
 
-d_-_q-cuantos_le := d_-_q-cuantos_lex.
 
-;  <type val="d_-_q-todo-sg_le">
-;  <description>Determiner, quant., ("todo", sing) 
-;  <ex>toda persona ajena a la empresa
-;  <todo>
+d_-_q-cuantos_le := d_-_q-cuantos_lex
+  """
+  
+  """.
+
+
 d_-_q-todo-sg_native_le := d_-_q-todo-sg_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-todo-sg_le">
+  <description>Determiner, quant., ("todo", sing)
+  <ex>toda persona ajena a la empresa
+  <todo>
   """.
 
-d_-_q-todo-sg_le := d_-_q-todo-sg_lex.
 
-;  <type val="d_-_q-otro_le">
-;  <description>Determiner, quant., ("otro")
-;  <ex>el otro muchacho.
-;  <todo>
+d_-_q-todo-sg_le := d_-_q-todo-sg_lex
+  """
+  
+  """.
+
+
 d_-_q-otro_native_le := d_-_q-otro_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-otro_le">
+  <description>Determiner, quant., ("otro")
+  <ex>el otro muchacho.
+  <todo>
   """.
 
-d_-_q-otro_le := d_-_q-otro_lex.
 
-;  <type val="d_-_q-mucho_le">
-;  <description>Determiner, quant., ("mucho") 
-;  <ex>muchos otros muchachos.
-;  <todo>
+d_-_q-otro_le := d_-_q-otro_lex
+  """
+  
+  """.
+
+
 d_-_q-mucho_native_le := d_-_q-mucho_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-mucho_le">
+  <description>Determiner, quant., ("mucho")
+  <ex>muchos otros muchachos.
+  <todo>
   """.
 
-d_-_q-mucho_le := d_-_q-mucho_lex.
 
-;  <type val="d_-_q-poco_le">
-;  <description>Determiner, quant., ("poco") 
-;  <ex>pocos muchachos.
-;  <todo>
+d_-_q-mucho_le := d_-_q-mucho_lex
+  """
+  
+  """.
+
+
 d_-_q-poco_native_le := d_-_q-poco_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-poco_le">
+  <description>Determiner, quant., ("poco")
+  <ex>pocos muchachos.
+  <todo>
   """.
 
-d_-_q-poco_le := d_-_q-poco_lex.
 
-;  <type val="d_-_q-bastante_le">
-;  <description>Determiner, quant., ("bastante") 
-;  <ex>bastantes muchachos.
-;  <todo>
+d_-_q-poco_le := d_-_q-poco_lex
+  """
+  
+  """.
+
+
 d_-_q-bastante_native_le := d_-_q-bastante_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-bastante_le">
+  <description>Determiner, quant., ("bastante")
+  <ex>bastantes muchachos.
+  <todo>
   """.
 
-d_-_q-bastante_le := d_-_q-bastante_lex.
 
-;  <type val="d_-_q-demasiado_le">
-;  <description>Determiner, quant., ("demasiado") 
-;  <ex>he comido demasiada sopa.
-;  <todo>
+d_-_q-bastante_le := d_-_q-bastante_lex
+  """
+  
+  """.
+
+
 d_-_q-demasiado_native_le := d_-_q-demasiado_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-demasiado_le">
+  <description>Determiner, quant., ("demasiado")
+  <ex>he comido demasiada sopa.
+  <todo>
   """.
 
-d_-_q-demasiado_le := d_-_q-demasiado_lex.
 
-;  <type val="d_-_q-varios_le">
-;  <description>Determiner, quant., ("varios")
-;  <ex>varios muchachos.
-;  <todo>
+d_-_q-demasiado_le := d_-_q-demasiado_lex
+  """
+  
+  """.
+
+
 d_-_q-varios_native_le := d_-_q-varios_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-varios_le">
+  <description>Determiner, quant., ("varios")
+  <ex>varios muchachos.
+  <todo>
   """.
 
-d_-_q-varios_le := d_-_q-varios_lex.
 
-;  <type val="d_-_q-multiples_le">
-;  <description>Determiner, quant., ("múltiples")
-;  <ex>varios muchachos.
-;  <todo>
+d_-_q-varios_le := d_-_q-varios_lex
+  """
+  
+  """.
+
+
 d_-_q-multiples_native_le := d_-_q-multiples_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-multiples_le">
+  <description>Determiner, quant., ("múltiples")
+  <ex>varios muchachos.
+  <todo>
   """.
 
-d_-_q-multiples_le := d_-_q-multiples_lex.
 
-;  <type val="d_-_q-demas_le">
-;  <description>Determiner, quant., ("demás")
-;  <ex>vinieron mi padre, mi madre y demás familia.
-;  <todo>
+d_-_q-multiples_le := d_-_q-multiples_lex
+  """
+  
+  """.
+
+
 d_-_q-demas_native_le := d_-_q-demas_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-demas_le">
+  <description>Determiner, quant., ("demás")
+  <ex>vinieron mi padre, mi madre y demás familia.
+  <todo>
   """.
 
-d_-_q-demas_le := d_-_q-demas_lex.
 
-;  <type val="d_pp_cmp-mas_le">
-;  <description>Determiner, compar, ("más")
-;  <ex>más niños que niñas
-;  <todo>
+d_-_q-demas_le := d_-_q-demas_lex
+  """
+  
+  """.
+
+
 d_pp_cmp-mas_native_le := d_pp_cmp-mas_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_pp_cmp-mas_le">
+  <description>Determiner, compar, ("más")
+  <ex>más niños que niñas
+  <todo>
   """.
 
-d_pp_cmp-mas_le := d_pp_cmp-mas_lex.
 
-;  <type val="d_pp_cmp-menos_le">
-;  <description>Determiner, compar, ("menos")
-;  <ex>menos niños que niñas
-;  <todo>
+d_pp_cmp-mas_le := d_pp_cmp-mas_lex
+  """
+  
+  """.
+
+
 d_pp_cmp-menos_native_le := d_pp_cmp-menos_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_pp_cmp-menos_le">
+  <description>Determiner, compar, ("menos")
+  <ex>menos niños que niñas
+  <todo>
   """.
 
-d_pp_cmp-menos_le := d_pp_cmp-menos_lex.
 
-;  <type val="d_pp_cmp-tanto_le">
-;  <description>Determiner, compar ("tanto")
-;  <ex>tantos niños como niñas
-;  <todo>
+d_pp_cmp-menos_le := d_pp_cmp-menos_lex
+  """
+  
+  """.
+
+
 d_pp_cmp-tanto_native_le := d_pp_cmp-tanto_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_pp_cmp-tanto_le">
+  <description>Determiner, compar ("tanto")
+  <ex>tantos niños como niñas
+  <todo>
   """.
 
-d_pp_cmp-tanto_le := d_pp_cmp-tanto_lex.
 
-;  <type val="d_pp_cmp-mas-de_le">
-;  <description>Determiner, compar ("más de")
-;  <ex>más de tres niños
-;  <todo>
-;  d_pp_cmp-mas-de_le := d_pp_cmp-mas-de_lex.
-;  <type val="d_pp_cmp-menos-de_le">
-;  <description>Determiner, compar ("menos de")
-;  <ex>menos de tres niños
-;  <todo>
-;  d_pp_cmp-menos-de_le := d_pp_cmp-menos-de_lex.
-;  <type val="d_-_rel-poss_le">
-;  <description>Determiner, rel ("cuyo")
-;  <ex>
-;  <todo>
+d_pp_cmp-tanto_le := d_pp_cmp-tanto_lex
+  """
+  
+  """.
+
+
 d_-_rel-poss_native_le := d_-_rel-poss_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_pp_cmp-mas-de_le">
+  <description>Determiner, compar ("más de")
+  <ex>más de tres niños
+  <todo>
+  d_pp_cmp-mas-de_le := d_pp_cmp-mas-de_lex.
+  <type val="d_pp_cmp-menos-de_le">
+  <description>Determiner, compar ("menos de")
+  <ex>menos de tres niños
+  <todo>
+  d_pp_cmp-menos-de_le := d_pp_cmp-menos-de_lex.
+  <type val="d_-_rel-poss_le">
+  <description>Determiner, rel ("cuyo")
+  <ex>
+  <todo>
   """.
 
-d_-_rel-poss_le := d_-_rel-poss_lex.
 
-;  <type val="d_-_wh-que_le">
-;  <description>Determiner, int ("qué")
-;  <ex>
-;  <todo>
+d_-_rel-poss_le := d_-_rel-poss_lex
+  """
+  
+  """.
+
+
 d_-_wh-que_native_le := d_-_wh-que_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_wh-que_le">
+  <description>Determiner, int ("qué")
+  <ex>
+  <todo>
   """.
 
-d_-_wh-que_le := d_-_wh-que_lex.
 
-;  <type val="d_-_wh-cual_le">
-;  <description>Determiner, int ("cuál")
-;  <ex>
-;  <todo>
-d_-_wh-cual_le := d_-_wh-cual_lex.
+d_-_wh-que_le := d_-_wh-que_lex
+  """
+  
+  """.
 
-;  <type val="d_-_wh-cuanto_le">
-;  <description>Determiner, int ("cuánto")
-;  <ex>
-;  <todo>
+
+d_-_wh-cual_le := d_-_wh-cual_lex
+  """
+  <type val="d_-_wh-cual_le">
+  <description>Determiner, int ("cuál")
+  <ex>
+  <todo>
+  """.
+
+
 d_-_wh-cuanto_native_le := d_-_wh-cuanto_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_wh-cuanto_le">
+  <description>Determiner, int ("cuánto")
+  <ex>
+  <todo>
   """.
 
-d_-_wh-cuanto_le := d_-_wh-cuanto_lex.
 
-;  <type val="d_-_q-nu-card_le">
-;  <description>Determiner, card num
-;  <ex>los tres hermanos
-;  <todo>
+d_-_wh-cuanto_le := d_-_wh-cuanto_lex
+  """
+  
+  """.
+
+
 d_-_q-nu-card_native_le := d_-_q-nu-card_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-nu-card_le">
+  <description>Determiner, card num
+  <ex>los tres hermanos
+  <todo>
   """.
 
-d_-_q-nu-card_le := d_-_q-nu-card_lex.
 
-;  <type val="d_-_q-nu-distr_le">
-;  <description>Determiner, distr num
-;  <ex>íbamos al cine tres de cada dos domingos
-;  <todo>
+d_-_q-nu-card_le := d_-_q-nu-card_lex
+  """
+  
+  """.
+
+
 d_-_q-nu-distr_native_le := d_-_q-nu-distr_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="d_-_q-nu-distr_le">
+  <description>Determiner, distr num
+  <ex>íbamos al cine tres de cada dos domingos
+  <todo>
   """.
 
-d_-_q-nu-distr_le := d_-_q-nu-distr_lex.
 
-;  <type val="cm_s_le">
-;  <description>Complementizer, Sent/Ques ("que")
-;  <ex>no me gusta que a los toros te pongas la minifalda.
-;  <ex>gritó que dónde habíamos puesto el dinero.
-;  <todo>
+d_-_q-nu-distr_le := d_-_q-nu-distr_lex
+  """
+  
+  """.
+
+
 cm_s_native_le := cm_s_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="cm_s_le">
+  <description>Complementizer, Sent/Ques ("que")
+  <ex>no me gusta que a los toros te pongas la minifalda.
+  <ex>gritó que dónde habíamos puesto el dinero.
+  <todo>
   """.
 
-cm_s_le := cm_s_lex.
 
-;  <type val="cm_s_q_le">
-;  <description>Complementizer, Ques ("si")
-;  <ex>no sé si vendrá.
-;  <todo>
+cm_s_le := cm_s_lex
+  """
+  
+  """.
+
+
 cm_s_q_native_le := cm_s_q_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="cm_s_q_le">
+  <description>Complementizer, Ques ("si")
+  <ex>no sé si vendrá.
+  <todo>
   """.
 
-cm_s_q_le := cm_s_q_lex.
 
-;  <type val="cm_vp_q_le">
-;  <description>Complementizer, Ques inf ("si")
-;  <ex>no sé si ir.
-;  <todo>
+cm_s_q_le := cm_s_q_lex
+  """
+  
+  """.
+
+
 cm_vp_q_native_le := cm_vp_q_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="cm_vp_q_le">
+  <description>Complementizer, Ques inf ("si")
+  <ex>no sé si ir.
+  <todo>
   """.
 
-cm_vp_q_le := cm_vp_q_lex.
 
-;  <type val="c_xp_comma_le">
-;  <description>Conjunction, Coord., (comma)
-;  <ex>Pablo llora, Oscar ríe.
-;  <todo>
+cm_vp_q_le := cm_vp_q_lex
+  """
+  
+  """.
+
+
 c_xp_comma_native_le := c_xp_comma_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_comma_le">
+  <description>Conjunction, Coord., (comma)
+  <ex>Pablo llora, Oscar ríe.
+  <todo>
   """.
 
-c_xp_comma_le := c_xp_comma_lex.
 
-;  <type val="c_xp_fstop_le">
-;  <description>Conjunction, Coord., (full-stop)
-;  <ex>Pablo llora. Oscar ríe.
-;  <todo>
+c_xp_comma_le := c_xp_comma_lex
+  """
+  
+  """.
+
+
 c_xp_fstop_native_le := c_xp_fstop_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_fstop_le">
+  <description>Conjunction, Coord., (full-stop)
+  <ex>Pablo llora. Oscar ríe.
+  <todo>
   """.
 
-c_xp_fstop_le := c_xp_fstop_lex.
 
-;  <type val="c_xp_semi-cln_le">
-;  <description>Conjunction, Coord., (semi-colon)
-;  <ex>Pablo llora; Oscar ríe.
-;  <todo>
+c_xp_fstop_le := c_xp_fstop_lex
+  """
+  
+  """.
+
+
 c_xp_semi-cln_native_le := c_xp_semi-cln_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_semi-cln_le">
+  <description>Conjunction, Coord., (semi-colon)
+  <ex>Pablo llora; Oscar ríe.
+  <todo>
   """.
 
-c_xp_semi-cln_le := c_xp_semi-cln_lex.
 
-;  <type val="c_xp_y_le">
-;  <description>Conjunction, Coord., ("y")
-;  <ex>Oscar y Pablo lloran lloran.
-;  <todo>
+c_xp_semi-cln_le := c_xp_semi-cln_lex
+  """
+  
+  """.
+
+
 c_xp_y_native_le := c_xp_y_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_y_le">
+  <description>Conjunction, Coord., ("y")
+  <ex>Oscar y Pablo lloran lloran.
+  <todo>
   """.
 
-c_xp_y_le := c_xp_y_lex.
 
-;  <type val="c_xp_e_le">
-;  <description>Conjunction, Coord., ("e")
-;  <ex>Ana e Inés lloran.
-;  <todo>
+c_xp_y_le := c_xp_y_lex
+  """
+  
+  """.
+
+
 c_xp_e_native_le := c_xp_e_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_e_le">
+  <description>Conjunction, Coord., ("e")
+  <ex>Ana e Inés lloran.
+  <todo>
   """.
 
-c_xp_e_le := c_xp_e_lex.
 
-;  <type val="c_xp_o_le">
-;  <description>Conjunction, Coord., ("o")
-;  <ex>vendrá Oscar o Pablo.
-;  <todo>
+c_xp_e_le := c_xp_e_lex
+  """
+  
+  """.
+
+
 c_xp_o_native_le := c_xp_o_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_o_le">
+  <description>Conjunction, Coord., ("o")
+  <ex>vendrá Oscar o Pablo.
+  <todo>
   """.
 
-c_xp_o_le := c_xp_o_lex.
 
-;  <type val="c_xp_u_le">
-;  <description>Conjunction, Coord., ("u")
-;  <ex>vendrá Pablo u Oscar.
-;  <todo>
+c_xp_o_le := c_xp_o_lex
+  """
+  
+  """.
+
+
 c_xp_u_native_le := c_xp_u_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_u_le">
+  <description>Conjunction, Coord., ("u")
+  <ex>vendrá Pablo u Oscar.
+  <todo>
   """.
 
-c_xp_u_le := c_xp_u_lex.
 
-;  <type val="c_xp_o-nrel_le">
-;  <description>Conjunction, o, no-rel
-;  <ex>vendrá o Pablo o Sara.
-;  <todo>
+c_xp_u_le := c_xp_u_lex
+  """
+  
+  """.
+
+
 c_xp_o-nrel_native_le := c_xp_o-nrel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_o-nrel_le">
+  <description>Conjunction, o, no-rel
+  <ex>vendrá o Pablo o Sara.
+  <todo>
   """.
 
-c_xp_o-nrel_le := c_xp_o-nrel_lex.
 
-;  <type val="c_xp_u-nrel_le">
-;  <description>Conjunction, Coord., ("u", no-rel)
-;  <ex>vendrá A u O.
-;  <todo>
+c_xp_o-nrel_le := c_xp_o-nrel_lex
+  """
+  
+  """.
+
+
 c_xp_u-nrel_native_le := c_xp_u-nrel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_u-nrel_le">
+  <description>Conjunction, Coord., ("u", no-rel)
+  <ex>vendrá A u O.
+  <todo>
   """.
 
-c_xp_u-nrel_le := c_xp_u-nrel_lex.
 
-;  <type val="c_xp_ni_le">
-;  <description>Conjunction, Coord., ("ni")
-;  <ex>no traje el libro ni para Juan ni para Pedro.
-;  <todo>
+c_xp_u-nrel_le := c_xp_u-nrel_lex
+  """
+  
+  """.
+
+
 c_xp_ni_native_le := c_xp_ni_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_ni_le">
+  <description>Conjunction, Coord., ("ni")
+  <ex>no traje el libro ni para Juan ni para Pedro.
+  <todo>
   """.
 
-c_xp_ni_le := c_xp_ni_lex.
 
-;  <type val="c_xp_ni-nrel_le">
-;  <description>Conjunction, Coord., ("ni", no-rel)
-;  <ex>no traje el libro ni para Juan ni para Pedro.
-;  <todo>
+c_xp_ni_le := c_xp_ni_lex
+  """
+  
+  """.
+
+
 c_xp_ni-nrel_native_le := c_xp_ni-nrel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_ni-nrel_le">
+  <description>Conjunction, Coord., ("ni", no-rel)
+  <ex>no traje el libro ni para Juan ni para Pedro.
+  <todo>
   """.
 
-c_xp_ni-nrel_le := c_xp_ni-nrel_lex.
 
-;  <type val="c_xp_sea_le">
-;  <description>Conjunction, Coord., ("sea")
-;  <ex>lo compraremos de todos modos, sea grande (o) sea pequeño
-;  <todo>
+c_xp_ni-nrel_le := c_xp_ni-nrel_lex
+  """
+  
+  """.
+
+
 c_xp_sea_native_le := c_xp_sea_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_sea_le">
+  <description>Conjunction, Coord., ("sea")
+  <ex>lo compraremos de todos modos, sea grande (o) sea pequeño
+  <todo>
   """.
 
-c_xp_sea_le := c_xp_sea_lex.
 
-;  <type val="c_xp_sea-nrel_le">
-;  <description>Conjunction, Coord., ("sea", no-rel)
-;  <ex>lo compraremos de todos modos, sea grande sea pequeño
-;  <todo>
+c_xp_sea_le := c_xp_sea_lex
+  """
+  
+  """.
+
+
 c_xp_sea-nrel_native_le := c_xp_sea-nrel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_sea-nrel_le">
+  <description>Conjunction, Coord., ("sea", no-rel)
+  <ex>lo compraremos de todos modos, sea grande sea pequeño
+  <todo>
   """.
 
-c_xp_sea-nrel_le := c_xp_sea-nrel_lex.
 
-;  <type val="c_xp_o-sea-nrel_le">
-;  <description>Conjunction, Coord., ("o sea", no-rel)
-;  <ex>lo compraremos de todos modos, sea grande o sea pequeño
-;  <todo>
+c_xp_sea-nrel_le := c_xp_sea-nrel_lex
+  """
+  
+  """.
+
+
 c_xp_o-sea-nrel_native_le := c_xp_o-sea-nrel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_o-sea-nrel_le">
+  <description>Conjunction, Coord., ("o sea", no-rel)
+  <ex>lo compraremos de todos modos, sea grande o sea pequeño
+  <todo>
   """.
 
-c_xp_o-sea-nrel_le := c_xp_o-sea-nrel_lex.
 
-;  <type val="c_xp_bien_le">
-;  <description>Conjunction, Coord., ("bien")
-;  <ex>el cartero recoge el correo bien en la tarde bien en la mañana
-;  <todo>
+c_xp_o-sea-nrel_le := c_xp_o-sea-nrel_lex
+  """
+  
+  """.
+
+
 c_xp_bien_native_le := c_xp_bien_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_bien_le">
+  <description>Conjunction, Coord., ("bien")
+  <ex>el cartero recoge el correo bien en la tarde bien en la mañana
+  <todo>
   """.
 
-c_xp_bien_le := c_xp_bien_lex.
 
-;  <type val="c_xp_bien-nrel_le">
-;  <description>Conjunction, bien, no-rel
-;  <ex>el cartero recoge el correo bien en la tarde bien en la mañana
-;  <todo>
+c_xp_bien_le := c_xp_bien_lex
+  """
+  
+  """.
+
+
 c_xp_bien-nrel_native_le := c_xp_bien-nrel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_bien-nrel_le">
+  <description>Conjunction, bien, no-rel
+  <ex>el cartero recoge el correo bien en la tarde bien en la mañana
+  <todo>
   """.
 
-c_xp_bien-nrel_le := c_xp_bien-nrel_lex.
 
-;  <type val="c_xp_o-bien_le">
-;  <description>Conjunction, Coord., ("o bien")
-;  <ex>el cartero recoge el correo o bien en la tarde o bien en la mañana.
-;  <todo>
+c_xp_bien-nrel_le := c_xp_bien-nrel_lex
+  """
+  
+  """.
+
+
 c_xp_o-bien_native_le := c_xp_o-bien_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_o-bien_le">
+  <description>Conjunction, Coord., ("o bien")
+  <ex>el cartero recoge el correo o bien en la tarde o bien en la mañana.
+  <todo>
   """.
 
-c_xp_o-bien_le := c_xp_o-bien_lex.
 
-;  <type val="c_xp_o-bien-nrel_le">
-;  <description>Conjunction, Coord., ("o bien", no-rel)
-;  <ex>el cartero recoge el correo bien en la tarde o bien en la mañana.
-;  <todo>
+c_xp_o-bien_le := c_xp_o-bien_lex
+  """
+  
+  """.
+
+
 c_xp_o-bien-nrel_native_le := c_xp_o-bien-nrel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_o-bien-nrel_le">
+  <description>Conjunction, Coord., ("o bien", no-rel)
+  <ex>el cartero recoge el correo bien en la tarde o bien en la mañana.
+  <todo>
   """.
 
-c_xp_o-bien-nrel_le := c_xp_o-bien-nrel_lex.
 
-;  <type val="c_xp_o-bien-nrel-o-bien_le">
-;  <description>Conjunction, Coord., ("o bien ... o bien", no-rel)
-;  <ex>el cartero recoge el correo o bien en la tarde o bien en la mañana.
-;  <todo>
+c_xp_o-bien-nrel_le := c_xp_o-bien-nrel_lex
+  """
+  
+  """.
+
+
 c_xp_o-bien-nrel-o-bien_native_le := c_xp_o-bien-nrel-o-bien_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_o-bien-nrel-o-bien_le">
+  <description>Conjunction, Coord., ("o bien ... o bien", no-rel)
+  <ex>el cartero recoge el correo o bien en la tarde o bien en la mañana.
+  <todo>
   """.
 
-c_xp_o-bien-nrel-o-bien_le := c_xp_o-bien-nrel-o-bien_lex.
 
-;  <type val="c_xp_ora_le">
-;  <description>Conjunction, Coord., ("ora")
-;  <ex>tomando ora la espada, ora la pluma
-;  <todo>
+c_xp_o-bien-nrel-o-bien_le := c_xp_o-bien-nrel-o-bien_lex
+  """
+  
+  """.
+
+
 c_xp_ora_native_le := c_xp_ora_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_ora_le">
+  <description>Conjunction, Coord., ("ora")
+  <ex>tomando ora la espada, ora la pluma
+  <todo>
   """.
 
-c_xp_ora_le := c_xp_ora_lex.
 
-;  <type val="c_xp_ora-nrel_le">
-;  <description>Conjunction, Coord., ("ora", no-rel)
-;  <ex>tomando ora la espada, ora la pluma
-;  <todo>
+c_xp_ora_le := c_xp_ora_lex
+  """
+  
+  """.
+
+
 c_xp_ora-nrel_native_le := c_xp_ora-nrel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_ora-nrel_le">
+  <description>Conjunction, Coord., ("ora", no-rel)
+  <ex>tomando ora la espada, ora la pluma
+  <todo>
   """.
 
-c_xp_ora-nrel_le := c_xp_ora-nrel_lex.
 
-;  <type val="c_xp_tanto_le">
-;  <description>Conjunction, Coord., ("tanto")
-;  <ex>tanto el vino como la cerveza contienen alcohol
-;  <todo>
+c_xp_ora-nrel_le := c_xp_ora-nrel_lex
+  """
+  
+  """.
+
+
 c_xp_tanto_native_le := c_xp_tanto_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_tanto_le">
+  <description>Conjunction, Coord., ("tanto")
+  <ex>tanto el vino como la cerveza contienen alcohol
+  <todo>
   """.
 
-c_xp_tanto_le := c_xp_tanto_lex.
 
-;  <type val="c_xp_como-nrel_le">
-;  <description>Conjunction, Coord., ("como")
-;  <ex>tanto el vino como la cerveza contienen alcohol
-;  <todo>
+c_xp_tanto_le := c_xp_tanto_lex
+  """
+  
+  """.
+
+
 c_xp_como-nrel_native_le := c_xp_como-nrel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_como-nrel_le">
+  <description>Conjunction, Coord., ("como")
+  <ex>tanto el vino como la cerveza contienen alcohol
+  <todo>
   """.
 
-c_xp_como-nrel_le := c_xp_como-nrel_lex.
 
-;  <type val="c_xp_no-sólo_le">
-;  <description>Conjunction, Coord., ("no sólo")
-;  <ex>no sólo el vino, sino la cerveza contienen alcohol
-;  <todo>
+c_xp_como-nrel_le := c_xp_como-nrel_lex
+  """
+  
+  """.
+
+
 c_xp_no-sólo_native_le := c_xp_no-sólo_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_no-sólo_le">
+  <description>Conjunction, Coord., ("no sólo")
+  <ex>no sólo el vino, sino la cerveza contienen alcohol
+  <todo>
   """.
 
-c_xp_no-sólo_le := c_xp_no-sólo_lex.
 
-;  <type val="c_xp_sino-nrel_le">
-;  <description>Conjunction, Coord., ("sino", no-rel)
-;  <ex>no sólo el vino, sino la cerveza contienen alcohol
-;  <todo>
+c_xp_no-sólo_le := c_xp_no-sólo_lex
+  """
+  
+  """.
+
+
 c_xp_sino-nrel_native_le := c_xp_sino-nrel_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_sino-nrel_le">
+  <description>Conjunction, Coord., ("sino", no-rel)
+  <ex>no sólo el vino, sino la cerveza contienen alcohol
+  <todo>
   """.
 
-c_xp_sino-nrel_le := c_xp_sino-nrel_lex.
 
-;  <type val="c_xp_así-como_le">
-;  <description>Conjunction, Coord., ("así como")
-;  <ex>el vino, así como la cerveza, contienen alcohol
-;  <todo>
+c_xp_sino-nrel_le := c_xp_sino-nrel_lex
+  """
+  
+  """.
+
+
 c_xp_así-como_native_le := c_xp_así-como_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_así-como_le">
+  <description>Conjunction, Coord., ("así como")
+  <ex>el vino, así como la cerveza, contienen alcohol
+  <todo>
   """.
 
-c_xp_así-como_le := c_xp_así-como_lex.
 
-;  <type val="c_xp_aunque_le">
-;  <description>Conjunction, advers., ("aunque")
-;  <ex>vino con mi hermano, aunque no con mi hermana
-;  <todo>
+c_xp_así-como_le := c_xp_así-como_lex
+  """
+  
+  """.
+
+
 c_xp_aunque_native_le := c_xp_aunque_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_aunque_le">
+  <description>Conjunction, advers., ("aunque")
+  <ex>vino con mi hermano, aunque no con mi hermana
+  <todo>
   """.
 
-c_xp_aunque_le := c_xp_aunque_lex.
 
-;  <type val="c_xp_siquiera_le">
-;  <description>Conjunction, advers., ("siquiera")
-;  <ex>
-;  <todo>
+c_xp_aunque_le := c_xp_aunque_lex
+  """
+  
+  """.
+
+
 c_xp_siquiera_native_le := c_xp_siquiera_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_siquiera_le">
+  <description>Conjunction, advers., ("siquiera")
+  <ex>
+  <todo>
   """.
 
-c_xp_siquiera_le := c_xp_siquiera_lex.
 
-;  <type val="c_xp_siquier_le">
-;  <description>Conjunction, advers., ("siquier")
-;  <ex>
-;  <todo>
+c_xp_siquiera_le := c_xp_siquiera_lex
+  """
+  
+  """.
+
+
 c_xp_siquier_native_le := c_xp_siquier_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_siquier_le">
+  <description>Conjunction, advers., ("siquier")
+  <ex>
+  <todo>
   """.
 
-c_xp_siquier_le := c_xp_siquier_lex.
 
-;  <type val="c_xp_mas_le">
-;  <description>Conjunction, advers., ("mas")
-;  <ex>vino con mi hermano, mas no con mi hermana
-;  <todo>
+c_xp_siquier_le := c_xp_siquier_lex
+  """
+  
+  """.
+
+
 c_xp_mas_native_le := c_xp_mas_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_mas_le">
+  <description>Conjunction, advers., ("mas")
+  <ex>vino con mi hermano, mas no con mi hermana
+  <todo>
   """.
 
-c_xp_mas_le := c_xp_mas_lex.
 
-;  <type val="c_xp_pero_le">
-;  <description>Conjunction, advers., ("pero")
-;  <ex>el miércoles iremos a ver a Pepe, pero el jueves volveremos aquí
-;  <todo>
+c_xp_mas_le := c_xp_mas_lex
+  """
+  
+  """.
+
+
 c_xp_pero_native_le := c_xp_pero_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_pero_le">
+  <description>Conjunction, advers., ("pero")
+  <ex>el miércoles iremos a ver a Pepe, pero el jueves volveremos aquí
+  <todo>
   """.
 
-c_xp_pero_le := c_xp_pero_lex.
 
-;  <type val="c_xp_empero_le">
-;  <description>Conjunction, advers., ("empero")
-;  <ex>
-;  <todo>
+c_xp_pero_le := c_xp_pero_lex
+  """
+  
+  """.
+
+
 c_xp_empero_native_le := c_xp_empero_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_empero_le">
+  <description>Conjunction, advers., ("empero")
+  <ex>
+  <todo>
   """.
 
-c_xp_empero_le := c_xp_empero_lex.
 
-;  <type val="c_xp_sino_le">
-;  <description>Conjunction, advers., ("sino")
-;  <ex>no recogímos a Rosa sino a Elena
-;  <todo>
+c_xp_empero_le := c_xp_empero_lex
+  """
+  
+  """.
+
+
 c_xp_sino_native_le := c_xp_sino_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_sino_le">
+  <description>Conjunction, advers., ("sino")
+  <ex>no recogímos a Rosa sino a Elena
+  <todo>
   """.
 
-c_xp_sino_le := c_xp_sino_lex.
 
-;  <type val="c_xp_sino-que_le">
-;  <description>Conjunction, advers., ("sino que")
-;  <ex>
-;  <todo>
+c_xp_sino_le := c_xp_sino_lex
+  """
+  
+  """.
+
+
 c_xp_sino-que_native_le := c_xp_sino-que_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="c_xp_sino-que_le">
+  <description>Conjunction, advers., ("sino que")
+  <ex>
+  <todo>
   """.
 
-c_xp_sino-que_le := c_xp_sino-que_lex.
 
-;  <type val="i_-_le">
-;  <description>interjection
-;  <ex>
-;  <todo>
+c_xp_sino-que_le := c_xp_sino-que_lex
+  """
+  
+  """.
+
+
 i_-_native_le := i_-_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="i_-_le">
+  <description>interjection
+  <ex>
+  <todo>
   """.
 
-i_-_le := i_-_lex.
 
-;  <type val="pt_-_fstop_le">
-;  <description>Punct, full stop
-;  <ex>
-;  <todo>
+i_-_le := i_-_lex
+  """
+  
+  """.
+
+
 pt_-_fstop_native_le := pt_-_fstop_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_fstop_le">
+  <description>Punct, full stop
+  <ex>
+  <todo>
   """.
 
-pt_-_fstop_le := pt_-_fstop_lex.
 
-;  <type val="pt_-_3dots_le">
-;  <description>Punct, 3 dots
-;  <ex>
-;  <todo>
+pt_-_fstop_le := pt_-_fstop_lex
+  """
+  
+  """.
+
+
 pt_-_3dots_native_le := pt_-_3dots_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_3dots_le">
+  <description>Punct, 3 dots
+  <ex>
+  <todo>
   """.
 
-pt_-_3dots_le := pt_-_3dots_lex.
 
-;  <type val="pt_-_comma_le">
-;  <description>Punct, comma
-;  <ex>
-;  <todo>
+pt_-_3dots_le := pt_-_3dots_lex
+  """
+  
+  """.
+
+
 pt_-_comma_native_le := pt_-_comma_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_comma_le">
+  <description>Punct, comma
+  <ex>
+  <todo>
   """.
 
-pt_-_comma_le := pt_-_comma_lex.
 
-;  <type val="pt_-_cln_le">
-;  <description>Punct, colon
-;  <ex>
-;  <todo>
+pt_-_comma_le := pt_-_comma_lex
+  """
+  
+  """.
+
+
 pt_-_cln_native_le := pt_-_cln_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_cln_le">
+  <description>Punct, colon
+  <ex>
+  <todo>
   """.
 
-pt_-_cln_le := pt_-_cln_lex.
 
-;  <type val="pt_-_quots_le">
-;  <description>Punct, quotes
-;  <ex>
-;  <todo>
-pt_-_quots_le := pt_-_quots_lex.
+pt_-_cln_le := pt_-_cln_lex
+  """
+  
+  """.
 
-;  <type val="pt_-_hyphn_le">
-;  <description>Punct, hyphen
-;  <ex>
-;  <todo>
+
+pt_-_quots_le := pt_-_quots_lex
+  """
+  <type val="pt_-_quots_le">
+  <description>Punct, quotes
+  <ex>
+  <todo>
+  """.
+
+
 pt_-_lhyphn_native_le := pt_-_lhyphn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_hyphn_le">
+  <description>Punct, hyphen
+  <ex>
+  <todo>
   """.
 
 
-;  <type val="pt_-_hyphn_le">
-;  <description>Punct, hyphen
-;  <ex>
-;  <todo>
 pt_-_hyphn_native_le := pt_-_hyphn_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_hyphn_le">
+  <description>Punct, hyphen
+  <ex>
+  <todo>
   """.
 
-pt_-_hyphn_le := pt_-_hyphn_lex.
 
-;  <type val="pt_-_quest-op_le">
-;  <description>Punct, question mark, open
-;  <ex>
-;  <todo>
+pt_-_hyphn_le := pt_-_hyphn_lex
+  """
+  
+  """.
+
+
 pt_-_quest-op_native_le := pt_-_quest-op_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_quest-op_le">
+  <description>Punct, question mark, open
+  <ex>
+  <todo>
   """.
 
-pt_-_quest-op_le := pt_-_quest-op_lex.
 
-;  <type val="pt_-_quest-cl_le">
-;  <description>Punct, question mark, close
-;  <ex>
-;  <todo>
+pt_-_quest-op_le := pt_-_quest-op_lex
+  """
+  
+  """.
+
+
 pt_-_quest-cl_native_le := pt_-_quest-cl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_quest-cl_le">
+  <description>Punct, question mark, close
+  <ex>
+  <todo>
   """.
 
-pt_-_quest-cl_le := pt_-_quest-cl_lex.
 
-;  <type val="pt_-_excl-op_le">
-;  <description>Punct, exclamation, open
-;  <ex>
-;  <todo>
+pt_-_quest-cl_le := pt_-_quest-cl_lex
+  """
+  
+  """.
+
+
 pt_-_excl-op_native_le := pt_-_excl-op_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_excl-op_le">
+  <description>Punct, exclamation, open
+  <ex>
+  <todo>
   """.
 
-pt_-_excl-op_le := pt_-_excl-op_lex.
 
-;  <type val="pt_-_excl-cl_le">
-;  <description>Punct, exclamation, close
-;  <ex>
-;  <todo>
+pt_-_excl-op_le := pt_-_excl-op_lex
+  """
+  
+  """.
+
+
 pt_-_excl-cl_native_le := pt_-_excl-cl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_excl-cl_le">
+  <description>Punct, exclamation, close
+  <ex>
+  <todo>
   """.
 
-pt_-_excl-cl_le := pt_-_excl-cl_lex.
 
-;  <type val="pt_-_brckt-op_le">
-;  <description>Punct, brackets, open
-;  <ex>
-;  <todo>
+pt_-_excl-cl_le := pt_-_excl-cl_lex
+  """
+  
+  """.
+
+
 pt_-_brckt-op_native_le := pt_-_brckt-op_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_brckt-op_le">
+  <description>Punct, brackets, open
+  <ex>
+  <todo>
   """.
 
-pt_-_brckt-op_le := pt_-_brckt-op_lex.
 
-;  <type val="pt_-_brckt-cl_le">
-;  <description>Punct, brackets, close
-;  <ex>
-;  <todo>
+pt_-_brckt-op_le := pt_-_brckt-op_lex
+  """
+  
+  """.
+
+
 pt_-_brckt-cl_native_le := pt_-_brckt-cl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_brckt-cl_le">
+  <description>Punct, brackets, close
+  <ex>
+  <todo>
   """.
 
-pt_-_brckt-cl_le := pt_-_brckt-cl_lex.
 
-;  <type val="pt_-_fr-cl_le">
-;  <description>Punct, ">>"
-;  <ex>
-;  <todo>
+pt_-_brckt-cl_le := pt_-_brckt-cl_lex
+  """
+  
+  """.
+
+
 pt_-_fr-cl_native_le := pt_-_fr-cl_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_fr-cl_le">
+  <description>Punct, ">>"
+  <ex>
+  <todo>
   """.
 
-pt_-_fr-cl_le := pt_-_fr-cl_lex.
 
-;  <type val="pt_-_fr-op_le">
-;  <description>Punct, "<<"
-;  <ex>
-;  <todo>
+pt_-_fr-cl_le := pt_-_fr-cl_lex
+  """
+  
+  """.
+
+
 pt_-_fr-op_native_le := pt_-_fr-op_lex & native_le
   """
   This is a native lexical entry type, for words that are in the lexicon.
+  
+  <type val="pt_-_fr-op_le">
+  <description>Punct, "<<"
+  <ex>
+  <todo>
   """.
 
-pt_-_fr-op_le := pt_-_fr-op_lex.
 
+pt_-_fr-op_le := pt_-_fr-op_lex
+  """
+  
+  """.

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -7051,16 +7051,24 @@ av_-_s-psth-n_lex := nonspec-adverb-lex & norm-zero-arg &
 
 ; --- verb modifiers
 
-; e.g. (*muy) quizás yo venga mañana
 av_-_s-vm_lex := nonspec-adverb-lex & norm-zero-arg &
   [ SYNSEM nonspec_scopal_xp_adverb_synsem & 
            [ LOCAL.CAT.HEAD [ PRD non-prd,
-                              MOD < [ LOCAL.CAT.HEAD verb ] > ] ] ].
+                              MOD < [ LOCAL.CAT.HEAD verb ] > ] ] ]
+"""
+; --- 4.1.2. modal adverbs
+; --- verb modifiers
+; e.g. (*muy) quizás yo venga mañana
+""".
 
-; e.g. (muy) probablemente iremos al cine
 av_-_s-vm-spd_lex := spec-adverb-lex & basic-one-arg &
   [ SYNSEM scopal_xp_adverb_synsem & 
-          [ LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT.HEAD verb ] > ] ].
+          [ LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT.HEAD verb ] > ] ]
+"""
+; --- 4.1.2. modal adverbs
+; --- verb modifiers
+; e.g. (muy) probablemente iremos al cine
+""".
 
 ; --- non-verb modifiers
 

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -9389,16 +9389,19 @@ n_pp_psd-part-nu-card_lex := n_quant &
 
 
 ; --- 7.2. Ordinals (Adjectives)
+
+aj_-_i-nu-ord_lex := non-modfied-adj-lex & a_mrkd_np & basic-one-arg &
+  [ SYNSEM intersective_adjective_synsem &
+            [ LOCAL.CAT [ HEAD.PRD prd,
+                          VAL.COMPS < [ OPT +,
+                                        LOCAL.CAT.HEAD.KEYS.KEY _de_p_sel_rel ] > ] ] ]
+"""
 ; NOTA: los ordinales precedidos de 'lo' pueden desempeñar funciones típica de 
 ; sustantivos (e.g. me propuso ir al cine o tomar una copa, y elegí lo segundo) y de 
 ; adverbios (e.g. lo rechazaron por dos razones: lo primero, porque...; lo segundo, porque...)
 ; e.g. los/sus/estos/dos primeros pasos. *su segundo/el segundo suyo.
 ; NOTA: in the ERG there is the feature CARG to specify the numeral
-aj_-_i-nu-ord_lex := non-modfied-adj-lex & a_mrkd_np & basic-one-arg &
-  [ SYNSEM intersective_adjective_synsem &
-            [ LOCAL.CAT [ HEAD.PRD prd,
-                          VAL.COMPS < [ OPT +,
-                                        LOCAL.CAT.HEAD.KEYS.KEY _de_p_sel_rel ] > ] ] ].
+""".
 
 aj_-_i-nu-ord-ms_lex := non-modfied-adj-lex & a_mrkd_np & basic-one-arg &
   [ SYNSEM intersective_adjective_synsem &
@@ -9408,55 +9411,66 @@ aj_-_i-nu-ord-ms_lex := non-modfied-adj-lex & a_mrkd_np & basic-one-arg &
                             VAL.COMPS < [ OPT +,
                                           LOCAL.CAT.HEAD.KEYS.KEY _de_p_sel_rel ] > ] ] ] ].
 
-
 ; --- 7.3. Partitives
+  
 
-; a)- se combinan con cardinales; e.g. un tercio (de (los) alumnos)
-; b)- card + ord + "parte"; e.g. dos terceras partes
-; !!! also for percentage!!!
-n_pp_part-nu_lex := n_pp_part_lex.
+n_pp_part-nu_lex := n_pp_part_lex
+  """
+  --- 7.3. Partitives
+  a)- se combinan con cardinales; e.g. un tercio (de (los) alumnos)
+  b)- card + ord + "parte"; e.g. dos terceras partes
+  !!! also for percentage!!!
+  """.
 
-; c)- el sustantivo "mitad" puede dar lugar a una construcción comparativa
-;     e.g. la mitad (de (los) asistentes), gana la mitad (de dinero) (que su hermana)
 
-; d)- el adjetivo medio se combina con cualquier sustantivo, incluso los sust. cardinales
-;     e.g. medio pollo, medio millar/centenar de personas.
-aj_-_i-nu-part_lex := non-modfied-adj-lex & a_intrans & norm-zero-arg & 
-  [ SYNSEM intersective_adjective_synsem &
-           [ LOCAL.CAT [ POSTHEAD -,
-                         HEAD.PRD non-prd ] ] ].
-
+aj_-_i-nu-part_lex := non-modfied-adj-lex & a_intrans & norm-zero-arg &
+  [ SYNSEM intersective_adjective_synsem & [ LOCAL.CAT [ POSTHEAD -,
+                                                         HEAD.PRD non-prd ] ] ]
+  """
+  --- 7.3. Partitives
+  c)- el sustantivo "mitad" puede dar lugar a una construcción comparativa
+      e.g. la mitad (de (los) asistentes), gana la mitad (de dinero) (que su hermana)
+  d)- el adjetivo medio se combina con cualquier sustantivo, incluso los sust. cardinales
+      e.g. medio pollo, medio millar/centenar de personas.
+  """.
 
 ; --- 7.4. Multiplicative (doble, triple, duplo, triplo, cuádruplo)
-
-; a)- quantitive reading (pronoun)
-; e.g. comió el doble/triple (de pan) (que su hermana)
-;      es el doble de bueno (que yo)
+  
 n_pp_pr-part-nu-mult_lex := spec-partitive-pron-lex &
-  [ SYNSEM norm-basic-partitive-pron-synsem & 
-           [ LOCAL.CAT.VAL.SPR < [ OPT  -, 
-                                   LOCAL.CAT.HEAD.KEYS.KEY art_def_q_rel ] >, 
-             NON-LOCAL.SLASH 0-dlist ] ].
+  [ SYNSEM norm-basic-partitive-pron-synsem & [ LOCAL.CAT.VAL.SPR < [ OPT -,
+                                                                      LOCAL.CAT.HEAD.KEYS.KEY art_def_q_rel ] >,
+                                                NON-LOCAL.SLASH 0-dlist ] ]
+  """
+  --- 7.4. Multiplicative (doble, triple, duplo, triplo, cuádruplo)
+  a)- quantitive reading (pronoun)
+  e.g. comió el doble/triple (de pan) (que su hermana)
+       es el doble de bueno (que yo)
+  """.
 
-; b)- qualificative reading (adjective)
-; e.g. tiene (una) doble personalidad/personalidad doble
+
 aj_-_i-nu-mult_lex := non-modfied-adj-lex & a_intrans & norm-zero-arg &
-  [ SYNSEM intersective_adjective_synsem &
-           [ LOCAL [ CAT.HEAD.PRD prd,
-                     CONT.HCONS <! !> ] ] ].
+  [ SYNSEM intersective_adjective_synsem & [ LOCAL [ CAT.HEAD.PRD prd,
+                                                     CONT.HCONS <! !> ] ] ]
+  """
+  --- 7.4. Multiplicative (doble, triple, duplo, triplo, cuádruplo)
+  b)- qualificative reading (adjective)
+  e.g. tiene (una) doble personalidad/personalidad doble
+  """.
 
-; c)- adverbial reading 
-; e.g. tuvo que estudiar el triple, pagó doble
-;av_-_nu-mult_lex := 
 
-
-; --- 7.5. Distributive
-
-; - cardinal + 'de' + 'cada' + cardinal + N' (Zp)
-; e.g. íbamos al cine tres de cada dos domingos
 d_-_q-nu-distr_lex := det_quant_indef &
   [ SYNSEM [ LOCAL.CAT.VAL.SPR < >,
-             LKEYS.KEYREL.PRED distr_numb_q_rel ] ].
+             LKEYS.KEYREL.PRED distr_numb_q_rel ] ]
+  """
+  --- 7.4. Multiplicative (doble, triple, duplo, triplo, cuádruplo)
+   c)- adverbial reading
+   e.g. tuvo que estudiar el triple, pagó doble
+  av_-_nu-mult_lex :=
+   --- 7.5. Distributive
+   - cardinal + 'de' + 'cada' + cardinal + N' (Zp)
+   e.g. íbamos al cine tres de cada dos domingos
+  """.
+
 
 
 
@@ -9556,17 +9570,30 @@ vp_inf_ques_comp_synsem := ques_comp_synsem &
                       CLTS < > ] ] ]. 
 
 
-; e.g. no me gusta que a los toros te pongas la minifalda; gritó que dónde habíamos puesto el dinero 
-cm_s_lex := basic-comp-lex & basic-one-arg & 
-  [ SYNSEM s_fin_prop-or-ques_comp_synsem ].
 
-; e.g. no sé si vendrá
-cm_s_q_lex := basic-comp-lex & basic-one-arg & 
-  [ SYNSEM s_fin_ques_comp_synsem ].
+cm_s_lex := basic-comp-lex & basic-one-arg &
+  [ SYNSEM s_fin_prop-or-ques_comp_synsem ]
+  """
+  --- 8. Complementizers
+  e.g. no me gusta que a los toros te pongas la minifalda; gritó que dónde habíamos puesto el dinero
+  """.
 
-; e.g. no sé si ir
-cm_vp_q_lex := basic-comp-lex & basic-one-arg & 
-  [ SYNSEM vp_inf_ques_comp_synsem ].
+
+cm_s_q_lex := basic-comp-lex & basic-one-arg &
+  [ SYNSEM s_fin_ques_comp_synsem ]
+  """
+  --- 8. Complementizers
+  e.g. no sé si vendrá
+  """.
+
+
+cm_vp_q_lex := basic-comp-lex & basic-one-arg &
+  [ SYNSEM vp_inf_ques_comp_synsem ]
+  """
+  --- 8. Complementizers
+  e.g. no sé si ir
+  """.
+
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -9651,29 +9678,44 @@ subconj_inf_synsem := basic_onearg_subconj_synsem &
 
 
 
-; e.g. aunque se disculpe, no volveré; mientras siga allí, no lo conseguirá; lo compré porque quise
+
 p_cl_vm_lex := basic-subconj-lex & basic-one-arg &
-  [ SYNSEM subconj_s_synsem & 
-           [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CAT.VAL.COMPS < > ] >,
-                         VAL.COMPS < [ LOCAL.CAT.HEAD verb ] > ] ] ].
+  [ SYNSEM subconj_s_synsem & [ LOCAL.CAT [ HEAD.MOD < [ LOCAL.CAT.VAL.COMPS < > ] >,
+                                            VAL.COMPS < [ LOCAL.CAT.HEAD verb ] > ] ] ]
+  """
+  Subordinating conjunctions
+  e.g. aunque se disculpe, no volveré; mientras siga allí, no lo conseguirá; lo compré porque quise
+  """.
 
-; locative prep. and 'durante' can't take cp_prop_fin or vp_inf
-; e.g. con que vengan, no arreglas nada (modal); no he vuelto desde que se fueron (tmp); no cejó hasta 
-; que lo consiguió (tmp); lo repito para que no te olvides (purpose); lo he aprendido sin que me hayan 
-; ayudado (mode) 
+
 p_cp_vm_lex := basic-subconj-lex & basic-one-arg &
-  [ SYNSEM subconj_s_synsem & 
-           [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD comp ] > ] ].
+  [ SYNSEM subconj_s_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD comp ] > ] ]
+  """
+  Subordinating conjunctions
+  locative prep. and 'durante' can't take cp_prop_fin or vp_inf
+  e.g. con que vengan, no arreglas nada (modal); no he vuelto desde que se fueron (tmp); no cejó hasta
+  que lo consiguió (tmp); lo repito para que no te olvides (purpose); lo he aprendido sin que me hayan
+  ayudado (mode)
+  """.
 
-; e.g. al terminar la función, nos despedimos
-p_vp_vm_lex :=  basic-subconj-lex & basic-one-arg &
-  [ SYNSEM subconj_inf_synsem ].
 
-; e.g. disparaban a matar (purpose), con no comer no arreglas nada (modal), no paró hasta conseguirlo 
-; (tmp), le llamó para quedar con él (purpose), enfermó por no comer (cause), trabaja sin cesar (mode), 
-; tras venderlo se arrepintió (tmp)
-p_vp_ctrl-vm_lex :=  basic-subconj-lex & basic-one-arg &
-  [ SYNSEM subconj_inf_ctrl_synsem ].
+p_vp_vm_lex := basic-subconj-lex & basic-one-arg &
+  [ SYNSEM subconj_inf_synsem ]
+  """
+  Subordinating conjunctions
+  e.g. al terminar la función, nos despedimos
+  """.
+
+
+p_vp_ctrl-vm_lex := basic-subconj-lex & basic-one-arg &
+  [ SYNSEM subconj_inf_ctrl_synsem ]
+  """
+  Subordinating conjunctions
+  e.g. disparaban a matar (purpose), con no comer no arreglas nada (modal), no paró hasta conseguirlo
+  (tmp), le llamó para quedar con él (purpose), enfermó por no comer (cause), trabaja sin cesar (mode),
+  tras venderlo se arrepintió (tmp)
+  """.
+
 
 
 

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -6254,8 +6254,6 @@ n_pp_pr-wh-cuanto_lex := pron_wh_part_lex &
   """.
 
 
-
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;
 ; --- 3. Adjectives
@@ -6358,10 +6356,14 @@ modfied-adj-lex := basic-adjective-lex &
 
 
 ; -- subcat types
+
 a_intrans := basic-adjective-lex & 
   [ SYNSEM.LOCAL [ CAT [ HEAD.KEYS.KEY adj_rel,
                          VAL.COMPS < > ], 
-                   CONT.RELS <! adj-arg1-relation !> ] ].  
+                   CONT.RELS <! adj-arg1-relation !> ] ]
+"""
+; -- subcat types
+""".  
 
 a_trans := basic-adjective-lex & 
   [ SYNSEM.LOCAL [ CAT [ POSTHEAD +,
@@ -6427,345 +6429,438 @@ a_mrkd_cp_prop_inf_rais_synsem := basic_adjective_synsem &
                    ARG1 #harg ] ]. 
 
 ; fot LRs
+
 a_mrkd_cp_prop-or-ques_fin_synsem := intersective_adjective_synsem &
   [  LOCAL.CAT.VAL.COMPS < [ LOCAL mrkd_or_unmrkd_cp_prop_or_ques_local &
                                    [ CAT.HEAD.KEYS.ALTKEY v_event_rel,
                                      CONT.HOOK.INDEX.E [ TENSE tense,
-                                                         MOOD ind_or_sub_mood ] ] ] > ].
+                                                         MOOD ind_or_sub_mood ] ] ] > ]
+"""
+; fot LRs
+""".
 
 a_mrkd_cp_prop-or-ques_inf_synsem := intersective_adjective_synsem &
   [  LOCAL.CAT.VAL.COMPS < [ LOCAL mrkd_or_unmrkd_cp_prop_or_ques_local &
                                    [ CAT.HEAD.KEYS.ALTKEY v_event_rel,
                                      CONT.HOOK.INDEX.E [ TENSE nontense,
-                                                         ASPECT no-aspect ] ] ] > ]. 
+                                                         ASPECT no-aspect ] ] ] > ]
+"""
+; fot LRs
+""". 
 
 
 ; --- Adjectival lexical entry types
 
-; --- 3.1. Adverbial adjectives (do not introduce properties, but modify a referent modifier) 
-aj_adv := a_intrans & non-modfied-adj-lex & norm-zero-arg & 
-  [ SYNSEM scopal_adjective_synsem &
-           [ LOCAL.CAT.HEAD.PRD non-prd ] ].
 
-; --- 3.1.1. Event modifiers (they refer to objects or processes as entities which take place in 
-; a particular time, place and manner. They are variants of qualitative adjectives)
-; a)- Circunstanciales (temporal, locative, manner)
-; e.g. próximo año/año próximo, cercana casa/casa cercana, mirada dulce/dulce mirada
-; b)- Aspectual (modify event or result nouns, and nouns refering to states or relations) 
-; e.g. periódicas revisiones, largo adiós, esporádicas crisis
-aj_-_s-nprd_lex := aj_adv.
+aj_adv := a_intrans & non-modfied-adj-lex & norm-zero-arg &
+  [ SYNSEM scopal_adjective_synsem & [ LOCAL.CAT.HEAD.PRD non-prd ] ]
+  """
+  --- 3.1. Adverbial adjectives (do not introduce properties, but modify a referent modifier)
+  """.
 
-aj_-_s-mismo_lex := a_intrans & non-modfied-adj-lex & norm-zero-arg & 
-  [ SYNSEM non-agr_basic_adjective_synsem & 
-           [ LOCAL [ CAT [ POSTHEAD +,
-                           HEAD [ PRD non-prd,
-                                  MOD < [ LOCAL scopal-mod &
-                                                [ CAT [ HEAD noun,
-                                                        VAL.SPR < > ],
-                                                  CONT.HOOK [ LTOP #larg,
-                                                              INDEX #index & [ PRONTYPE real_pron ] ] ] ] > ] ],
-                     CONT [ HOOK.INDEX #index,
-                            HCONS <! qeq & [ HARG #harg,
-                                             LARG #larg ] !> ] ],
-             LKEYS.KEYREL.ARG1 #harg ] ].
 
-; --- 3.1.2. Intentional (indicate the way a given concept applies to a given referent)
-; a)- Modal: e.g. el presunto asesino, un posible acuerdo, un falso amigo
-; b)- Restrictive: e.g. el mero hecho, la verdadera razón
-aj_-_s-nprd-prh_lex := aj_adv & 
-  [ SYNSEM.LOCAL.CAT.POSTHEAD - ]. 
+aj_-_s-nprd_lex := aj_adv
+  """
+  --- 3.1.1. Event modifiers (they refer to objects or processes as entities which take place in
+  a particular time, place and manner. They are variants of qualitative adjectives)
+  a)- Circunstanciales (temporal, locative, manner)
+  e.g. próximo año/año próximo, cercana casa/casa cercana, mirada dulce/dulce mirada
+  b)- Aspectual (modify event or result nouns, and nouns refering to states or relations)
+  e.g. periódicas revisiones, largo adiós, esporádicas crisis
+  """.
 
-; --- 3.2. Relational adjectives  (they express a set of properties)
-; - not graduable but may co-occur with focalizing adverbs (e.g. viaje específicamente/sólo turístico)
-; - by default intersective
-; - always in post-nominal position (except those ones that are recategorized as calificative adjectives).
-; - the noun and the relational adjectives which follow it form a compact unit, they cannot be intercalated 
-; among them or with calificative adjectives (eg. magnífica actuación policial/actuación 
-; policial magnífica/*actuación policial magnífica), neither with modals nor with adverbials (el posible 
-; avance normando/*el avance posible normando) or possessives (un recurso administrativo suyo/*un
-; recurso suyo administrativo), or "alguno" (no tengo reloj eléctrico alguno/*reloj alguno 
-; eléctrico), or PPs (eg. la producción industrial de Francia/*la producción de Francia 
-; industrial), or when N+PP form a semi-compound (eg. tren francés de alta velocidad/?tren 
-; de alta velocidad francés), but they admit pronouns, eg. la sociedad industrial y la cibernética
-aj_rel :=  non-modfied-adj-lex & 
-  [ SYNSEM intersective_adjective_synsem &
-           [ LOCAL.CAT.POSTHEAD + ] ].
 
-; --- 3.2.1. Predicative relational adjectives
-; Classifying predicates that co-occur with concrete or abstract nouns.
-; e.g. la revista mensual / la revista es mensual
-aj_-_i-nspd_lex := aj_rel & a_intrans & norm-zero-arg & 
+aj_-_s-mismo_lex := a_intrans & non-modfied-adj-lex & norm-zero-arg &
+  [ SYNSEM non-agr_basic_adjective_synsem & [ LOCAL [ CAT [ POSTHEAD +,
+                                                            HEAD [ PRD non-prd,
+                                                                   MOD < [ LOCAL scopal-mod & [ CAT [ HEAD noun,
+                                                                                                      VAL.SPR < > ],
+                                                                                                CONT.HOOK [ LTOP #larg,
+                                                                                                            INDEX #index & [ PRONTYPE real_pron ] ] ] ] > ] ],
+                                                      CONT [ HOOK.INDEX #index,
+                                                             HCONS <! qeq & [ HARG #harg,
+                                                                              LARG #larg ] !> ] ],
+                                              LKEYS.KEYREL.ARG1 #harg ] ]
+  """
+  
+  """.
+
+
+aj_-_s-nprd-prh_lex := aj_adv &
+  [ SYNSEM.LOCAL.CAT.POSTHEAD - ]
+  """
+  --- 3.1.2. Intentional (indicate the way a given concept applies to a given referent)
+  a)- Modal: e.g. el presunto asesino, un posible acuerdo, un falso amigo
+  b)- Restrictive: e.g. el mero hecho, la verdadera razón
+  """.
+
+
+aj_rel := non-modfied-adj-lex &
+  [ SYNSEM intersective_adjective_synsem & [ LOCAL.CAT.POSTHEAD + ] ]
+  """
+  --- 3.2. Relational adjectives  (they express a set of properties)
+  - not graduable but may co-occur with focalizing adverbs (e.g. viaje específicamente/sólo turístico)
+  - by default intersective
+  - always in post-nominal position (except those ones that are recategorized as calificative adjectives).
+  - the noun and the relational adjectives which follow it form a compact unit, they cannot be intercalated
+  among them or with calificative adjectives (eg. magnífica actuación policial/actuación
+  policial magnífica/*actuación policial magnífica), neither with modals nor with adverbials (el posible
+  avance normando/*el avance posible normando) or possessives (un recurso administrativo suyo/*un
+  recurso suyo administrativo), or "alguno" (no tengo reloj eléctrico alguno/*reloj alguno
+  eléctrico), or PPs (eg. la producción industrial de Francia/*la producción de Francia
+  industrial), or when N+PP form a semi-compound (eg. tren francés de alta velocidad/?tren
+  de alta velocidad francés), but they admit pronouns, eg. la sociedad industrial y la cibernética
+  """.
+
+
+aj_-_i-nspd_lex := aj_rel & a_intrans & norm-zero-arg &
   [ SYNSEM.LOCAL [ CAT.HEAD.PRD.COPV ser,
-                   CONT.HCONS <! !> ] ].
+                   CONT.HCONS <! !> ] ]
+  """
+  --- 3.2.1. Predicative relational adjectives
+  Classifying predicates that co-occur with concrete or abstract nouns.
+  e.g. la revista mensual / la revista es mensual
+  """.
 
-; --- 3.2.2. Non-predicative relational intransitive
-; they mostly go with deverbal nouns, but only result nominalizations, and describe the arguments of the noun
-; e.g. la actuación policial / *la actuación fue policial
-aj_-_i-nprd_lex := aj_rel & a_intrans & norm-zero-arg & 
+
+aj_-_i-nprd_lex := aj_rel & a_intrans & norm-zero-arg &
   [ SYNSEM.LOCAL [ CAT.HEAD.PRD non-prd,
-                   CONT.HCONS <! !> ] ].
+                   CONT.HCONS <! !> ] ]
+  """
+  --- 3.2.2. Non-predicative relational intransitive
+  they mostly go with deverbal nouns, but only result nominalizations, and describe the arguments of the noun
+  e.g. la actuación policial / *la actuación fue policial
+  """.
 
-; --- 3.2.3. Non-predicative relational transitive adjectives
-; e.g. consistente en 
+
 aj_pp_i-nprd_lex := aj_rel & a_mrkd_np & basic-one-arg &
   [ SYNSEM.LOCAL.CAT [ HEAD.PRD non-prd,
-                       VAL.COMPS < [ OPT - ] > ] ].
+                       VAL.COMPS < [ OPT - ] > ] ]
+  """
+  --- 3.2.3. Non-predicative relational transitive adjectives
+  e.g. consistente en
+  """.
 
-; --- for "referente a" and "consistente en", e.g. "una visión de negocio consistente en estar alerta/
-; que estén alerta/cómo se ha ejercido..." 
+
 aj_cp_p-i-nprd_lex := aj_rel & a_cp_prop_fin & basic-one-arg &
-  [ SYNSEM [ LOCAL.CAT [ HEAD.PRD non-prd,
-                          VAL.COMPS < [ OPT -,
-                                        LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+  [ SYNSEM.LOCAL.CAT [ HEAD.PRD non-prd,
+                       VAL.COMPS < [ OPT -,
+                                     LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ]
+  """
+  --- for "referente a" and "consistente en", e.g. "una visión de negocio consistente en estar alerta/
+  que estén alerta/cómo se ha ejercido..."
+  """.
+
 
 aj_cp_q-i-nprd_lex := aj_rel & a_cp_question & basic-one-arg &
   [ SYNSEM.LOCAL.CAT [ HEAD.PRD non-prd,
-                       VAL.COMPS < [ OPT - ] > ] ].
+                       VAL.COMPS < [ OPT - ] > ] ]
+  """
+  
+  """.
 
-; --- 3.3. Qualitative Adjectives (express a single property)
-; - they are predicative and gradable
-a_qual := modfied-adj-lex & 
-  [ SYNSEM basic_adjective_synsem & 
-           [ LOCAL.CAT [ HEAD.PRD prd,
-                         VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY degree_rel ] > ] ] ]. 
 
-; --- 3.3.1. Qualitative intransitive adjectives
-aj_qual_intr := a_qual & a_intrans & basic-one-arg & 
-   [ SYNSEM.LOCAL.CONT.HCONS <! !> ].
+a_qual := modfied-adj-lex &
+  [ SYNSEM basic_adjective_synsem & [ LOCAL.CAT [ HEAD.PRD prd,
+                                                  VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY degree_rel ] > ] ] ]
+  """
+  --- 3.3. Qualitative Adjectives (express a single property)
+  - they are predicative and gradable
+  """.
 
-; a)- scopal qualitative intransitive adjectives (co-ocurring with ser and estar
-; and pre/post-nominal (adjectives of evaluation, physical dimension, velocity, age, physical 
-; properties (weight, consistency, taste, touch, smell, temperature, sonority))
-; e.g. ésto es/está alto, dulce sabor/sabor dulce  
-; !!! problem in predicative constructions
-aj_-_s_lex := aj_qual_intr & 
-  [ SYNSEM intersective_adjective_synsem ].
 
-; b)- intersective qualitative intransitive adjectives co-ocurring with ser (though 
-; we could also find them with estar), and pre/post-nominal (adjectives of colour, shape, 
-; aptitudes and human (pre)dispositions)
-; e.g. el cielo es/está azul, ojos negros/negros ojos 
-aj_-_i_lex := aj_qual_intr & 
-  [ SYNSEM intersective_adjective_synsem ].
+aj_qual_intr := a_qual & a_intrans & basic-one-arg &
+  [ SYNSEM.LOCAL.CONT.HCONS <! !> ]
+  """
+  --- 3.3.1. Qualitative intransitive adjectives
+  """.
 
-; c)- intersective qualitative intransitive adjectives co-occurring with 'ser' 
-; (though we could also find them with estar), and post-nominal (aptitude and human 
-; (pre)disposition adjectives
-; e.g. 
-aj_-_i-psth_lex := aj_qual_intr & 
-  [ SYNSEM intersective_adjective_synsem & 
-           [ LOCAL.CAT.POSTHEAD + ] ]. 
 
-; d)- intersective qualitative intransitive adjectives, co-occurring with 'estar' 
-; and post-nominal (adjectives derived from participles and adjectival participles)
-; e.g. está seco, maduro, abierto lleno (un vaso lleno/*un lleno vaso) 
-aj_-_i-e_lex := aj_qual_intr & 
-  [ SYNSEM intersective_adjective_synsem & 
-           [ LOCAL.CAT [ POSTHEAD +,
-                         HEAD.PRD.COPV estar ] ] ]. 
+aj_-_s_lex := aj_qual_intr &
+  [ SYNSEM intersective_adjective_synsem ]
+  """
+  a)- scopal qualitative intransitive adjectives (co-ocurring with ser and estar
+  and pre/post-nominal (adjectives of evaluation, physical dimension, velocity, age, physical
+  properties (weight, consistency, taste, touch, smell, temperature, sonority))
+  e.g. ésto es/está alto, dulce sabor/sabor dulce
+  !!! problem in predicative constructions
+  """.
 
-; --- 3.3.2. Qualitative transitive adjectives 
-a_qual_trans := a_qual & basic-two-arg & 
-  [ SYNSEM intersective_adjective_synsem ].
 
-; --- 3.3.2.1. Qualitative transitive adjectives taking marked NPs
-; they can have dative clitics which alter with the complements with the preposition 
-; "para" ("for")(e.g. le es útil/es útil para él) 
+aj_-_i_lex := aj_qual_intr &
+  [ SYNSEM intersective_adjective_synsem ]
+  """
+  b)- intersective qualitative intransitive adjectives co-ocurring with ser (though
+  we could also find them with estar), and pre/post-nominal (adjectives of colour, shape,
+  aptitudes and human (pre)dispositions)
+  e.g. el cielo es/está azul, ojos negros/negros ojos
+  """.
 
-; e.g. es/está muy atento con sus compañeros
+
+aj_-_i-psth_lex := aj_qual_intr &
+  [ SYNSEM intersective_adjective_synsem & [ LOCAL.CAT.POSTHEAD + ] ]
+  """
+  c)- intersective qualitative intransitive adjectives co-occurring with 'ser'
+  (though we could also find them with estar), and post-nominal (aptitude and human
+  (pre)disposition adjectives
+  e.g.
+  """.
+
+
+aj_-_i-e_lex := aj_qual_intr &
+  [ SYNSEM intersective_adjective_synsem & [ LOCAL.CAT [ POSTHEAD +,
+                                                         HEAD.PRD.COPV estar ] ] ]
+  """
+  d)- intersective qualitative intransitive adjectives, co-occurring with 'estar'
+  and post-nominal (adjectives derived from participles and adjectival participles)
+  e.g. está seco, maduro, abierto lleno (un vaso lleno/*un lleno vaso)
+  """.
+
+
+a_qual_trans := a_qual & basic-two-arg &
+  [ SYNSEM intersective_adjective_synsem ]
+  """
+  --- 3.3.2. Qualitative transitive adjectives
+  """.
+
+
 aj_pp_i_lex := a_qual_trans & a_mrkd_np &
   [ SYNSEM.LOCAL.CAT [ POSTHEAD +,
-                       VAL.COMPS < [ OPT - ] > ] ].
+                       VAL.COMPS < [ OPT - ] > ] ]
+  """
+  --- 3.3.2.1. Qualitative transitive adjectives taking marked NPs
+  they can have dative clitics which alter with the complements with the preposition
+  "para" ("for")(e.g. le es útil/es útil para él)
+  e.g. es/está muy atento con sus compañeros
+  """.
 
-; e.g. es/está muy vulnerable (a todo)
+
 aj_pp*_i_lex := a_qual_trans & a_mrkd_np &
-  [ SYNSEM.LOCAL.CAT.VAL.COMPS < [ OPT + ] > ].
+  [ SYNSEM.LOCAL.CAT.VAL.COMPS < [ OPT + ] > ]
+  """
+  e.g. es/está muy vulnerable (a todo)
+  """.
 
-; e.g. está/*es atento a las notícias
-aj_pp_i-e_lex := a_qual_trans & a_mrkd_np & 
+
+aj_pp_i-e_lex := a_qual_trans & a_mrkd_np &
   [ SYNSEM.LOCAL.CAT [ POSTHEAD +,
                        HEAD.PRD.COPV estar,
-                       VAL.COMPS < [ OPT - ] > ] ].
+                       VAL.COMPS < [ OPT - ] > ] ]
+  """
+  e.g. está/*es atento a las notícias
+  """.
 
-; e.g. estoy/*soy harto (de tí)
+
 aj_pp*_i-e_lex := a_qual_trans & a_mrkd_np &
   [ SYNSEM.LOCAL.CAT [ POSTHEAD +,
                        HEAD.PRD.COPV estar,
-                       VAL.COMPS < [ OPT + ] > ] ].
+                       VAL.COMPS < [ OPT + ] > ] ]
+  """
+  e.g. estoy/*soy harto (de tí)
+  """.
 
-; --- 3.3.2.2. Qualitative transitive adjectives taking finite completive clauses/free infinitives
 
-; e.g. es partidaria (de) que legalizen la droga/de legalizar la droga
-aj_cp_p-i-s_lex := a_qual_trans & a_cp_prop_fin & 
+aj_cp_p-i-s_lex := a_qual_trans & a_cp_prop_fin &
   [ SYNSEM.LOCAL.CAT [ HEAD.PRD.COPV ser,
-                       VAL.COMPS < [ OPT - ] > ] ].
+                       VAL.COMPS < [ OPT - ] > ] ]
+  """
+  --- 3.3.2.2. Qualitative transitive adjectives taking finite completive clauses/free infinitives
+  e.g. es partidaria (de) que legalizen la droga/de legalizar la droga
+  """.
 
-; e.g. estoy segura (de) que vendrá/de cambiarlo
-aj_cp_p-i-e_lex := a_qual_trans & a_cp_prop_fin & 
+
+aj_cp_p-i-e_lex := a_qual_trans & a_cp_prop_fin &
   [ SYNSEM.LOCAL.CAT [ HEAD.PRD.COPV estar,
-                       VAL.COMPS < [ OPT - ] > ] ].
+                       VAL.COMPS < [ OPT - ] > ] ]
+  """
+  e.g. estoy segura (de) que vendrá/de cambiarlo
+  """.
 
-; --- 3.3.2.3. Qualitative transitive adjectives taking interrogative clauses (finite & infinitival)
 
-; e.g. es muy revelador de cómo actuan
-aj_q_i-s_lex := a_qual_trans & a_cp_question & 
+aj_q_i-s_lex := a_qual_trans & a_cp_question &
   [ SYNSEM.LOCAL.CAT [ HEAD.PRD.COPV ser,
-                       VAL.COMPS < [ OPT - ] > ] ].
+                       VAL.COMPS < [ OPT - ] > ] ]
+  """
+  --- 3.3.2.3. Qualitative transitive adjectives taking interrogative clauses (finite & infinitival)
+  e.g. es muy revelador de cómo actuan
+  """.
 
-; e.g. no estoy muy seguro de cuándo/de si vendrá/ir
-aj_q_i-e_lex := a_qual_trans & a_cp_question & 
+
+aj_q_i-e_lex := a_qual_trans & a_cp_question &
   [ SYNSEM.LOCAL.CAT [ POSTHEAD +,
                        HEAD.PRD.COPV estar,
-                       VAL.COMPS < [ OPT - ] > ] ].
+                       VAL.COMPS < [ OPT - ] > ] ]
+  """
+  e.g. no estoy muy seguro de cuándo/de si vendrá/ir
+  """.
 
-; -- 3.4. Subject Raising Adjectives
-; - post-nominal, co-occurring with 'ser', optional complement
-; e.g. soy muy libre de pensarlo
-aj_vp_sr-i-s_lex := a_qual & a_cp_prop_inf & basic-two-arg & 
-  [ SYNSEM a_mrkd_cp_prop_inf_rais_synsem & 
-            [ LOCAL [ CAT [ POSTHEAD +,
-                            HEAD.PRD.COPV ser,
-                            VAL.COMPS < [ OPT -, 
-                                          LOCAL.CONT.HOOK.XARG #ctrl,
-                                          NON-LOCAL.SLASH 0-dlist ] > ],
-                      CONT.HOOK.XARG #ctrl & ref-ind ] ] ]. 
 
-; --- 3.5. Subject Control Adjectives 
-aj_sctrl := a_qual & a_cp_prop_inf & basic-two-arg & 
-  [ SYNSEM a_mrkd_cp_prop_inf_ctrl_synsem & 
-           [ LOCAL [ CAT [ POSTHEAD +,
-                           VAL.COMPS < [ LOCAL.CONT.HOOK.XARG #ctrl,
-                                         NON-LOCAL.SLASH 0-dlist ] > ],
-                     CONT.HOOK.XARG #ctrl & ref-ind ] ] ]. 
+aj_vp_sr-i-s_lex := a_qual & a_cp_prop_inf & basic-two-arg &
+  [ SYNSEM a_mrkd_cp_prop_inf_rais_synsem & [ LOCAL [ CAT [ POSTHEAD +,
+                                                            HEAD.PRD.COPV ser,
+                                                            VAL.COMPS < [ OPT -,
+                                                                          LOCAL.CONT.HOOK.XARG #ctrl,
+                                                                          NON-LOCAL.SLASH 0-dlist ] > ],
+                                                      CONT.HOOK.XARG #ctrl & ref-ind ] ] ]
+  """
+  -- 3.4. Subject Raising Adjectives
+  - post-nominal, co-occurring with 'ser', optional complement
+  e.g. soy muy libre de pensarlo
+  """.
 
-; e.g. aficionado a (es aficionado (a jugar a tenis)), capaz de (no soy capaz (de hacerlo))
-aj_vp_sc-i-s_lex := aj_sctrl & 
+
+aj_sctrl := a_qual & a_cp_prop_inf & basic-two-arg &
+  [ SYNSEM a_mrkd_cp_prop_inf_ctrl_synsem & [ LOCAL [ CAT [ POSTHEAD +,
+                                                            VAL.COMPS < [ LOCAL.CONT.HOOK.XARG #ctrl,
+                                                                          NON-LOCAL.SLASH 0-dlist ] > ],
+                                                      CONT.HOOK.XARG #ctrl & ref-ind ] ] ]
+  """
+  --- 3.5. Subject Control Adjectives
+  """.
+
+
+aj_vp_sc-i-s_lex := aj_sctrl &
   [ SYNSEM.LOCAL.CAT [ HEAD.PRD.COPV ser,
-                       VAL.COMPS < [ OPT - ] > ] ]. 
+                       VAL.COMPS < [ OPT - ] > ] ]
+  """
+  e.g. aficionado a (es aficionado (a jugar a tenis)), capaz de (no soy capaz (de hacerlo))
+  """.
 
-; e.g. dispuesto a (no estoy dispuesto a venderlo), seguro de (no estoy seguro (de poder hacerlo))
-aj_vp_sc-i-e_lex := aj_sctrl & 
+
+aj_vp_sc-i-e_lex := aj_sctrl &
   [ SYNSEM.LOCAL.CAT [ HEAD.PRD.COPV estar,
-                       VAL.COMPS < [ OPT - ] > ] ]. 
+                       VAL.COMPS < [ OPT - ] > ] ]
+  """
+  e.g. dispuesto a (no estoy dispuesto a venderlo), seguro de (no estoy seguro (de poder hacerlo))
+  """.
 
-;--- 3.6. Object Raising Adjectives
-; - pre/post-nominal, co-occurring with 'ser', optional complement (PPde)
-; e.g. difícil de (el violín es muy difícil (de tocar))
-aj_vp_or-i-s_lex := a_qual & a_cp_prop_inf & o_rais-two-arg & 
-  [ SYNSEM a_mrkd_cp_prop_inf_rais_synsem & 
-           [ LOCAL [ CAT [ POSTHEAD +,
-                           HEAD [ PRD.COPV ser,
-                                  MOD #mod ],
-                           VAL.COMPS < [ OPT -, 
-                                         NON-LOCAL.SLASH <! np_acc_local &
-                                                            [ CAT.HEAD.MOD #mod,
-                                                              CONT.HOOK.INDEX #ctrl ] !> ] > ], 
-                     CONT.HOOK.XARG #ctrl & ref-ind ] ] ]. 
 
-; --- 3.7. Object Control Adjectives
-; - post-nominal, co-occurring with 'estar', complement (PPde)
-; e.g. pendiente (el contrato está (*muy) pendiente (de firmar/ser firmado/firma)))!!!
-aj_vp_oc-i-s_lex := non-modfied-adj-lex & a_cp_prop_inf & o_rais-one-arg & 
-  [ SYNSEM a_mrkd_cp_prop_inf_ctrl_synsem & 
-           [ LOCAL [ CAT[ POSTHEAD +,
-                          HEAD.PRD.COPV estar,
-                          VAL.COMPS < [ OPT -, 
-                                        NON-LOCAL.SLASH <! np_acc_local &
-                                                           [ CONT.HOOK.INDEX #ctrl ] !> ] > ],
-                     CONT.HOOK.XARG #ctrl & ref-ind ] ] ]. 
+aj_vp_or-i-s_lex := a_qual & a_cp_prop_inf & o_rais-two-arg &
+  [ SYNSEM a_mrkd_cp_prop_inf_rais_synsem & [ LOCAL [ CAT [ POSTHEAD +,
+                                                            HEAD [ PRD.COPV ser,
+                                                                   MOD #mod ],
+                                                            VAL.COMPS < [ OPT -,
+                                                                          NON-LOCAL.SLASH <! np_acc_local & [ CAT.HEAD.MOD #mod,
+                                                                                                              CONT.HOOK.INDEX #ctrl ] !> ] > ],
+                                                      CONT.HOOK.XARG #ctrl & ref-ind ] ] ]
+  """
+  --- 3.6. Object Raising Adjectives
+   - pre/post-nominal, co-occurring with 'ser', optional complement (PPde)
+   e.g. difícil de (el violín es muy difícil (de tocar))
+  """.
 
-; --- 3.8. Comparative Adjectives
-compar-adj-lex := basic-adjective-lex & basic-two-arg & 
-  [ SYNSEM intersective_adjective_synsem &
-           [ LOCAL [ CAT [ POSTHEAD -,
-                           HEAD [ PRD prd,
-                                  KEYS [ ALTKEY compar ],
-                                  MOD < [ LOCAL.CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY quant_rel ] > ] > ],
-                           VAL [ SPR < #spr & 
-                                       [ OPT +,
-                                         LOCAL [ CAT [ MC na,
-                                                       HEAD adv & [ KEYS.KEY degree_rel ],
-                                                       VAL.COMPS < > ], 
-                                                 CONT.HOOK [ LTOP #hand,
-                                                             XARG #altarg0 ] ],
-                                         NON-LOCAL.SLASH 0-dlist ] >,
-                                 COMPS #comps &
-;                                       < [ LOCAL mrkd_np_local &
-;                                                 [ CAT.HEAD.KEYS.KEY #ckey & selected_rel,  
-;                                                   CONT.HOOK.INDEX #arg2 ] ] > ] ],
-                                       < [ LOCAL local &
-                                                 [ CAT [ HEAD adp & 
-                                                              [ PRD non-prd,
-                                                                MOD < >,
-                                                                KEYS.KEY #ckey & selected_rel ], 
-                                                         VAL [ SUBJ < >,
-                                                               COMPS < > ] ], 
-                                                   CONT.HOOK.INDEX #arg2 ] ] > ] ],
-                     CONT [ RELS <! adj-arg1-relation &
-                                    [ LBL #hand,
-                                      ARG0 #arg0 ],
-                                    #altkey & 
-                                    [ PRED compar,
-                                      LBL #hand,
-                                      ARG0 #altarg0,
-                                      ARG1 #arg0,
-                                      ARG2 #arg2 ] !>,
-                            HCONS <! !> ] ],
-             LKEYS [ ALTKEYREL #altkey,
-                     --COMPKEY #ckey ] ], 
-    ARG-ST < #spr . #comps > ].
 
-; a)- (mucho/bastante/...) mejor, peor, mayor, menor + que
-aj_pp_i-cmp_lex := compar-adj-lex & 
+aj_vp_oc-i-s_lex := non-modfied-adj-lex & a_cp_prop_inf & o_rais-one-arg &
+  [ SYNSEM a_mrkd_cp_prop_inf_ctrl_synsem & [ LOCAL [ CAT [ POSTHEAD +,
+                                                            HEAD.PRD.COPV estar,
+                                                            VAL.COMPS < [ OPT -,
+                                                                          NON-LOCAL.SLASH <! np_acc_local & [ CONT.HOOK.INDEX #ctrl ] !> ] > ],
+                                                      CONT.HOOK.XARG #ctrl & ref-ind ] ] ]
+  """
+  --- 3.7. Object Control Adjectives
+  - post-nominal, co-occurring with 'estar', complement (PPde)
+  e.g. pendiente (el contrato está (*muy) pendiente (de firmar/ser firmado/firma)))!!!
+  """.
+
+
+compar-adj-lex := basic-adjective-lex & basic-two-arg &
+  [ SYNSEM intersective_adjective_synsem & [ LOCAL [ CAT [ POSTHEAD -,
+                                                           HEAD [ PRD prd,
+                                                                  KEYS.ALTKEY compar,
+                                                                  MOD < [ LOCAL.CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY quant_rel ] > ] > ],
+                                                           VAL [ SPR < #spr & [ OPT +,
+                                                                                LOCAL [ CAT [ MC na,
+                                                                                              HEAD adv & [ KEYS.KEY degree_rel ],
+                                                                                              VAL.COMPS < > ],
+                                                                                        CONT.HOOK [ LTOP #hand,
+                                                                                                    XARG #altarg0 ] ],
+                                                                                NON-LOCAL.SLASH 0-dlist ] >,
+                                                                 COMPS #comps & < [ LOCAL local & [ CAT [ HEAD adp & [ PRD non-prd,
+                                                                                                                       MOD < >,
+                                                                                                                       KEYS.KEY #ckey & selected_rel ],
+                                                                                                          VAL [ SUBJ < >,
+                                                                                                                COMPS < > ] ],
+                                                                                                    CONT.HOOK.INDEX #arg2 ] ] > ] ],
+                                                     CONT [ RELS <! adj-arg1-relation & [ LBL #hand,
+                                                                                          ARG0 #arg0 ],
+                                                                    #altkey & [ PRED compar,
+                                                                                LBL #hand,
+                                                                                ARG0 #altarg0,
+                                                                                ARG1 #arg0,
+                                                                                ARG2 #arg2 ] !>,
+                                                            HCONS <! !> ] ],
+                                             LKEYS [ ALTKEYREL #altkey,
+                                                     --COMPKEY #ckey ] ],
+    ARG-ST < #spr . #comps > ]
+  """
+  --- 3.8. Comparative Adjectives
+  """.
+
+
+aj_pp_i-cmp_lex := compar-adj-lex &
   [ SYNSEM [ LOCAL.CAT.HEAD.KEYS.KEY adj_rel,
-             LKEYS.--COMPKEY _que_p_comp_rel ] ].
+             LKEYS.--COMPKEY _que_p_comp_rel ] ]
+  """
+  a)- (mucho/bastante/...) mejor, peor, mayor, menor + que
+  """.
 
-; b)- (mucho/bastante/...) igual, anterior, posterior, inferior, superior + que/a
-aj_pp_i-cmp-altp_lex := compar-adj-lex & 
+
+aj_pp_i-cmp-altp_lex := compar-adj-lex &
   [ SYNSEM [ LOCAL.CAT.HEAD.KEYS.KEY adj_rel,
-             LKEYS.--COMPKEY que_or_a_p_comp_rel ] ]. 
+             LKEYS.--COMPKEY que_or_a_p_comp_rel ] ]
+  """
+  b)- (mucho/bastante/...) igual, anterior, posterior, inferior, superior + que/a
+  """.
 
-; c)- (mucho/poco/bastante) + MÁS/MENOS + 'de' + Number
-; e.g. más/menos de tres chicos
-aj_pp_i-cmp-menos_lex := compar-adj-lex & 
+
+aj_pp_i-cmp-menos_lex := compar-adj-lex &
   [ SYNSEM [ LOCAL.CAT [ HEAD.KEYS.KEY compar_adj_rel,
                          VAL.COMPS < [ OPT + ] > ],
-             LKEYS.--COMPKEY _de_p_sel_rel ] ].
+             LKEYS.--COMPKEY _de_p_sel_rel ] ]
+  """
+  c)- (mucho/poco/bastante) + MÁS/MENOS + 'de' + Number
+  e.g. más/menos de tres chicos
+  """.
 
-aj_pp_i-cmp-mas_lex := compar-adj-lex & 
+
+aj_pp_i-cmp-mas_lex := compar-adj-lex &
   [ SYNSEM [ LOCAL.CAT [ HEAD.KEYS.KEY compar_adj_rel,
                          VAL.COMPS < [ OPT + ] > ],
-             LKEYS.--COMPKEY _de_p_sel_rel ] ].
+             LKEYS.--COMPKEY _de_p_sel_rel ] ]
+  """
+  
+  """.
 
-; --- 3.9. Superlative Adjectives (mejor, peor, mayor, menor)
-aj_pp_i-sup_lex := non-modfied-adj-lex & basic-one-arg & 
-  [ SYNSEM intersective_adjective_synsem &
-           [ LOCAL [ CAT [ HEAD [ PRD prd,
-                                  KEYS.ALTKEY superl,
-                                  MOD < [ LOCAL.CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY def_q_rel ] > ] > ],
-                           VAL.COMPS #comps &
-                                     < [ LOCAL mrkd_np_local &
-                                               [ CAT.HEAD.KEYS.KEY #ckey & _de_p_sel_rel ] ] >  ],
-                     CONT [ RELS <! adj-arg1-relation &
-                                    [ LBL #hand,
-                                      ARG0 #arg0 ],
-                                    #altkey & 
-                                    [ PRED superl,
-                                      LBL #hand,
-                                      ARG0 event,
-                                      ARG1 #arg0 ]!>,
-                            HCONS <! !> ] ],
-             LKEYS [ ALTKEYREL #altkey,
-                     --COMPKEY #ckey ] ], 
-    ARG-ST #comps ].
 
-; --- 3.10. Possessives: when they follow the noun, they are modifiers 
-; and they require the def. article or the demonstrative
-; e.g. la/esa canción tuya me gustó
-aj_-_i-poss_lex := aj_qual_intr & 
-  [ SYNSEM intersective_adjective_synsem &
-           [ LOCAL.CAT [ HEAD.KEYS.KEY poss_adj_rel,
-                         POSTHEAD + ] ] ]. 
+aj_pp_i-sup_lex := non-modfied-adj-lex & basic-one-arg &
+  [ SYNSEM intersective_adjective_synsem & [ LOCAL [ CAT [ HEAD [ PRD prd,
+                                                                  KEYS.ALTKEY superl,
+                                                                  MOD < [ LOCAL.CAT.VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY def_q_rel ] > ] > ],
+                                                           VAL.COMPS #comps & < [ LOCAL mrkd_np_local & [ CAT.HEAD.KEYS.KEY #ckey & _de_p_sel_rel ] ] > ],
+                                                     CONT [ RELS <! adj-arg1-relation & [ LBL #hand,
+                                                                                          ARG0 #arg0 ],
+                                                                    #altkey & [ PRED superl,
+                                                                                LBL #hand,
+                                                                                ARG0 event,
+                                                                                ARG1 #arg0 ] !>,
+                                                            HCONS <! !> ] ],
+                                             LKEYS [ ALTKEYREL #altkey,
+                                                     --COMPKEY #ckey ] ],
+    ARG-ST #comps ]
+  """
+  --- 3.9. Superlative Adjectives (mejor, peor, mayor, menor)
+  """.
+
+
+aj_-_i-poss_lex := aj_qual_intr &
+  [ SYNSEM intersective_adjective_synsem & [ LOCAL.CAT [ HEAD.KEYS.KEY poss_adj_rel,
+                                                         POSTHEAD + ] ] ]
+  """
+  --- 3.10. Possessives: when they follow the noun, they are modifiers
+  and they require the def. article or the demonstrative
+  e.g. la/esa canción tuya me gustó
+  """.
+
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -2948,551 +2948,753 @@ v_np*-pp_e-vp-inf-oc-rcp_lex := v_trans_np_mrkd_vp_inf &
                          VAL.COMPS < [ OPT + ], synsem > ] ] ].
 
 
-; --- 1.3.3.4. Transitive verbs taking DO and LCOMP
 
-v_trans_np_lcomp_synsem := v_trans_np_synsem & 
+v_trans_np_lcomp_synsem := v_trans_np_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
                   VAL.COMPS < [ LOCAL [ CAT.HEAD.KEYS.KEY non_modable_rel,
-                                        CONT.HOOK.INDEX #arg2 ] ], 
-                              [ LOCAL lcomp_local & 
-                                      [ CAT.HEAD.KEYS.KEY #ocompkey,
-                                        CONT.HOOK [ LTOP #larg,
-                                                    XARG #arg2 ] ] ] > ],
+                                        CONT.HOOK.INDEX #arg2 ] ],
+                              [ LOCAL lcomp_local & [ CAT.HEAD.KEYS.KEY #ocompkey,
+                                                      CONT.HOOK [ LTOP #larg,
+                                                                  XARG #arg2 ] ] ] > ],
             CONT [ RELS <! arg123-ev-relation !>,
                    HCONS <! qeq & [ HARG #harg,
                                     LARG #larg ] !> ] ],
     LKEYS [ KEYREL.ARG3 #harg & handle,
-            --OCOMPKEY #ocompkey & dir_or_state_nontemp_rel ] ].
+            --OCOMPKEY #ocompkey & dir_or_state_nontemp_rel ] ]
+  """
+  --- 1.3.3.4. Transitive verbs taking DO and LCOMP
+  """.
+
 
 v_trans_np_lcomp_loc_synsem := v_trans_np_lcomp_synsem &
-  [ LKEYS.--OCOMPKEY state_loc_rel ].
+  [ LKEYS.--OCOMPKEY state_loc_rel ]
+  """
+  
+  """.
+
 
 v_trans_np_lcomp_dir_synsem := v_trans_np_lcomp_synsem &
-  [ LKEYS.--OCOMPKEY dir_rel ].
+  [ LKEYS.--OCOMPKEY dir_rel ]
+  """
+  
+  """.
 
 
-v_trans_np_lcomp := v_trans_np & 
-  [ ALTS.PASS + ].
+v_trans_np_lcomp := v_trans_np &
+  [ ALTS.PASS + ]
+  """
+  
+  """.
 
 
 vprn_trans_np_lcomp := v_trans_np & norm-pronominal-verb &
   [ ALTS.PASS +,
-    SYNSEM [ LOCAL.CAT.VAL [ SUBJ < #subj >, 
-                             COMPS < #comp1 , #comp2 >,
-                             CLTS < #clt > ] ], 
-    ARG-ST < #subj , #comp1, #comp2,  #clt > ].
+    SYNSEM.LOCAL.CAT.VAL [ SUBJ < #subj >,
+                           COMPS < #comp1, #comp2 >,
+                           CLTS < #clt > ],
+    ARG-ST < #subj,
+             #comp1,
+             #comp2,
+             #clt > ]
+  """
+  
+  """.
 
 
-; -- a)- verbs of location
-
-; e.g. poner (pon los libros en el cajón/aqui; pon aquí los libros)
-v_np-pp_loc_lex := v_trans_np_lcomp & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, RFX -, RCP - ],
-    SYNSEM v_trans_np_lcomp_loc_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
-
-; e.g. estacionar
-v_np*-pp_loc_lex := v_trans_np_lcomp & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, RFX -, RCP - ],
-    SYNSEM v_trans_np_lcomp_loc_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ].
-
-; e.g. ubicar, colgar, distribuir,...
-v_np-pp*_loc_lex := v_trans_np_lcomp & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, RFX -, RCP - ],
-    SYNSEM v_trans_np_lcomp_loc_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
-
-; e.g. dejarse (se la dejó aquí)
-v_np-pp*_loc-prn_lex := vprn_trans_np_lcomp & basic-four-arg & 
-  [ ALTS [ RFX -, RCP - ],
-    SYNSEM v_trans_np_lcomp_loc_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
+v_np-pp_loc_lex := v_trans_np_lcomp & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           RFX -,
+           RCP - ],
+    SYNSEM v_trans_np_lcomp_loc_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT - ],
+                                                                   [ OPT - ] > ] ] ]
+  """
+  -- a)- verbs of location
+  e.g. poner (pon los libros en el cajón/aqui; pon aquí los libros)
+  """.
 
 
-; -- b)- verbs of movement and direction
-
-; e.g. 
-v_np-pp_dir_lex := v_trans_np_lcomp & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, RFX -, RCP - ],
-    SYNSEM v_trans_np_lcomp_dir_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
-
-; e.g. apuntar, conducir,...
-v_np*-pp_dir_lex := v_trans_np_lcomp & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, RFX -, RCP - ],
-    SYNSEM v_trans_np_lcomp_dir_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ].
-
-; e.g. deportar, redeireccionar,... 
-v_np-pp*_dir_lex := v_trans_np_lcomp & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, RFX -, RCP - ],
-    SYNSEM v_trans_np_lcomp_dir_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
-
-; e.g. llevar (se lo llevó al cine)
-v_np-pp*_dir-prn_lex := vprn_trans_np_lcomp & basic-four-arg & 
-  [ ALTS [ RFX -, RCP - ],
-    SYNSEM v_trans_np_lcomp_dir_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
+v_np*-pp_loc_lex := v_trans_np_lcomp & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           RFX -,
+           RCP - ],
+    SYNSEM v_trans_np_lcomp_loc_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT + ],
+                                                                   [ OPT - ] > ] ] ]
+  """
+  e.g. estacionar
+  """.
 
 
-; e.g. tumbar(se), levantar(se), sentar(se) 
-;      Juan sentó al niño en la trona -> el niño se sentó en la trona
-v_np-pp*_loc-rfx_lex := v_trans_np_lcomp & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, RFX +, RCP - ],
-    SYNSEM v_trans_np_lcomp_loc_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
 
-; e.g. alejar(se), alzar(se)
-v_np-pp*_dir-rfx_lex := v_trans_np_lcomp & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, RFX +, RCP - ],
-    SYNSEM v_trans_np_lcomp_dir_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
-
-; e.g. copiar
-v_np*-pp*_dir-rcp_lex := v_trans_np_lcomp & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, RFX -, RCP + ],
-    SYNSEM v_trans_np_lcomp_dir_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ].
-
-; e.g. buscar(se)
-v_np-pp*_loc-rfx-rcp_lex := v_trans_np_lcomp & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, RFX +, RCP + ],
-    SYNSEM v_trans_np_lcomp_loc_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
+v_np-pp*_loc_lex := v_trans_np_lcomp & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           RFX -,
+           RCP - ],
+    SYNSEM v_trans_np_lcomp_loc_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT - ],
+                                                                   [ OPT + ] > ] ] ]
+  """
+  e.g. ubicar, colgar, distribuir,...
+  """.
 
 
-; --- 1.3.3.5. ditransitive verbs taking DO and NP
-v_trans_np_np_synsem := v_trans_np_synsem & 
+v_np-pp*_loc-prn_lex := vprn_trans_np_lcomp & basic-four-arg &
+  [ ALTS [ RFX -,
+           RCP - ],
+    SYNSEM v_trans_np_lcomp_loc_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT - ],
+                                                                   [ OPT + ] > ] ] ]
+  """
+  e.g. dejarse (se la dejó aquí)
+  """.
+
+
+v_np-pp_dir_lex := v_trans_np_lcomp & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           RFX -,
+           RCP - ],
+    SYNSEM v_trans_np_lcomp_dir_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT - ],
+                                                                   [ OPT - ] > ] ] ]
+  """
+  -- b)- verbs of movement and direction
+  e.g.
+  """.
+
+
+v_np*-pp_dir_lex := v_trans_np_lcomp & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           RFX -,
+           RCP - ],
+    SYNSEM v_trans_np_lcomp_dir_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT + ],
+                                                                   [ OPT - ] > ] ] ]
+  """
+  e.g. apuntar, conducir,...
+  """.
+
+
+v_np-pp*_dir_lex := v_trans_np_lcomp & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           RFX -,
+           RCP - ],
+    SYNSEM v_trans_np_lcomp_dir_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT - ],
+                                                                   [ OPT + ] > ] ] ]
+  """
+  e.g. deportar, redeireccionar,...
+  """.
+
+
+v_np-pp*_dir-prn_lex := vprn_trans_np_lcomp & basic-four-arg &
+  [ ALTS [ RFX -,
+           RCP - ],
+    SYNSEM v_trans_np_lcomp_dir_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT - ],
+                                                                   [ OPT + ] > ] ] ]
+  """
+  e.g. llevar (se lo llevó al cine)
+  """.
+
+
+v_np-pp*_loc-rfx_lex := v_trans_np_lcomp & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           RFX +,
+           RCP - ],
+    SYNSEM v_trans_np_lcomp_loc_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT - ],
+                                                                   [ OPT + ] > ] ] ]
+  """
+  e.g. tumbar(se), levantar(se), sentar(se)
+       Juan sentó al niño en la trona -> el niño se sentó en la trona
+  """.
+
+
+v_np-pp*_dir-rfx_lex := v_trans_np_lcomp & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           RFX +,
+           RCP - ],
+    SYNSEM v_trans_np_lcomp_dir_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT - ],
+                                                                   [ OPT + ] > ] ] ]
+  """
+  e.g. alejar(se), alzar(se)
+  """.
+
+
+v_np*-pp*_dir-rcp_lex := v_trans_np_lcomp & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           RFX -,
+           RCP + ],
+    SYNSEM v_trans_np_lcomp_dir_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT + ],
+                                                                   [ OPT + ] > ] ] ]
+  """
+  e.g. copiar
+  """.
+
+
+v_np-pp*_loc-rfx-rcp_lex := v_trans_np_lcomp & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           RFX +,
+           RCP + ],
+    SYNSEM v_trans_np_lcomp_loc_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_lcomp_loc_synsem,
+                                                       VAL.COMPS < [ OPT - ],
+                                                                   [ OPT + ] > ] ] ]
+  """
+  e.g. buscar(se)
+  """.
+
+
+v_trans_np_np_synsem := v_trans_np_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
-                  VAL.COMPS < [ LOCAL [ CAT.HEAD [ CASE acc,
-                                                   KEYS.KEY non_modable_rel ] ] ], 
-                              [ LOCAL np_acc_unmrkd_local &
-                                      [ CAT.HEAD.KEYS.KEY #ockey,
-                                        CONT.HOOK.INDEX ref-ind & #ind3 ],
-                                NON-LOCAL.REL 0-dlist & [ LIST < > ] ],... > ],
+                  VAL.COMPS < [ LOCAL.CAT.HEAD [ CASE acc,
+                                                 KEYS.KEY non_modable_rel ] ],
+                              [ LOCAL np_acc_unmrkd_local & [ CAT.HEAD.KEYS.KEY #ockey,
+                                                              CONT.HOOK.INDEX ref-ind & #ind3 ],
+                                NON-LOCAL.REL 0-dlist & [ LIST < > ] ], ... > ],
             CONT [ RELS <! arg123-ev-relation !>,
                    HCONS <! !> ] ],
     LKEYS [ KEYREL [ ARG2.SORT #sort,
                      ARG3 #ind3 & [ SORT #sort ] ],
-            --OCOMPKEY #ockey ] ].
-
-v_trans_np_np := v_trans_np & 
-  [ ALTS [ IMPERS +, 
-           PASS + ] ]. 
-
-; e.g. titular (lo tituló...)
-v_np-np_id_lex := v_trans_np_np & main-verb & basic-three-arg & 
-  [ ALTS [ RCP -, RFX - ],  
-    SYNSEM v_trans_np_np_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+            --OCOMPKEY #ockey ] ]
+  """
+  --- 1.3.3.5. ditransitive verbs taking DO and NP
+  """.
 
 
-; --- 1.3.3.5. ditransitive verbs taking DO and IO 
-v_ditrans_synsem := v_trans_np_synsem & 
+v_trans_np_np := v_trans_np &
+  [ ALTS [ IMPERS +,
+           PASS + ] ]
+  """
+  
+  """.
+
+
+v_np-np_id_lex := v_trans_np_np & main-verb & basic-three-arg &
+  [ ALTS [ RCP -,
+           RFX - ],
+    SYNSEM v_trans_np_np_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_np_synsem,
+                                                VAL.COMPS < [ OPT - ],
+                                                            [ OPT - ] > ] ] ]
+  """
+  e.g. titular (lo tituló...)
+  """.
+
+
+v_ditrans_synsem := v_trans_np_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
-                  VAL.COMPS < [ LOCAL np_acc_unmrkd_local & 
-                                      [ CAT.HEAD.KEYS.KEY non_modable_rel ] ], 
-                              [ LOCAL dative_local & 
-                                      [ CAT.HEAD.KEYS.KEY #ockey, 
-                                        CONT.HOOK.INDEX ref-ind & #ind3 ],
-                                NON-LOCAL.REL 0-dlist & [ LIST < > ] ],... > ],
+                  VAL.COMPS < [ LOCAL np_acc_unmrkd_local & [ CAT.HEAD.KEYS.KEY non_modable_rel ] ],
+                              [ LOCAL dative_local & [ CAT.HEAD.KEYS.KEY #ockey,
+                                                       CONT.HOOK.INDEX ref-ind & #ind3 ],
+                                NON-LOCAL.REL 0-dlist & [ LIST < > ] ], ... > ],
             CONT [ RELS <! arg123-ev-relation !>,
                    HCONS <! !> ] ],
     LKEYS [ KEYREL.ARG3 #ind3,
-            --OCOMPKEY #ockey ] ].
-
-v_ditrans := v_trans_np. 
-
-; e.g. costar ((le) costó  3 pesetas)
-v_np-ppa*_npsv_lex := v_ditrans & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS -, PASS -, RCP -, RFX - ],  
-    SYNSEM v_ditrans_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
-
-; e.g. pasar (¿me pasas la sal?)
-v_np-ppa_lex := v_ditrans & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, PASS +, RCP -, RFX - ],  
-    SYNSEM v_ditrans_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
-
-; e.g. agradecer ((me) agradeció la propuesta) 
-v_np-ppa*_lex := v_ditrans & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, PASS +, RCP -,RFX - ],  
-    SYNSEM v_ditrans_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
-
-; e.g. disparar (le disparó (un tiro))
-v_np*-ppa_lex := v_ditrans & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, PASS +, RCP -, RFX - ],  
-    SYNSEM v_ditrans_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ].
-
-; e.g. robar ((le) robó (el bolso))
-v_np*-ppa*_lex := v_ditrans & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, PASS +, RCP -, RFX - ],  
-    SYNSEM v_ditrans_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ].
-
-; e.g. 
-v_np-ppa_rfx_lex := v_ditrans & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, PASS +, RCP -, RFX + ],  
-    SYNSEM v_ditrans_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
-
-; e.g. encomendar
-v_np-ppa*_rfx_lex := v_ditrans & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS +, PASS +, RCP -, RFX + ],  
-    SYNSEM v_ditrans_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
-
-; e.g. hacer falta
-v_np-ppa*_idm_lex := v_ditrans & main-verb & basic-three-arg & 
-  [ ALTS [ IMPERS -, PASS -, RCP -, RFX - ],  
-    SYNSEM v_ditrans_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
+            --OCOMPKEY #ockey ] ]
+  """
+  --- 1.3.3.5. ditransitive verbs taking DO and IO
+  """.
 
 
-; --- 1.3.3.6. transitive verbs taking verbal complement
-v_trans_cp_prop-or-ques_synsem := v_trans_synsem & 
-  [ LOCAL [ CAT [ VAL.COMPS < [ LOCAL v_local &
-                                      [ COORD -,
-                                        CONT.HOOK.LTOP #larg ] ] > ],
+v_ditrans := v_trans_np
+  """
+  
+  """.
+
+
+v_np-ppa*_npsv_lex := v_ditrans & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS -,
+           PASS -,
+           RCP -,
+           RFX - ],
+    SYNSEM v_ditrans_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem,
+                                            VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+  """
+  e.g. costar ((le) costó  3 pesetas)
+  """.
+
+
+v_np-ppa_lex := v_ditrans & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           PASS +,
+           RCP -,
+           RFX - ],
+    SYNSEM v_ditrans_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem,
+                                            VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]
+  """
+  e.g. pasar (¿me pasas la sal?)
+  """.
+
+
+v_np-ppa*_lex := v_ditrans & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           PASS +,
+           RCP -,
+           RFX - ],
+    SYNSEM v_ditrans_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem,
+                                            VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+  """
+  e.g. agradecer ((me) agradeció la propuesta)
+  """.
+
+
+v_np*-ppa_lex := v_ditrans & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           PASS +,
+           RCP -,
+           RFX - ],
+    SYNSEM v_ditrans_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem,
+                                            VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+  """
+  e.g. disparar (le disparó (un tiro))
+  """.
+
+
+v_np*-ppa*_lex := v_ditrans & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           PASS +,
+           RCP -,
+           RFX - ],
+    SYNSEM v_ditrans_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem,
+                                            VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]
+  """
+  e.g. robar ((le) robó (el bolso))
+  """.
+
+
+v_np-ppa_rfx_lex := v_ditrans & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           PASS +,
+           RCP -,
+           RFX + ],
+    SYNSEM v_ditrans_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem,
+                                            VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]
+  """
+  e.g.
+  """.
+
+
+v_np-ppa*_rfx_lex := v_ditrans & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS +,
+           PASS +,
+           RCP -,
+           RFX + ],
+    SYNSEM v_ditrans_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem,
+                                            VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+  """
+  e.g. encomendar
+  """.
+
+
+v_np-ppa*_idm_lex := v_ditrans & main-verb & basic-three-arg &
+  [ ALTS [ IMPERS -,
+           PASS -,
+           RCP -,
+           RFX - ],
+    SYNSEM v_ditrans_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_synsem,
+                                            VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+  """
+  e.g. hacer falta
+  """.
+
+
+v_trans_cp_prop-or-ques_synsem := v_trans_synsem &
+  [ LOCAL [ CAT.VAL.COMPS < [ LOCAL v_local & [ COORD -,
+                                                CONT.HOOK.LTOP #larg ] ] >,
             CONT [ RELS <! arg12-ev-relation !>,
                    HCONS <! [ HARG #harg,
                               LARG #larg ] !> ] ],
-    LKEYS.KEYREL.ARG2 #harg ].
+    LKEYS.KEYREL.ARG2 #harg ]
+  """
+  --- 1.3.3.6. transitive verbs taking verbal complement
+  """.
 
-v_trans_cp_prop-or-ques_fin_synsem := v_trans_cp_prop-or-ques_synsem & 
+
+v_trans_cp_prop-or-ques_fin_synsem := v_trans_cp_prop-or-ques_synsem &
   [ LOCAL.CAT [ HEAD.INV -,
                 VAL.COMPS < [ OPT -,
-                              LOCAL.CAT.HEAD.VFORM fin ] > ] ].
+                              LOCAL.CAT.HEAD.VFORM fin ] > ] ]
+  """
+  
+  """.
 
-v_trans_cp_prop-or-ques_inf_synsem := v_trans_cp_prop-or-ques_synsem & 
-  [ LOCAL.CAT [ HEAD.INV -, 
+
+v_trans_cp_prop-or-ques_inf_synsem := v_trans_cp_prop-or-ques_synsem &
+  [ LOCAL.CAT [ HEAD.INV -,
                 VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX ref-ind & #ind ] >,
                       COMPS < [ OPT -,
-                                LOCAL [ CAT [ HEAD.VFORM inf, 
+                                LOCAL [ CAT [ HEAD.VFORM inf,
                                               VAL [ SUBJ < [ NON-LOCAL [ SLASH 0-dlist,
                                                                          REL 0-dlist,
                                                                          QUE 0-dlist ] ] >,
                                                     COMPS < > ] ],
-                                        CONT.HOOK.XARG #ind ] ] > ] ] ].
+                                        CONT.HOOK.XARG #ind ] ] > ] ] ]
+  """
+  
+  """.
 
-v_trans_cp_prop-or-ques := basic-main-verb & 
+
+v_trans_cp_prop-or-ques := basic-main-verb &
   [ ALTS [ RCP -,
            RFX -,
-           PASS - ] ].
+           PASS - ] ]
+  """
+  
+  """.
 
 
-; --- 1.3.3.6.1. predicative verbs taking Vfin/Vinf complement (no control)
-; e.g. ser (El error fue haberlo comprado en rebajas.)
 v_prd_cp_prop_inf_synsem := v_trans_cp_prop-or-ques_synsem &
   [ LOCAL [ AGR #agr,
-            CAT [ HEAD.INV -, 
+            CAT [ HEAD.INV -,
                   VAL [ SUBJ < [ OPT - ] >,
-                        COMPS < [ LOCAL vp_inf_local &
-                                        [ CAT [ HEAD.VFORM inf, 
-                                                VAL [ SUBJ < [ NON-LOCAL [ SLASH 0-dlist,
-                                                                           REL 0-dlist,
-                                                                           QUE 0-dlist ] ] >,
-                                                      COMPS < >, 
-                                                      CLTS #clts ] ] ] ] >,
+                        COMPS < [ LOCAL vp_inf_local & [ CAT [ HEAD.VFORM inf,
+                                                               VAL [ SUBJ < [ NON-LOCAL [ SLASH 0-dlist,
+                                                                                          REL 0-dlist,
+                                                                                          QUE 0-dlist ] ] >,
+                                                                     COMPS < >,
+                                                                     CLTS #clts ] ] ] ] >,
                         CLTS #clts ] ],
-            CONT.HOOK.XARG #agr ] ].
+            CONT.HOOK.XARG #agr ] ]
+  """
+  --- 1.3.3.6.1. predicative verbs taking Vfin/Vinf complement (no control)
+  e.g. ser (El error fue haberlo comprado en rebajas.)
+  """.
+
 
 v_prd_cp_prop_fin_synsem := v_trans_cp_prop-or-ques_synsem &
-  [ LOCAL.CAT [ HEAD.INV -, 
-                VAL.COMPS < [ LOCAL s_or_cp_fin_local &
-                                    [ CAT.HEAD.VFORM fin ] ] > ] ].
+  [ LOCAL.CAT [ HEAD.INV -,
+                VAL.COMPS < [ LOCAL s_or_cp_fin_local & [ CAT.HEAD.VFORM fin ] ] > ] ]
+  """
+  
+  """.
 
-v_prd_cp_prop := v_trans_cp_prop-or-ques & 
+
+v_prd_cp_prop := v_trans_cp_prop-or-ques &
   [ ALTS [ VCALT -,
            IMPERS - ],
-    SYNSEM v_trans_cp_prop-or-ques_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop-or-ques_synsem, 
-                         VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX ref-ind ] >,
-                               COMPS < [ OPT -,
-                                         LOCAL [ CAT [ MC -,
-                                                       HEAD.KEYS.ALT2KEY prop ],
-                                                 CONT.HOOK.INDEX.SF prop ] ] > ] ] ] ].
-
-v_vp_inf-ser_lex := v_prd_cp_prop & cc-two-arg & 
-  [ SYNSEM v_prd_cp_prop_inf_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_prd_cp_prop_inf_synsem, 
-                         VAL [ SUBJ < #subj >,
-                               COMPS < #comps >,
-                               CLTS #clts ] ] ],
-    ARG-ST < #subj . < #comps . #clts > > ].
-
-v_cp_p-ser_lex := v_prd_cp_prop & basic-two-arg & 
-  [ SYNSEM v_prd_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_prd_cp_prop_fin_synsem,
-                         VAL [ SUBJ < #subj >,
-                               COMPS #comps ] ] ], 
-    ARG-ST < #subj . #comps > ].
+    SYNSEM v_trans_cp_prop-or-ques_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop-or-ques_synsem,
+                                                          VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX ref-ind ] >,
+                                                                COMPS < [ OPT -,
+                                                                          LOCAL [ CAT [ MC -,
+                                                                                        HEAD.KEYS.ALT2KEY prop ],
+                                                                                  CONT.HOOK.INDEX.SF prop ] ] > ] ] ] ]
+  """
+  
+  """.
 
 
-; --- 1.3.3.6.1. transitive verbs taking Vinf complement (only) - subject control verbs
+v_vp_inf-ser_lex := v_prd_cp_prop & cc-two-arg &
+  [ SYNSEM v_prd_cp_prop_inf_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_prd_cp_prop_inf_synsem,
+                                                    VAL [ SUBJ < #subj >,
+                                                          COMPS < #comps >,
+                                                          CLTS #clts ] ] ],
+    ARG-ST < #subj, #comps . < #comps . #clts > > ]
+  """
+  
+  """.
 
-v_trans_cp_prop_inf_synsem := v_trans_cp_prop-or-ques_synsem & 
+
+v_cp_p-ser_lex := v_prd_cp_prop & basic-two-arg &
+  [ SYNSEM v_prd_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_prd_cp_prop_fin_synsem,
+                                                    VAL [ SUBJ < #subj >,
+                                                          COMPS #comps ] ] ],
+    ARG-ST < #subj . #comps > ]
+  """
+  
+  """.
+
+
+v_trans_cp_prop_inf_synsem := v_trans_cp_prop-or-ques_synsem &
   [ LOCAL.CAT [ HEAD.INV #inv,
-                VAL.COMPS < [ LOCAL vp_inf_local &
-                                    [ CAT [ MC -,
-                                            HEAD [ INV #inv, 
-                                                   KEYS.ALT2KEY prop ] ], 
-                                      CONT.HOOK.INDEX.SF prop ] ] > ] ].
+                VAL.COMPS < [ LOCAL vp_inf_local & [ CAT [ MC -,
+                                                           HEAD [ INV #inv,
+                                                                  KEYS.ALT2KEY prop ] ],
+                                                     CONT.HOOK.INDEX.SF prop ] ] > ] ]
+  """
+  --- 1.3.3.6.1. transitive verbs taking Vinf complement (only) - subject control verbs
+  """.
 
-v_trans_cp_prop_inf := v_trans_cp_prop-or-ques & 
+
+v_trans_cp_prop_inf := v_trans_cp_prop-or-ques &
   [ ALTS [ VCALT -,
-           IMPERS - ] ].
-
-; e.g. intentar (¿has intentado hacerlo (tú)?)
-v_vp_inf-sc_lex := v_trans_cp_prop_inf & cc-two-arg & 
-  [ SYNSEM v_trans_cp_prop_inf_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_inf_synsem, 
-                         VAL [ SUBJ < #subj >,
-                               COMPS < #comps & [ OPT -, LOCAL.CAT.VAL.CLTS #clts ] >,
-                               CLTS #clts ] ] ],
-    ARG-ST < #subj . < #comps . #clts > > ].
-
-; e.g. se dejó querer  
-v_vp_inf-oc-prn_lex := v_trans_cp_prop_inf & main-vprn & cc-two-arg & 
-  [ SYNSEM v_trans_cp_prop_inf_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_inf_synsem, 
-                         VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #ind2 ] >,
-                               COMPS < [ OPT -, LOCAL.CONT.RELS.LIST < [ ARG2 #ind2 ],... > ] > ] ] ] ].
+           IMPERS - ] ]
+  """
+  
+  """.
 
 
-; --- 1.3.3.6.2. transitive verbs taking finite completive clauses
+v_vp_inf-sc_lex := v_trans_cp_prop_inf & cc-two-arg &
+  [ SYNSEM v_trans_cp_prop_inf_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_inf_synsem,
+                                                      VAL [ SUBJ < #subj >,
+                                                            COMPS < #comps & [ OPT -,
+                                                                               LOCAL.CAT.VAL.CLTS #clts ] >,
+                                                            CLTS #clts ] ] ],
+    ARG-ST < #subj, #comps . < #comps . #clts > > ]
+  """
+  e.g. intentar (¿has intentado hacerlo (tú)?)
+  """.
+
+
+v_vp_inf-oc-prn_lex := v_trans_cp_prop_inf & main-vprn & cc-two-arg &
+  [ SYNSEM v_trans_cp_prop_inf_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_inf_synsem,
+                                                      VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #ind2 ] >,
+                                                            COMPS < [ OPT -,
+                                                                      LOCAL.CONT.RELS.LIST < [ ARG2 #ind2 ], ... > ] > ] ] ] ]
+  """
+  e.g. se dejó querer
+  """.
+
+
 v_trans_cp_prop_fin_synsem := v_trans_cp_prop-or-ques_fin_synsem &
   [ LOCAL.CAT.VAL.COMPS < [ OPT -,
                             LOCAL [ CAT [ MC -,
                                           HEAD.KEYS.ALT2KEY prop ],
-                                    CONT.HOOK.INDEX.SF prop ] ] > ].
+                                    CONT.HOOK.INDEX.SF prop ] ] > ]
+  """
+  --- 1.3.3.6.2. transitive verbs taking finite completive clauses
+  """.
 
-v_trans_cp_prop_fin := v_trans_cp_prop-or-ques & 
-  [ ALTS [ VCALT + ] ].
+
+v_trans_cp_prop_fin := v_trans_cp_prop-or-ques &
+  [ ALTS.VCALT + ]
+  """
+  
+  """.
 
 
-; e.g. no entiende que la quiero/quisiera
-v_cp_p_lex := v_trans_cp_prop_fin & main-verb & basic-two-arg & 
-  [ SYNSEM v_trans_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ LOCAL s_or_cp_fin_local ] > ] ] ].
+v_cp_p_lex := v_trans_cp_prop_fin & main-verb & basic-two-arg &
+  [ SYNSEM v_trans_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_fin_synsem,
+                                                      VAL.COMPS < [ LOCAL s_or_cp_fin_local ] > ] ] ]
+  """
+  e.g. no entiende que la quiero/quisiera
+  """.
 
-; e.g. ¿Crees que aceptará/*aceptara?
-v_cp_p-ind_lex := v_trans_cp_prop_fin & main-verb & basic-two-arg & 
-  [ SYNSEM v_trans_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ LOCAL s_or_cp_fin_local &
-                                         [ CAT.HEAD.TAM.MOOD ind ] ] > ] ] ].
 
-; e.g. se figura que vendrá/*venga
-v_cp_p-ind-prn_lex := v_trans_cp_prop_fin & main-vprn & basic-three-arg & 
-  [ SYNSEM v_trans_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ LOCAL s_or_cp_fin_local &
-                                         [ CAT.HEAD.TAM.MOOD ind ] ] > ] ] ].
+v_cp_p-ind_lex := v_trans_cp_prop_fin & main-verb & basic-two-arg &
+  [ SYNSEM v_trans_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_fin_synsem,
+                                                      VAL.COMPS < [ LOCAL s_or_cp_fin_local & [ CAT.HEAD.TAM.MOOD ind ] ] > ] ] ]
+  """
+  e.g. ¿Crees que aceptará/*aceptara?
+  """.
 
-; e.g. dudo que venga/*viene
-v_cp_p-sub_lex := v_trans_cp_prop_fin & main-verb & basic-two-arg & 
-  [ SYNSEM v_trans_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ LOCAL s_or_cp_fin_local &
-                                         [ CAT.HEAD.TAM.MOOD sub ] ] > ] ] ].
 
-; -- con algunos verbos de temor, voluntar y deseo
-; e.g. sentir (siento (que) no hayáis recibido el paquete)
-v_cp_p-sub-optcm_lex := v_trans_cp_prop_fin & main-verb & basic-two-arg & 
-  [ SYNSEM v_trans_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ LOCAL s_or_cp_fin_local & 
-                                         [ CAT.HEAD.TAM.MOOD sub ] ] > ] ] ].
+v_cp_p-ind-prn_lex := v_trans_cp_prop_fin & main-vprn & basic-three-arg &
+  [ SYNSEM v_trans_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_fin_synsem,
+                                                      VAL.COMPS < [ LOCAL s_or_cp_fin_local & [ CAT.HEAD.TAM.MOOD ind ] ] > ] ] ]
+  """
+  e.g. se figura que vendrá/*venga
+  """.
 
-; -- with the verb "ver" it can be introduced by the conjunctive adverb "como", 
-; e.g. vas a ver como no le gusta
 
-; --- 1.3.3.6.3. verbs taking interrogative clauses 
-; - The usual thing is that they appear in indicative, but they can appear in subjunctive in dubitative 
-; clauses of courtesy use.
-v_trans_cp_ques_fin_synsem :=  v_trans_cp_prop-or-ques_fin_synsem & 
+v_cp_p-sub_lex := v_trans_cp_prop_fin & main-verb & basic-two-arg &
+  [ SYNSEM v_trans_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_fin_synsem,
+                                                      VAL.COMPS < [ LOCAL s_or_cp_fin_local & [ CAT.HEAD.TAM.MOOD sub ] ] > ] ] ]
+  """
+  e.g. dudo que venga/*viene
+  """.
+
+
+v_cp_p-sub-optcm_lex := v_trans_cp_prop_fin & main-verb & basic-two-arg &
+  [ SYNSEM v_trans_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_prop_fin_synsem,
+                                                      VAL.COMPS < [ LOCAL s_or_cp_fin_local & [ CAT.HEAD.TAM.MOOD sub ] ] > ] ] ]
+  """
+  -- con algunos verbos de temor, voluntar y deseo
+  e.g. sentir (siento (que) no hayáis recibido el paquete)
+  """.
+
+
+v_trans_cp_ques_fin_synsem := v_trans_cp_prop-or-ques_fin_synsem &
   [ LOCAL.CAT.VAL.COMPS < [ OPT -,
-                            LOCAL s_or_cp_fin_local & 
-                                  [ CAT.HEAD [ TAM.MOOD ind,
-                                               KEYS.ALT2KEY ques ] ] ] > ].
+                            LOCAL s_or_cp_fin_local & [ CAT.HEAD [ TAM.MOOD ind,
+                                                                   KEYS.ALT2KEY ques ] ] ] > ]
+  """
+  -- with the verb "ver" it can be introduced by the conjunctive adverb "como",
+  e.g. vas a ver como no le gusta
+  --- 1.3.3.6.3. verbs taking interrogative clauses
+  - The usual thing is that they appear in indicative, but they can appear in subjunctive in dubitative
+  clauses of courtesy use.
+  """.
 
-v_trans_cp_ques := v_trans_cp_prop-or-ques & 
+
+v_trans_cp_ques := v_trans_cp_prop-or-ques &
   [ ALTS [ VCALT +,
-           IMPERS - ] ].
+           IMPERS - ] ]
+  """
+  
+  """.
 
 
-; -- (PIVs). they are always interpreted as questions. Syntactically, they are introduced by 'que'; 
-; they may co-ocur with verbs taking direct question (e.g. pregunto/dijo: ¿quién irá?/que quién irá); 
-; may co-ocur with appositive disjunctions, but not with appositive coordination (e.g. preguntó/dijo 
-; que quién, Juan o Pedro, iría; *preguntó/dijo que quién, Juan y Pedro, iría)
-
-; a)- 'Que' is optional; for 'inquirir' (and 'preguntar(se)' (below)).
-; e.g. La maestra inquirió (que) por qué había estado ausente tantos días.
-v_cp_q-optcm_lex := v_trans_cp_ques & main-verb & basic-two-arg & 
-  [ SYNSEM v_trans_cp_ques_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_ques_fin_synsem, 
-                         VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SF ques ] > ] ] ].
-
-; e.g. se preguntó (que) dónde había ido.
-v_cp_q-optcm-prn_lex := v_trans_cp_ques & main-vprn & basic-three-arg & 
-  [ SYNSEM v_trans_cp_ques_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_ques_fin_synsem, 
-                         VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SF ques ] > ] ] ].
+v_cp_q-optcm_lex := v_trans_cp_ques & main-verb & basic-two-arg &
+  [ SYNSEM v_trans_cp_ques_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_ques_fin_synsem,
+                                                      VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SF ques ] > ] ] ]
+  """
+  -- (PIVs). they are always interpreted as questions. Syntactically, they are introduced by 'que';
+  they may co-ocur with verbs taking direct question (e.g. pregunto/dijo: ¿quién irá?/que quién irá);
+  may co-ocur with appositive disjunctions, but not with appositive coordination (e.g. preguntó/dijo
+  que quién, Juan o Pedro, iría; *preguntó/dijo que quién, Juan y Pedro, iría)
+  a)- 'Que' is optional; for 'inquirir' (and 'preguntar(se)' (below)).
+  e.g. La maestra inquirió (que) por qué había estado ausente tantos días.
+  """.
 
 
-; b)- 'que' is obligatory
-; e.g. gritó que dónde habíamos puesto el dinero 
-v_cp_q-cm_lex := v_trans_cp_ques & main-verb & basic-two-arg & 
-  [ SYNSEM v_trans_cp_ques_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_ques_fin_synsem, 
-                         VAL.COMPS < [ LOCAL [ CAT.HEAD comp & [ KEYS.ALTKEY prop ],
-                                               CONT.HOOK.INDEX.SF ques ] ] > ] ] ].
+v_cp_q-optcm-prn_lex := v_trans_cp_ques & main-vprn & basic-three-arg &
+  [ SYNSEM v_trans_cp_ques_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_ques_fin_synsem,
+                                                      VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SF ques ] > ] ] ]
+  """
+  e.g. se preguntó (que) dónde había ido.
+  """.
 
 
-; -- (PIIs). they are interpreted as assertions. Syntactically, they are not introduced by 'que'; 
-; they may be coordinated with completive clauses (e.g. Sabe que le envió un paquete y cuándo se 
-; lo envió);  may co-occur with appositive coordination, but not with appositive disjunction
-; (e.g. sabe quién, Juan y Pedro, iría; *sabe quién, Juan o Pedro, iría)
-
-; e.g. dijo *que quién ganaría.
-v_cp_q_lex := v_trans_cp_ques & main-verb & basic-two-arg & 
-  [ SYNSEM v_trans_cp_ques_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_ques_fin_synsem, 
-                         VAL.COMPS < [ LOCAL [ CAT.HEAD.KEYS.ALTKEY ques,
-                                               CONT.HOOK.INDEX.SF ques ] ] > ] ] ].
-;                                               CONT.HOOK.INDEX.SF prop-or-ques ] ] > ] ] ].
+v_cp_q-cm_lex := v_trans_cp_ques & main-verb & basic-two-arg &
+  [ SYNSEM v_trans_cp_ques_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_ques_fin_synsem,
+                                                      VAL.COMPS < [ LOCAL [ CAT.HEAD comp & [ KEYS.ALTKEY prop ],
+                                                                            CONT.HOOK.INDEX.SF ques ] ] > ] ] ]
+  """
+  b)- 'que' is obligatory
+  e.g. gritó que dónde habíamos puesto el dinero
+  """.
 
 
-; --- 1.3.3.7. Ditransitive verbs taking completive clause and IO
-; With some verbs the subject can acquire sentential format
-; (cf. v_subj_cp_prop_ditrans_cp_prop_le; e.g. oír música no (te) impide trabajar/que trabajes)
-v_ditrans_cp_prop-or-ques_synsem := arg1_lt & 
+v_cp_q_lex := v_trans_cp_ques & main-verb & basic-two-arg &
+  [ SYNSEM v_trans_cp_ques_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_cp_ques_fin_synsem,
+                                                      VAL.COMPS < [ LOCAL [ CAT.HEAD.KEYS.ALTKEY ques,
+                                                                            CONT.HOOK.INDEX.SF ques ] ] > ] ] ]
+  """
+  -- (PIIs). they are interpreted as assertions. Syntactically, they are not introduced by 'que';
+  they may be coordinated with completive clauses (e.g. Sabe que le envió un paquete y cuándo se
+  lo envió);  may co-occur with appositive coordination, but not with appositive disjunction
+  (e.g. sabe quién, Juan y Pedro, iría; *sabe quién, Juan o Pedro, iría)
+  e.g. dijo *que quién ganaría.
+  """.
+
+
+v_ditrans_cp_prop-or-ques_synsem := arg1_lt &
   [ LOCAL [ CAT [ HEAD.INV -,
-                  VAL.COMPS < [ LOCAL dative_local & 
-                                      [ CAT.HEAD.KEYS.KEY #ckey,
-                                        CONT.HOOK.INDEX #ind3 ],
+                  VAL.COMPS < [ LOCAL dative_local & [ CAT.HEAD.KEYS.KEY #ckey,
+                                                       CONT.HOOK.INDEX #ind3 ],
                                 NON-LOCAL.REL 0-dlist & [ LIST < > ] ],
-                              [ LOCAL v_local & 
-                                      [ CAT.HEAD.KEYS.KEY #ockey,
-                                        CONT.HOOK.LTOP #larg ] ] > ], 
+                              [ LOCAL v_local & [ CAT.HEAD.KEYS.KEY #ockey,
+                                                  CONT.HOOK.LTOP #larg ] ] > ],
             CONT [ RELS <! arg123-ev-relation !>,
                    HCONS <! qeq & [ HARG #harg,
                                     LARG #larg ] !> ] ],
-    LKEYS [ KEYREL arg123-ev-relation & 
-                   [ ARG2 #harg,
-                     ARG3 #ind3 ],
+    LKEYS [ KEYREL arg123-ev-relation & [ ARG2 #harg,
+                                          ARG3 #ind3 ],
             --COMPKEY #ckey,
-            --OCOMPKEY #ockey ] ].
-;!!!!
-v_ditrans_cp_prop-or-ques_fin_synsem := v_ditrans_cp_prop-or-ques_synsem & 
-  [ LOCAL.CAT.VAL.COMPS < synsem,
-                          [ OPT -, 
-                            LOCAL.CAT.HEAD.VFORM fin ] > ].
+            --OCOMPKEY #ockey ] ]
+  """
+                                                CONT.HOOK.INDEX.SF prop-or-ques ] ] > ] ] ].
+  --- 1.3.3.7. Ditransitive verbs taking completive clause and IO
+  With some verbs the subject can acquire sentential format
+  (cf. v_subj_cp_prop_ditrans_cp_prop_le; e.g. oír música no (te) impide trabajar/que trabajes)
+  """.
 
-v_ditrans_cp_prop-or-ques_inf_synsem := v_ditrans_cp_prop-or-ques_synsem & 
+
+v_ditrans_cp_prop-or-ques_fin_synsem := v_ditrans_cp_prop-or-ques_synsem &
+  [ LOCAL.CAT.VAL.COMPS < synsem,
+                          [ OPT -,
+                            LOCAL.CAT.HEAD.VFORM fin ] > ]
+  """
+  !!!!
+  """.
+
+
+v_ditrans_cp_prop-or-ques_inf_synsem := v_ditrans_cp_prop-or-ques_synsem &
   [ LOCAL.CAT.VAL [ COMPS < [ OPT + ],
-                            [ OPT -, 
+                            [ OPT -,
                               LOCAL.CAT [ HEAD.VFORM inf,
                                           VAL [ SUBJ < [ NON-LOCAL [ SLASH 0-dlist,
                                                                      REL 0-dlist,
                                                                      QUE 0-dlist ] ] >,
                                                 COMPS < >,
                                                 CLTS #clts ] ] ] >,
-                    CLTS #clts ] ].
+                    CLTS #clts ] ]
+  """
+  
+  """.
 
-v_ditrans_cp_prop-or-ques_fin := basic-main-verb & 
+
+v_ditrans_cp_prop-or-ques_fin := basic-main-verb &
   [ ALTS [ RCP -,
            RFX -,
            PASS -,
-           IMPERS - ] ].
+           IMPERS - ] ]
+  """
+  
+  """.
 
-; --- 1.3.3.7.1. ditransitive verbs taking VPfin complement and IO
-v_ditrans_cp_prop_fin_synsem := v_ditrans_cp_prop-or-ques_fin_synsem & 
+
+v_ditrans_cp_prop_fin_synsem := v_ditrans_cp_prop-or-ques_fin_synsem &
   [ LOCAL.CAT.VAL.COMPS < synsem,
-                          [ LOCAL [ CAT [  MC -,
-                                           HEAD.KEYS.ALT2KEY prop ],
-                                    CONT.HOOK.INDEX.SF prop ] ] > ].
+                          [ LOCAL [ CAT [ MC -,
+                                          HEAD.KEYS.ALT2KEY prop ],
+                                    CONT.HOOK.INDEX.SF prop ] ] > ]
+  """
+  --- 1.3.3.7.1. ditransitive verbs taking VPfin complement and IO
+  """.
+
 
 v_ditrans_cp_prop_fin := v_ditrans_cp_prop-or-ques_fin &
-  [ ALTS.VCALT + ].
+  [ ALTS.VCALT + ]
+  """
+  
+  """.
 
 
-; a)- the subordinate clause appears in indicative/subjuntive
-; e.g. puntualizar
-v_ppa*-cp_p_lex := v_ditrans_cp_prop_fin & main-verb & basic-three-arg &  
-  [ SYNSEM v_ditrans_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT + ],
-                                     [ LOCAL s_or_cp_fin_local ] > ] ] ].
-
-; b)- the subordinate clause appears in indicative and may alternate with a VPinf if there is 
-; subject control (e.g. Juan aseguró no saber nada). Verbs like 'advertir' (to warn) or 'avisar' 
-; (to inform) do not admit VPinf
-; e.g. prometer (to promise) ((le) prometí que lo harían (ellos))
-v_ppa*-cp_p-ind_lex := v_ditrans_cp_prop_fin & main-verb & basic-three-arg & 
-  [ SYNSEM v_ditrans_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT + ],
-                                     [ LOCAL s_or_cp_fin_local & 
-                                             [ CAT.HEAD.TAM.MOOD ind ] ] > ] ] ].
-
-; e.g. advertir
-v_ppa*-cp_p-ind-optcm_lex := v_ditrans_cp_prop_fin & main-verb & basic-three-arg & 
-  [ SYNSEM v_ditrans_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT + ],
-                                     [ LOCAL s_or_cp_fin_local & 
-                                             [ CAT.HEAD.TAM.MOOD ind ] ] > ] ] ].
+v_ppa*-cp_p_lex := v_ditrans_cp_prop_fin & main-verb & basic-three-arg &
+  [ SYNSEM v_ditrans_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_prop_fin_synsem,
+                                                        VAL.COMPS < [ OPT + ],
+                                                                    [ LOCAL s_or_cp_fin_local ] > ] ] ]
+  """
+  a)- the subordinate clause appears in indicative/subjuntive
+  e.g. puntualizar
+  """.
 
 
-; c)- the nominal subordinate clause appears in subjunctive and can alternate with a VPinf (object control)
-; (e.g. me aconsejó ir a ver esta película)). Verbs like 'implorar, 'pedir', 'rogar' or 'suplicar' 
-; admit two paradigms: object control (e.g. les rogaron guardar un minuto de silencio) and subject control 
-; (e.g. pidió atender a los enfermos).
+v_ppa*-cp_p-ind_lex := v_ditrans_cp_prop_fin & main-verb & basic-three-arg &
+  [ SYNSEM v_ditrans_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_prop_fin_synsem,
+                                                        VAL.COMPS < [ OPT + ],
+                                                                    [ LOCAL s_or_cp_fin_local & [ CAT.HEAD.TAM.MOOD ind ] ] > ] ] ]
+  """
+  b)- the subordinate clause appears in indicative and may alternate with a VPinf if there is
+  subject control (e.g. Juan aseguró no saber nada). Verbs like 'advertir' (to warn) or 'avisar'
+  (to inform) do not admit VPinf
+  e.g. prometer (to promise) ((le) prometí que lo harían (ellos))
+  """.
 
-; e.g. ordenar (to order) (le ordené que volviese temprano)
-v_ppa*-cp_p-sub_lex := v_ditrans_cp_prop_fin & main-verb & basic-three-arg & 
-  [ SYNSEM v_ditrans_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT + ],
-                                     [ LOCAL s_or_cp_fin_local & 
-                                             [ CAT.HEAD.TAM.MOOD sub ] ] > ] ] ].
 
-; e.g. te ruego (que) me envíes/*envías más papel
-v_ppa*-cp_p-sub-optcm_lex := v_ditrans_cp_prop_fin & main-verb & basic-three-arg & 
-  [ SYNSEM v_ditrans_cp_prop_fin_synsem &
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT + ],
-                                     [ LOCAL s_or_cp_fin_local & 
-                                             [ CAT.HEAD.TAM.MOOD sub ] ] > ] ] ].
+v_ppa*-cp_p-ind-optcm_lex := v_ditrans_cp_prop_fin & main-verb & basic-three-arg &
+  [ SYNSEM v_ditrans_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_prop_fin_synsem,
+                                                        VAL.COMPS < [ OPT + ],
+                                                                    [ LOCAL s_or_cp_fin_local & [ CAT.HEAD.TAM.MOOD ind ] ] > ] ] ]
+  """
+  e.g. advertir
+  """.
+
+
+v_ppa*-cp_p-sub_lex := v_ditrans_cp_prop_fin & main-verb & basic-three-arg &
+  [ SYNSEM v_ditrans_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_prop_fin_synsem,
+                                                        VAL.COMPS < [ OPT + ],
+                                                                    [ LOCAL s_or_cp_fin_local & [ CAT.HEAD.TAM.MOOD sub ] ] > ] ] ]
+  """
+  c)- the nominal subordinate clause appears in subjunctive and can alternate with a VPinf (object control)
+  (e.g. me aconsejó ir a ver esta película)). Verbs like 'implorar, 'pedir', 'rogar' or 'suplicar'
+  admit two paradigms: object control (e.g. les rogaron guardar un minuto de silencio) and subject control
+  (e.g. pidió atender a los enfermos).
+  e.g. ordenar (to order) (le ordené que volviese temprano)
+  """.
+
+
+v_ppa*-cp_p-sub-optcm_lex := v_ditrans_cp_prop_fin & main-verb & basic-three-arg &
+  [ SYNSEM v_ditrans_cp_prop_fin_synsem & [ LOCAL.CAT [ HEAD.LSYNSEM v_ditrans_cp_prop_fin_synsem,
+                                                        VAL.COMPS < [ OPT + ],
+                                                                    [ LOCAL s_or_cp_fin_local & [ CAT.HEAD.TAM.MOOD sub ] ] > ] ] ]
+  """
+  e.g. te ruego (que) me envíes/*envías más papel
+  """.
+
 
 
 ; --- 1.3.3.7.2. ditransitive verbs taking VPinf complement and IO

--- a/letypes.tdl
+++ b/letypes.tdl
@@ -107,18 +107,24 @@ v_impers := basic-main-verb &
 
 ; --- 1.1.1. weather predicates
 
-; - llover (to rain), tronar (to thunder),...
 v_impers_strict_intr_synsem := v_impers_synsem & 
   [ LOCAL [ AGR.PNG.PN 3sg, 
             CAT [ HEAD.INV -,
                   VAL.COMPS < > ],
-            CONT.HCONS <! !> ] ].
+            CONT.HCONS <! !> ] ]
+"""; --- 1.1.1. weather predicates
+- llover (to rain), tronar (to thunder),...
+""".
 
 v_-_nsbj_lex := v_impers & main-verb-impers & norm-zero-arg & 
   [ SYNSEM v_impers_strict_intr_synsem &
            [ LOCAL.CAT.HEAD.LSYNSEM v_impers_strict_intr_synsem ] ].
 
 
+; --- 1.1.2. impersonal verbs taking nominal complements that don't passivize (haber)
+
+trans_impers_synsem := v_impers_synsem & transitive_verb_synsem
+"""
 ; - hacer + SN; e.g. hace calor/frío (it is hot/cold) =>> v_np_npsv-nsbj_lex
 
 ; - ser 3sg + PPde; e.g. en Islandia es de noche durante seis meses (Iceland is dark during six months)
@@ -137,8 +143,7 @@ v_-_nsbj_lex := v_impers & main-verb-impers & norm-zero-arg &
 ; algunos profesores/ there are some teachers)
 ; !!! hay 4 metros desde la mesa hasta la TV, hay bastante/suficiente con esto (there are four meters 
 ; from the table to the TV, it is enough with this)
-
-trans_impers_synsem := v_impers_synsem & transitive_verb_synsem.
+""".
 
 v_impers_np_ntr_synsem := trans_impers_synsem &
   [ LOCAL [ AGR.PNG.PN 3sg, 
@@ -156,8 +161,6 @@ v_np_npsv-nsbj_lex := v_impers & main-verb-impers & basic-one-arg &
 
 
 ; --- 1.1.3. impersonal verbs taking finite completive clauses (parecer, resultar, semejar, poder)
-; They also show a raising structure (e.g. parece que Juan trabaja mucho -> Juan parece trabajar mucho 
-; (it seems that John works a lot -> John seems to work a lot))
 
 v_impers_cp_prop_fin_synsem := v_impers_synsem &
   [ LOCAL [ AGR.PNG.PN 3sg, 
@@ -166,33 +169,39 @@ v_impers_cp_prop_fin_synsem := v_impers_synsem &
                                       [ CONT.HOOK.LTOP #larg ] ] > ],
             CONT.HCONS <! qeq & [ HARG #harg,
                                   LARG #larg ] !> ],
-    LKEYS.KEYREL arg2-ev-relation & [ ARG2 #harg ] ].
+    LKEYS.KEYREL arg2-ev-relation & [ ARG2 #harg ] ]
+    """; --- 1.1.3. impersonal verbs taking finite completive clauses (parecer, resultar, semejar, poder)
+; They also show a raising structure (e.g. parece que Juan trabaja mucho -> Juan parece trabajar mucho 
+; (it seems that John works a lot -> John seems to work a lot))
+""".
 
-; a)- taking indicative (parecer, resultar, semejar)
+v_cp_p-ind-nsbj_lex := v_impers & main-verb-impers & basic-one-arg & 
+  [ SYNSEM v_impers_cp_prop_fin_synsem & 
+           [ LOCAL.CAT [ HEAD.LSYNSEM v_impers_cp_prop_fin_synsem,
+                         VAL.COMPS < [ OPT -, 
+                                       LOCAL.CAT.HEAD.TAM.MOOD ind ] > ] ] ]
+"""; a)- taking indicative (parecer, resultar, semejar)
 ; e.g.- parece que Juan trabaja mucho -> Juan parece trabajar mucho 
 ;     (it seems that John works a lot -> John seems to work a lot)
 ;     - resultó que Juan fue el ganador -> Juan resultó ser el ganador (only with 'ser','estar' (to be) 
 ;     and 'tener' (to have))(it turned out that John was the winner -> John turned out to be the winner)
 ;     - semejaba que la curva continuaba -> la curva semejaba continuar (it seemed that the curve 
 ;     continued -> the curve seemed to continue)
-v_cp_p-ind-nsbj_lex := v_impers & main-verb-impers & basic-one-arg & 
-  [ SYNSEM v_impers_cp_prop_fin_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_impers_cp_prop_fin_synsem,
-                         VAL.COMPS < [ OPT -, 
-                                       LOCAL.CAT.HEAD.TAM.MOOD ind ] > ] ] ].
+""".
 
-; b)- taking subjunctive (poder)
-; e.g.  puede que mañana llueva -> mañana puede llover (it may be that tomorrow rains -> it may rain tomorrow)
 v_cp_p-sub-nsbj_lex := v_impers & main-verb-impers & basic-one-arg & 
   [ SYNSEM v_impers_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_impers_cp_prop_fin_synsem,
                          VAL.COMPS < [ OPT -, 
-                                       LOCAL.CAT.HEAD.TAM.MOOD sub ] > ] ] ].
+                                       LOCAL.CAT.HEAD.TAM.MOOD sub ] > ] ] ]
+"""
+; b)- taking subjunctive (poder)
+; e.g.  puede que mañana llueva -> mañana puede llover (it may be that tomorrow rains -> it may rain tomorrow)
+""".
 
 
 ; --- 1.1.4. other impersonal contructions 
 
-; --- "haber que + inf" (hay que trabajar más) ("it is necessary to + inf" (it is necessary to work more))
 v_impers_cp_p_inf_synsem := v_impers_synsem & 
   [ LOCAL [ AGR.PNG.PN 3sg, 
             CAT [ HEAD.INV -, 
@@ -205,14 +214,17 @@ v_impers_cp_p_inf_synsem := v_impers_synsem &
             CONT.HCONS <! qeq & [ HARG #harg,
                                   LARG #larg ] !> ],
     LKEYS [ KEYREL arg2-ev-relation &  [ ARG2 #harg ] ,
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+"""
+; --- 1.1.4. other impersonal contructions 
+
+; --- "haber que + inf" (hay que trabajar más) ("it is necessary to + inf" (it is necessary to work more))
+""".
 
 v_cp_p-inf-nsbj_lex := v_impers & main-verb-impers & basic-one-arg & 
   [ SYNSEM v_impers_cp_p_inf_synsem &
            [ LOCAL.CAT.HEAD.LSYNSEM v_impers_cp_p_inf_synsem ] ].
 
-; --- tratarse (to be about)
-; (e.g. se trata de un goleador nato (it is about (it is about a born goal scorer))
 v_impers_pron_intr_mrkd_np_synsem := v_impers_synsem &
   [ LOCAL [ AGR.PNG.PN 3sg, 
             CAT [ HEAD.INV -,
@@ -221,7 +233,11 @@ v_impers_pron_intr_mrkd_np_synsem := v_impers_synsem &
                                         CONT.HOOK.INDEX #ind2 ] ] > ],
             CONT.HCONS <! !> ],
     LKEYS [ KEYREL arg2-ev-relation & [ ARG2 #ind2 ],
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+"""
+; --- tratarse (to be about)
+; (e.g. se trata de un goleador nato (it is about (it is about a born goal scorer))
+""".
 
 v_pp_e-nsbj-prn_lex := v_impers & impers-pronominal-verb & basic-two-arg & 
   [ SYNSEM v_impers_pron_intr_mrkd_np_synsem & 
@@ -231,27 +247,31 @@ v_pp_e-nsbj-prn_lex := v_impers & impers-pronominal-verb & basic-two-arg &
     ARG-ST < #comps . #clt > ].
 
 
-; --- sobrar, bastar (to be enough)
 v_impers_intr_mrkd_np-or-prop_synsem := v_impers_synsem &
   [ LOCAL [ AGR.PNG.PN 3sg, 
             CAT [ HEAD.INV -,
                   VAL [ COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY #ckey & _con_p_sel_rel ] >,
                         CLTS < > ] ] ],
     LKEYS [ KEYREL arg2-ev-relation,
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+"""
+; --- sobrar, bastar (to be enough)
+""".
 
 v_impers_intr_mrkd_np-or-prop := v_impers & 
   [ SYNSEM v_impers_intr_mrkd_np-or-prop_synsem & 
            [ LOCAL.CAT.VAL.COMPS #comps ],
     ARG-ST #comps ]. 
 
-; e.g. sobra/basta con 100 ptas (it is more than enough with 100 ptas)
 v_impers_intr_mrkd_np_synsem := v_impers_intr_mrkd_np-or-prop_synsem &
   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL mrkd_np_local & 
                                     [ CAT.HEAD.KEYS.ALTKEY non_temp_nonpro_rel,
                                       CONT.HOOK.INDEX #arg2 & ref-ind ] ] >,
             CONT.HCONS <! !> ],
-    LKEYS.KEYREL.ARG2 #arg2 ].
+    LKEYS.KEYREL.ARG2 #arg2 ]
+"""
+; e.g. sobra/basta con 100 ptas (it is more than enough with 100 ptas)
+""".
 
 v_pp_e-nsbj_lex := v_impers_intr_mrkd_np-or-prop & basic-one-arg & 
   [ SYNSEM v_impers_intr_mrkd_np_synsem & 
@@ -259,14 +279,15 @@ v_pp_e-nsbj_lex := v_impers_intr_mrkd_np-or-prop & basic-one-arg &
                          VAL.COMPS <  [ OPT - ] > ] ] ].
 
 
-; e.g. sobra/basta con que vengas (it is more than enough that you come)
 v_impers_intr_mrkd_cp_fin_synsem := v_impers_intr_mrkd_np-or-prop_synsem &
   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL mrkd_cp_prop_fin_local &
                                     [ CONT.HOOK [ LTOP #larg,
                                                   INDEX.SF prop ] ] ] >, 
             CONT.HCONS <! qeq & [ HARG #harg,
                                   LARG #larg ] !> ],
-    LKEYS.KEYREL.ARG2 #harg ].
+    LKEYS.KEYREL.ARG2 #harg ]
+"""; e.g. sobra/basta con que vengas (it is more than enough that you come)
+""".
 
 v_pp_e-cp-p-nsbj_lex := v_impers_intr_mrkd_np-or-prop & basic-one-arg & 
   [ SYNSEM v_impers_intr_mrkd_cp_fin_synsem & 
@@ -274,7 +295,6 @@ v_pp_e-cp-p-nsbj_lex := v_impers_intr_mrkd_np-or-prop & basic-one-arg &
                          VAL.COMPS <  [ OPT - ] > ] ] ].
 
 
-; e.g. sobra/basta con verte (it is more than enough seeing you)
 v_impers_intr_mrkd_vp_inf_synsem := v_impers_intr_mrkd_np-or-prop_synsem &
   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL mrkd_cp_prop_inf_local &
                                     [ CAT.MC -,
@@ -282,7 +302,9 @@ v_impers_intr_mrkd_vp_inf_synsem := v_impers_intr_mrkd_np-or-prop_synsem &
                                                   INDEX.SF prop ] ] ] >, 
             CONT.HCONS <! qeq & [ HARG #harg,
                                   LARG #larg ] !> ],
-    LKEYS.KEYREL.ARG2 #harg ].
+    LKEYS.KEYREL.ARG2 #harg ]
+"""; e.g. sobra/basta con verte (it is more than enough seeing you)
+""".
 
 v_pp_e-vp-nsbj_lex :=  v_impers_intr_mrkd_np-or-prop & basic-one-arg & 
   [ SYNSEM v_impers_intr_mrkd_vp_inf_synsem & 
@@ -290,7 +312,6 @@ v_pp_e-vp-nsbj_lex :=  v_impers_intr_mrkd_np-or-prop & basic-one-arg &
                          VAL.COMPS <  [ OPT - ] > ] ] ].
 
 
-; --- sobrar, bastar (to be enough)
 v_impers_intr_io_mrkd_np-or-prop_synsem := v_impers_synsem &
   [ LOCAL [ AGR.PNG.PN 3sg, 
             CAT [ HEAD.INV -,
@@ -302,21 +323,24 @@ v_impers_intr_io_mrkd_np-or-prop_synsem := v_impers_synsem &
     LKEYS [ KEYREL arg23-ev-relation & 
                    [ ARG3 #arg3 ],
             --COMPKEY #ckey,
-            --OCOMPKEY #ockey ] ].
+            --OCOMPKEY #ockey ] ]
+"""; --- sobrar, bastar (to be enough)
+""".
 
 v_impers_intr_io_mrkd_np-or-prop := v_impers & 
   [ SYNSEM v_impers_intr_io_mrkd_np-or-prop_synsem & 
            [ LOCAL.CAT.VAL.COMPS #comps ],
     ARG-ST #comps ]. 
 
-; e.g. me sobra/basta con 100 ptas (for me it is more than enough with 100 ptas)
 v_impers_intr_io_mrkd_np_synsem := v_impers_intr_io_mrkd_np-or-prop_synsem &
   [ LOCAL [ CAT.VAL.COMPS < synsem,
                             [ LOCAL mrkd_np_local & 
                                     [ CAT.HEAD.KEYS.ALTKEY non_temp_nonpro_rel,
                                       CONT.HOOK.INDEX #arg2 & ref-ind ] ] >,
             CONT.HCONS <! !> ],
-    LKEYS.KEYREL.ARG2 #arg2 ].
+    LKEYS.KEYREL.ARG2 #arg2 ]
+"""; e.g. me sobra/basta con 100 ptas (for me it is more than enough with 100 ptas)
+""".
 
 v_ppa-pp_e-nsbj_lex := v_impers_intr_io_mrkd_np-or-prop & basic-two-arg & 
   [ SYNSEM v_impers_intr_io_mrkd_np_synsem & 
@@ -324,7 +348,6 @@ v_ppa-pp_e-nsbj_lex := v_impers_intr_io_mrkd_np-or-prop & basic-two-arg &
                          VAL.COMPS <  [ OPT - ], [ OPT - ] > ] ] ].
 
 
-; e.g. me sobra/basta con que vengas (for me it is more than enough that you come)
 v_impers_intr_io_mrkd_cp_fin_synsem := v_impers_intr_io_mrkd_np-or-prop_synsem &
   [ LOCAL [ CAT.VAL.COMPS < synsem,
                             [ LOCAL mrkd_cp_prop_fin_local &
@@ -332,7 +355,9 @@ v_impers_intr_io_mrkd_cp_fin_synsem := v_impers_intr_io_mrkd_np-or-prop_synsem &
                                                   INDEX.SF prop ] ] ] >, 
             CONT.HCONS <! qeq & [ HARG #harg,
                                   LARG #larg ] !> ],
-    LKEYS.KEYREL.ARG2 #harg ].
+    LKEYS.KEYREL.ARG2 #harg ]
+"""; e.g. me sobra/basta con que vengas (for me it is more than enough that you come)
+""".
 
 v_ppa-pp_e-cp-p-nsbj_lex := v_impers_intr_io_mrkd_np-or-prop & basic-two-arg & 
   [ SYNSEM v_impers_intr_io_mrkd_cp_fin_synsem & 
@@ -340,7 +365,6 @@ v_ppa-pp_e-cp-p-nsbj_lex := v_impers_intr_io_mrkd_np-or-prop & basic-two-arg &
                          VAL.COMPS <  [ OPT - ], [ OPT - ] > ] ] ].
 
 
-; e.g. me sobra/basta con verte (for me it is more than enough seeing you)
 v_impers_intr_io_mrkd_vp_inf_synsem := v_impers_intr_io_mrkd_np-or-prop_synsem &
   [ LOCAL [ CAT.VAL.COMPS < synsem,
                             [ LOCAL mrkd_cp_prop_inf_local &
@@ -349,13 +373,15 @@ v_impers_intr_io_mrkd_vp_inf_synsem := v_impers_intr_io_mrkd_np-or-prop_synsem &
                                                   INDEX.SF prop ] ] ] >, 
             CONT.HCONS <! qeq & [ HARG #harg,
                                   LARG #larg ] !> ],
-    LKEYS.KEYREL.ARG2 #harg ].
+    LKEYS.KEYREL.ARG2 #harg ]
+"""; e.g. me sobra/basta con verte (for me it is more than enough seeing you)
+""".
 
 v_ppa-pp_e-vp-nsbj_lex :=  v_impers_intr_io_mrkd_np-or-prop & basic-two-arg & 
   [ SYNSEM v_impers_intr_io_mrkd_vp_inf_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_impers_intr_io_mrkd_vp_inf_synsem, 
-                         VAL.COMPS <  [ OPT - ], [ OPT - ] > ] ] ].
-
+                         VAL.COMPS <  [ OPT - ], [ OPT - ] > ] ] ]
+"""
 ; se me hace tarde (it gets late),  
 ; me duele en este brazo (this arm hurts), me pica en el brazo (my arm itches)
 ; nos dio por reír (we started to laugh), no me da tiempo (I don't have enough time), 
@@ -363,6 +389,8 @@ v_ppa-pp_e-vp-nsbj_lex :=  v_impers_intr_io_mrkd_np-or-prop & basic-two-arg &
 ; (aquí) sobra/falta dinero (there is more than enough/ there is some money missing (here))
 ; aquí pone que se prohíbe fumar (here it says that smoking is not allowed)
 ; oler a pan (to smell of bread), saber a pan (to taste like bread), perception verbs (taking compl DIV +) 
+""".
+
 
 
 ; --- 1.2. Verbs taking verbal subjects
@@ -375,7 +403,10 @@ verbal-subj-synsem := lex-synsem &
                                        CAT.VAL.COMPS < >,
                                        CONT.HOOK.LTOP #xarg ] ] > ],
             CONT [ HOOK.XARG #xarg,
-                   HCONS.LIST < [ LARG #xarg ],... > ] ] ]. 
+                   HCONS.LIST < [ LARG #xarg ],... > ] ] ]
+"""
+; --- 1.2. Verbs taking verbal subjects
+""". 
 
 trans_vinf-subj-synsem := vinf-subj-synsem & transitive_verb_synsem.
 
@@ -398,6 +429,14 @@ vfin-subj-main-verb := basic-main-verb &
 
 
 
+v_subj_cp_prop_fin_unacc_synsem := vfin-subj-synsem &
+  [ LOCAL [ CAT [ HEAD.INV -,
+                  VAL [ SUBJ < [ LOCAL cp_fin_local ] >,
+                        COMPS <  > ] ],
+            CONT.HCONS <! [ HARG #harg ] !> ],
+    LKEYS.KEYREL arg2-ev-relation & 
+                 [ ARG2 #harg ] ]
+"""
 ; --- 1.2.1. Unaccusative verbs taking finite verbs as subjects
 ; The subject appears in post-verbal position. Occasionally, a locative complement, with literal meaning 
 ; (aparecer (to appear), figurar (to say), quedar (to stay)) or figurative meaning (desprenderse 
@@ -405,35 +444,29 @@ vfin-subj-main-verb := basic-main-verb &
 ; though it cannot be a physical entity (of first order) with 'desprenderse' (to follow). With NP subjects, 
 ; 'aparecer' (to appear) y 'quedar' and 'quedar' (to stay) can take an optional IO.
 ; canvio INV + a INV -
-v_subj_cp_prop_fin_unacc_synsem := vfin-subj-synsem &
-  [ LOCAL [ CAT [ HEAD.INV -,
-                  VAL [ SUBJ < [ LOCAL cp_fin_local ] >,
-                        COMPS <  > ] ],
-            CONT.HCONS <! [ HARG #harg ] !> ],
-    LKEYS.KEYREL arg2-ev-relation & 
-                 [ ARG2 #harg ] ].
+""".
 
 v_subj_cp_prop_fin_unacc := vfin-subj-main-verb & 
   [ ALTS.VCALT - ]. 
 
-; e.g. no figura en el contrato que el acuerdo es/sea irreversible (it does not appear in the 
-; contract that the agreement is irreversible)
 v_-_sbj-cp-p_lex := v_subj_cp_prop_fin_unacc & main-verb & basic-one-arg &
   [ SYNSEM v_subj_cp_prop_fin_unacc_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_subj_cp_prop_fin_unacc_synsem ] ]. 
+           [ LOCAL.CAT.HEAD.LSYNSEM v_subj_cp_prop_fin_unacc_synsem ] ]
+"""; e.g. no figura en el contrato que el acuerdo es/sea irreversible (it does not appear in the 
+; contract that the agreement is irreversible)
+""". 
 
-; e.g. de ahí no se desprende que la situación sea/es imposible (from there it does not follow that the 
-; situation is impossible)
 v_-_sbj-cp-p-prn_lex := v_subj_cp_prop_fin_unacc & impers-pronominal-verb & basic-two-arg & 
   [ SYNSEM v_subj_cp_prop_fin_unacc_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_unacc_synsem, 
                          VAL [ SUBJ < #subj >, 
                                CLTS #clt ] ] ],
-    ARG-ST < #subj . #clt > ]. 
+    ARG-ST < #subj . #clt > ]
+"""; e.g. de ahí no se desprende que la situación sea/es imposible (from there it does not follow that the 
+; situation is impossible)
+""". 
 
 
-; --- 1.2.2. Intransitive verbs taking Vfin subjects and IO
-; clitization/clitic doubling obligatory, that's why we specify the COMPS to be OPT -
 #|
 v_subj_cp_prop_intr_io_synsem := verbal-subj-synsem & 
   [ LOCAL [ CAT.VAL [ COMPS < [ LOCAL dative_local & 
@@ -454,9 +487,13 @@ v_subj_cp_prop_inf_io_synsem := v_subj_cp_prop_intr_io_synsem &
 v_subj_cp_prop_fin_intr_io*_synsem := v_subj_cp_prop_intr_io_synsem &
   [ LOCAL [ CAT.VAL.SUBJ < [ LOCAL s_local & 
                                    [ CAT.HEAD.VFORM fin ] ] >,
-            CONT.RELS <! relation !> ] ]. 
+            CONT.RELS <! relation !> ] ]
+"""; --- 1.2.2. Intransitive verbs taking Vfin subjects and IO
+; clitization/clitic doubling obligatory, that's why we specify the COMPS to be OPT -
+""". 
 
 |#
+
 v_subj_cp_prop_inf_io_synsem := vinf-subj-synsem & 
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL vp_inf_local ] >,
                       COMPS < [ LOCAL dative_local & 
@@ -484,24 +521,27 @@ v_subj_cp_prop_fin_intr_io*_synsem := vfin-subj-synsem &
 
 v_subj_cp_prop_fin_intr := vfin-subj-main-verb.
 
-; a)- event verbs (acaecer, acontecer, ocurrir, pasar, presentarse, sobrevenir, suceder (to happen, to occur, ...))
+v_subj_cp_prop_fin_io*_synsem := v_subj_cp_prop_fin_intr_io*_synsem & 
+  [ LOCAL.CAT.HEAD.INV - ]
+"""; a)- event verbs (acaecer, acontecer, ocurrir, pasar, presentarse, sobrevenir, suceder (to happen, to occur, ...))
 ; The subject must be postponed. The IO appears occasionally. The clause does not alternate with a VPinf. 
 ; Indicative/subjunctive alternate depending on whether the content is asserted or not (except for 'ocurrir'
 ; (to occur), which can alternate always). The clause can only take the determiner if the IO is present. 
 ; The clause alternates with an entity of second order.
 ; canvio INV + a INV -
-v_subj_cp_prop_fin_io*_synsem := v_subj_cp_prop_fin_intr_io*_synsem & 
-  [ LOCAL.CAT.HEAD.INV - ].
+""".
 
-; e.g. ocurrir ((le) ocurre que no hizo lo que le habían pedido ((to occur) it occurs that s/he didn't do what s/he was asked))
 v_ppa*_sbj-cp-p_lex := v_subj_cp_prop_fin_intr & main-verb & basic-two-arg &
   [ ALTS.VCALT -,
     SYNSEM v_subj_cp_prop_fin_io*_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_io*_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""; e.g. ocurrir ((le) ocurre que no hizo lo que le habían pedido ((to occur) it occurs that s/he didn't do what s/he was asked))
+""".
 
 
-; b)- "incumbencia" verbs (atañer (to concern), bastar (to be enough), caber (to fit), constar, convenir 
+v_subj_cp_prop_inf_or_fin_io*_synsem := v_subj_cp_prop_fin_intr_io*_synsem
+"""; b)- "incumbencia" verbs (atañer (to concern), bastar (to be enough), caber (to fit), constar, convenir 
 ; (to agree), faltar (to be missing), importar (to matter), parecer (to seem),...)
 ; The clause can alternate with abstract or eventive nouns ('caber' (to suit) is the only one that can 
 ; alternate with a first order entity). The clause can only take the determiner if the IO is present. 
@@ -509,47 +549,51 @@ v_ppa*_sbj-cp-p_lex := v_subj_cp_prop_fin_intr & main-verb & basic-two-arg &
 ; take only the subjunctive mood. The clause alternates with a VPinf and when the IO is present, it is 
 ; interpreted as the subject of the infinitive, when it is not, the construction has a generic 
 ; interpretation. "parecer" (to seem) demands the OI when it is constructed with a subject VPinf.
-v_subj_cp_prop_inf_or_fin_io*_synsem := v_subj_cp_prop_fin_intr_io*_synsem. 
+""". 
 
-; e.g. bastar (no (me) basta que me quieras/que me quieras no (me) basta) 
-; (to be enough (it is not enough (for me) that you love me/that you love me is not enough (for me))
 v_ppa*_sbj-cp-p-sub-cv_lex := v_subj_cp_prop_fin_intr & main-verb & basic-two-arg & 
   [ ALTS.VCALT +,
     SYNSEM v_subj_cp_prop_inf_or_fin_io*_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_inf_or_fin_io*_synsem, 
                          VAL [ SUBJ < [ LOCAL.CAT.HEAD.TAM.MOOD sub ] >,
-                               COMPS < [ OPT + ] > ] ] ] ].
+                               COMPS < [ OPT + ] > ] ] ] ]
+"""
+; e.g. bastar (no (me) basta que me quieras/que me quieras no (me) basta) 
+; (to be enough (it is not enough (for me) that you love me/that you love me is not enough (for me))
+""".
 
-; e.g. constar ((me) consta que estuvo aquí/no consta que supiese el día de su muerte hasta ese día)
-; (to be certain ((for me) it is certain that s/he was here/ it is not certain that s/he knew the day of 
-; his/her death till that day)
 v_ppa*_sbj-cp-p-cv_lex := v_subj_cp_prop_fin_intr & main-verb & basic-two-arg & 
   [ ALTS.VCALT +,
     SYNSEM v_subj_cp_prop_inf_or_fin_io*_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_inf_or_fin_io*_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
-
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""
+; e.g. constar ((me) consta que estuvo aquí/no consta que supiese el día de su muerte hasta ese día)
+; (to be certain ((for me) it is certain that s/he was here/ it is not certain that s/he knew the day of 
+; his/her death till that day)
 
 ; - with "parecer" the IO is obligatory when it takes a VPinf subject 
 ; => removed
+""".
 
 
-; c)- Psychological verbs (admirar, agobiar, alegrar, apetecer, asombrar, asustar,... (to admire, 
+v_subj_cp_prop_fin_sub_io*_synsem := v_subj_cp_prop_fin_intr_io*_synsem &
+  [ LOCAL.CAT.VAL.SUBJ < [ LOCAL.CAT.HEAD.TAM.MOOD sub ] > ]
+"""; c)- Psychological verbs (admirar, agobiar, alegrar, apetecer, asombrar, asustar,... (to admire, 
 ; to overwhelm, to make happy, to long for, to surprise, to scare,...))
 ; The clause can take the determiner. The subject can be preposed or postposed. The IO is common (but not 
 ; always obligatory). They do not accept the indicative mood. The clause alternates with VPinf only 
 ; when the IO is interpreted as the subject of the infinitive, and with an animate or inanimate NP.
-v_subj_cp_prop_fin_sub_io*_synsem := v_subj_cp_prop_fin_intr_io*_synsem &
-  [ LOCAL.CAT.VAL.SUBJ < [ LOCAL.CAT.HEAD.TAM.MOOD sub ] > ].
+""".
 
-; e.g. gustar (no *(me) gusta que a los toros te pongas la minifalda)
 v_ppa*_sbj-cp-p-sub_lex := v_subj_cp_prop_fin_intr & main-verb & basic-two-arg & 
   [ ALTS.VCALT +,
     SYNSEM v_subj_cp_prop_fin_sub_io*_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_sub_io*_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""; e.g. gustar (no *(me) gusta que a los toros te pongas la minifalda)
+""".
 
-; e.g. antojarse (to fancy)
 v_ppa*_sbj-cp-p-sub-prn_lex := v_subj_cp_prop_fin_intr & impers-pronominal-verb & basic-three-arg & 
   [ ALTS.VCALT +,
     SYNSEM v_subj_cp_prop_fin_sub_io*_synsem & 
@@ -557,15 +601,12 @@ v_ppa*_sbj-cp-p-sub-prn_lex := v_subj_cp_prop_fin_intr & impers-pronominal-verb 
                          VAL [ SUBJ < #subj >, 
                                COMPS < #comps & [ OPT + ] >,
                                CLTS #clt ] ] ],
-    ARG-ST < #subj . < #comps . #clt > > ].
+    ARG-ST < #subj . < #comps . #clt > > ]
+"""; e.g. antojarse (to fancy)
+""".
 
 ; --- 1.2.3. Intransitive verbs taking Vfin subject and marked NP
-; Always in the subjunctive mood and it can alternate with a (non-controlled) VPinf. The unmarked order 
-; is SVC. The subject must take the determiner when nothing is intercalated between the latter and the verb.
-; (e.g. (el) que las clases sean malas repercute en los alumnos/repercute en los alumnos (el) que las 
-; clases sean malas/en los alumnos repercute *(el) que las clases sean malas (the fact that classes are 
-; bad has repercussions on the students/It has repercussions on the students the fact that classes are 
-; bad/on the students has repercusions the fact that classes are bad))
+
 v_subj_cp_prop_inf_intr_mrkd_np_synsem := vinf-subj-synsem & 
   [ LOCAL [ CAT.VAL.COMPS < [ LOCAL mrkd_np_local & 
                                     [ CAT.HEAD.KEYS.KEY #ckey,
@@ -574,7 +615,15 @@ v_subj_cp_prop_inf_intr_mrkd_np_synsem := vinf-subj-synsem &
     LKEYS [ KEYREL arg12-ev-relation & 
                    [ ARG1 #harg,
                      ARG2 #ind2 ],
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+"""; --- 1.2.3. Intransitive verbs taking Vfin subject and marked NP
+; Always in the subjunctive mood and it can alternate with a (non-controlled) VPinf. The unmarked order 
+; is SVC. The subject must take the determiner when nothing is intercalated between the latter and the verb.
+; (e.g. (el) que las clases sean malas repercute en los alumnos/repercute en los alumnos (el) que las 
+; clases sean malas/en los alumnos repercute *(el) que las clases sean malas (the fact that classes are 
+; bad has repercussions on the students/It has repercussions on the students the fact that classes are 
+; bad/on the students has repercusions the fact that classes are bad))
+""".
 
 v_subj_cp_prop_fin_intr_mrkd_np_synsem := vfin-subj-synsem & 
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL cp_fin_local &
@@ -588,15 +637,16 @@ v_subj_cp_prop_fin_intr_mrkd_np_synsem := vfin-subj-synsem &
                      ARG2 #ind2 ],
             --COMPKEY #ckey ] ].
 
-; e.g. (el) que las clases sean malas repercute en los alumnos (the fact that classes are bad has 
-; repercussions on the students)
 v_pp_e-sbj-cp-p-sub_lex := v_subj_cp_prop_fin_intr & main-verb & basic-two-arg &
   [ ALTS.VCALT +,
     SYNSEM v_subj_cp_prop_fin_intr_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_intr_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""
+; e.g. (el) que las clases sean malas repercute en los alumnos (the fact that classes are bad has 
+; repercussions on the students)
+""".
 
-; e.g. traducirse en (be translated into)
 v_pp_e-sbj-cp-p-sub-prn_lex := v_subj_cp_prop_fin_intr & impers-pronominal-verb & basic-three-arg & 
   [ ALTS.VCALT +,
     SYNSEM v_subj_cp_prop_fin_intr_mrkd_np_synsem &
@@ -604,12 +654,16 @@ v_pp_e-sbj-cp-p-sub-prn_lex := v_subj_cp_prop_fin_intr & impers-pronominal-verb 
                          VAL [ SUBJ < #subj >, 
                                COMPS < #comps & [ OPT - ] >,
                                CLTS #clt ] ] ],
-    ARG-ST < #subj . < #comps . #clt > >  ].
+    ARG-ST < #subj . < #comps . #clt > >  ]
+"""; e.g. traducirse en (be translated into)
+""".
 
-; --- 1.2.4. Intransitive verbs taking Vfin subject, IO and marked NP
 v_subj_cp_prop_inf_intr_io*_mrkd_np_synsem := vinf-subj-synsem & 
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ], 
-                          [ LOCAL mrkd_np_local ] > ].
+                          [ LOCAL mrkd_np_local ] > ]
+"""
+; --- 1.2.4. Intransitive verbs taking Vfin subject, IO and marked NP
+""".
 
 v_subj_cp_prop_fin_intr_io*_mrkd_np_synsem := vfin-subj-synsem & 
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL cp_fin_local &
@@ -629,19 +683,19 @@ v_subj_cp_prop_fin_intr_io*_mrkd_np_synsem := vfin-subj-synsem &
             --OCOMPKEY #ockey ] ].
 
 
-; e.g. de nada le sirve luchar/que luchen
 v_ppa*-pp_e-sbj-cp-p-sub_lex := v_subj_cp_prop_fin_intr & main-verb & basic-three-arg & 
   [ ALTS.VCALT +,
     SYNSEM v_subj_cp_prop_fin_intr_io*_mrkd_np_synsem &
            [  LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_intr_io*_mrkd_np_synsem, 
-                          VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ].
+                          VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""; e.g. de nada le sirve luchar/que luchen
+""".
 
 
-; --- Transitive verbs taking Vfin
-; A determiner can be added to the subject. The subject alternates with the neutral pronoun and with 
-; abstract nouns. The majority accept a person as subject. The clause is always in the subjunctive mood.
 v_subj_cp_prop_inf_trans_np_synsem := trans_vinf-subj-synsem &
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local  ],... > ].
+
+; --- Transitive verbs taking Vfin
 
 v_subj_cp_prop_fin_trans_np_synsem := vfin-subj-synsem & transitive_verb_synsem &
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL cp_fin_local &
@@ -653,12 +707,23 @@ v_subj_cp_prop_fin_trans_np_synsem := vfin-subj-synsem & transitive_verb_synsem 
     LKEYS [ KEYREL arg12-ev-relation & 
                    [ ARG1 #harg,
                      ARG2 #ind ],
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+"""; --- Transitive verbs taking Vfin
+; A determiner can be added to the subject. The subject alternates with the neutral pronoun and with 
+; abstract nouns. The majority accept a person as subject. The clause is always in the subjunctive mood.
+""".
 
 v_subj_cp_prop_trans_np := vfin-subj-main-verb & 
   [ ALTS.VCALT + ].
 
+; --- 1.2.4. Transitive verbs taking Vfin subject and DO
 
+v_np_sbj-cp-p-sub_lex := v_subj_cp_prop_trans_np & main-verb & basic-two-arg & 
+  [ SYNSEM v_subj_cp_prop_fin_trans_np_synsem & 
+           [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_trans_np_synsem, 
+                         VAL.COMPS < [ OPT -, 
+                                       LOCAL np_acc_local ] > ] ] ]
+"""
 ; --- 1.2.4. Transitive verbs taking Vfin subject and DO
 
 ; a)- Implicative and evidencial verbs (e.g. implicar, evidenciar, denotar, destacar,... (to imply, 
@@ -676,31 +741,24 @@ v_subj_cp_prop_trans_np := vfin-subj-main-verb &
 
 ; e.g.que el poder político se descomponga no significa necesariamente una decadencia (the fact that the 
 ; political power decays does not mean necessarily a decadence)
-v_np_sbj-cp-p-sub_lex := v_subj_cp_prop_trans_np & main-verb & basic-two-arg & 
+""".
+
+v_np_sbj-cp-p-sub-idm_lex := v_subj_cp_prop_trans_np & main-verb & basic-two-arg & 
   [ SYNSEM v_subj_cp_prop_fin_trans_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_trans_np_synsem, 
                          VAL.COMPS < [ OPT -, 
-                                       LOCAL np_acc_local ] > ] ] ].
-
-; b)- support verbs (e.g. dar pena, hacer falta, tener gracia,...)(to grieve, to be needed, to have charm)
+                                       LOCAL np_acc_local ] > ] ] ]
+"""; b)- support verbs (e.g. dar pena, hacer falta, tener gracia,...)(to grieve, to be needed, to have charm)
 ; The NP appears as a DO which generally does not take a determiner, but may take intensifiers,
 ; its inmediately postverbal position is fixed and the subject is likely to occupy the final position.
 ; In some cases the presence of a dative expected or implied (e.g. dar asco, lástima (to be disgusting, 
 ; to grieve)). With some others it is possible (e.g. hacer falta, ilusión (to be needed, to be looking 
 ; forward to something) but with others it is impossible (e.g. tener gracia, pena, rabia / to have charm, 
 ; pitty, to make furious))
-v_np_sbj-cp-p-sub-idm_lex := v_subj_cp_prop_trans_np & main-verb & basic-two-arg & 
-  [ SYNSEM v_subj_cp_prop_fin_trans_np_synsem & 
-           [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_trans_np_synsem, 
-                         VAL.COMPS < [ OPT -, 
-                                       LOCAL np_acc_local ] > ] ] ].
-
+""".
 
 ; --- 1.2.5. Transitive verbs taking Vfin subject, DO and marked NP
-; The clause alternates with a VPinf controlled by the DO (e.g. trabajar la obliga a madrugar (working 
-; obliges her to get up early). The DO cannot be sentential. The prepositional complement can be optional 
-; and can be substituted by a clitic dative when it's human and is introduced by "a" 
-; (cf. v_subj_cp_prop_ditrans*_le)
+
 v_subj_cp_prop_fin_trans_np_mrkd_np_synsem := v_subj_cp_prop_fin_trans_np_synsem &
 [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ],
                         [ LOCAL mrkd_np_local & 
@@ -708,19 +766,26 @@ v_subj_cp_prop_fin_trans_np_mrkd_np_synsem := v_subj_cp_prop_fin_trans_np_synsem
                                   CONT.HOOK.INDEX #ind3 ] ] >,
     LKEYS [ KEYREL arg123-ev-relation & 
                    [ ARG3 #ind3 ],
-            --OCOMPKEY #ockey ] ].
+            --OCOMPKEY #ockey ] ]
+"""
+; --- 1.2.5. Transitive verbs taking Vfin subject, DO and marked NP
+
+; The clause alternates with a VPinf controlled by the DO (e.g. trabajar la obliga a madrugar (working 
+; obliges her to get up early). The DO cannot be sentential. The prepositional complement can be optional 
+; and can be substituted by a clitic dative when it's human and is introduced by "a" 
+; (cf. v_subj_cp_prop_ditrans*_le)
+""".
 
 
-; e.g. (el) que su partido haya perdido las elecciones lo apartará del poder
 v_np-pp_e-sbj-cp-p-sub_lex := v_subj_cp_prop_trans_np & main-verb & basic-three-arg &
   [ SYNSEM v_subj_cp_prop_fin_trans_np_mrkd_np_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_trans_np_mrkd_np_synsem,
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
-
+                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]
+"""; e.g. (el) que su partido haya perdido las elecciones lo apartará del poder
+""".
 
 ; --- 1.2.6. Ditransitive verbs taking Vfin subject
-; The clause alternates with a VPinf controlled by the IO (e.g. tener que aguantar los embotellamientos 
-; te estropea el día (having to put up with traffic jams spoils your day))
+
 v_subj_cp_prop_fin_ditrans_synsem := v_subj_cp_prop_fin_trans_np_synsem &
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_unmrkd_local ],
                           [ LOCAL dative_local & 
@@ -728,21 +793,30 @@ v_subj_cp_prop_fin_ditrans_synsem := v_subj_cp_prop_fin_trans_np_synsem &
                                     CONT.HOOK.INDEX #ind3 ] ] >,
     LKEYS [ KEYREL arg123-ev-relation & 
                    [ ARG3 #ind3 ],
-            --OCOMPKEY #ockey ] ].
+            --OCOMPKEY #ockey ] ]
+"""; --- 1.2.6. Ditransitive verbs taking Vfin subject
+
+; The clause alternates with a VPinf controlled by the IO (e.g. tener que aguantar los embotellamientos 
+; te estropea el día (having to put up with traffic jams spoils your day))
+""".
 
 
-; e.g. El que haya dicho esto le acarrea muchos problemas (a María) (the fact that he had 
-; said this causes many troubles (to María))
 v_np-ppa*_sbj-cp-p-sub_lex := v_subj_cp_prop_trans_np & main-verb & basic-three-arg & 
   [ SYNSEM v_subj_cp_prop_fin_ditrans_synsem &
            [  LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_ditrans_synsem, 
-                          VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ].
-
+                          VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+"""; e.g. El que haya dicho esto le acarrea muchos problemas (a María) (the fact that he had 
+; said this causes many troubles (to María))
+""".
 
 ; --- 1.2.7. Transitive verbs taking sentential subjects and finite completive clauses 
-; The subject must precede the main verb
+
 v_subj_cp_prop_inf_trans_cp_prop_fin_synsem := trans_vinf-subj-synsem & 
-  [ LOCAL.CAT.VAL.COMPS < [ LOCAL cp_fin_local ] > ].
+  [ LOCAL.CAT.VAL.COMPS < [ LOCAL cp_fin_local ] > ]
+"""; --- 1.2.7. Transitive verbs taking sentential subjects and finite completive clauses 
+
+; The subject must precede the main verb
+""".
 
 v_subj_cp_prop_fin_trans_cp_prop_fin_synsem := vfin-subj-synsem & transitive_verb_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
@@ -759,19 +833,22 @@ v_subj_cp_prop_fin_trans_cp_prop_fin_synsem := vfin-subj-synsem & transitive_ver
             --COMPKEY #ckey ] ].
 
 
-; e.g. que te haya aprobado no significa que no tengas que venir a clase (the fact that s/he has 
-; approved you/given you a passing grade doesn`t mean that you don't have to come to classes)
 v_cp_p-sbj-cp-p-sub_lex := vfin-subj-main-verb & main-verb & basic-two-arg & 
   [ ALTS.VCALT +,
     SYNSEM v_subj_cp_prop_fin_trans_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_trans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. que te haya aprobado no significa que no tengas que venir a clase (the fact that s/he has 
+; approved you/given you a passing grade doesn`t mean that you don't have to come to classes)
+""".
 
 
 ; --- 1.2.8. Ditransitive verbs taking sentential subjects, IO and finite completive clauses 
 
 v_subj_cp_prop_inf_ditrans_cp_prop_fin_synsem := trans_vinf-subj-synsem &
-  [ LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ], [ LOCAL cp_fin_local ] > ].
+  [ LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ], [ LOCAL cp_fin_local ] > ]
+"""; --- 1.2.8. Ditransitive verbs taking sentential subjects, IO and finite completive clauses 
+""".
 
 v_subj_cp_prop_fin_ditrans_cp_prop_fin_synsem := vfin-subj-synsem & transitive_verb_synsem &
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL cp_fin_local &
@@ -791,22 +868,16 @@ v_subj_cp_prop_fin_ditrans_cp_prop_fin_synsem := vfin-subj-synsem & transitive_v
             --COMPKEY #ckey,
             --OCOMPKEY #ockey ] ].
 
-; e.g. oír música no (te) impide trabajar/que trabajes (listening to music doesn't prevents you from working)
 v_ppa*-cp_p-sbj-cp-p-sub_lex := vfin-subj-main-verb & main-verb & basic-three-arg & 
   [ ALTS.VCALT +,
     SYNSEM v_subj_cp_prop_fin_ditrans_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_subj_cp_prop_fin_ditrans_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""; e.g. oír música no (te) impide trabajar/que trabajes (listening to music doesn't prevents you from working)
+""".
 
 
-; --- 1.2.9. Attributive structures (ser & estar (to be), parecer (to seem), quedar (to stay), 
-; resultar (to result) y aparecer (to appear))
-; The unmarked order is VCS, but SVC and CVS are also possible. 
-; The mode of the clause depends on the attribute. The attributes that combine with the indicative mood 
-; do not admit a VPinf subject, as neither do the attributes VPinf. If there is a dative correferent with 
-; the subject of the subordinate clause, the latter tends to take a non-flexionate form (VPinf).
-; !!! sentential subjects with null verbs (e.g. ¡(Es) Lástima que no hayas ganado! ¡Qué pena (es) 
-; que no vengas!)
+; --- 1.2.9. Attributive structures
 
 ; --- 1.2.9.1. Copula verbs
 
@@ -820,7 +891,21 @@ v_cop_verbal_subject_synsem := v_copula_basic_synsem &
                                      CONT.HOOK.INDEX.SF prop ],
                              NON-LOCAL [ SLASH 0-dlist & [ LIST < > ],
                                          REL 0-dlist & [ LIST < > ],
-                                         QUE 0-dlist & [ LIST < > ] ] ] > ] ].
+                                         QUE 0-dlist & [ LIST < > ] ] ] > ] ]
+"""
+; --- 1.2.9. Attributive structures
+
+; (ser & estar (to be), parecer (to seem), quedar (to stay), 
+; resultar (to result) y aparecer (to appear))
+; The unmarked order is VCS, but SVC and CVS are also possible. 
+; The mode of the clause depends on the attribute. The attributes that combine with the indicative mood 
+; do not admit a VPinf subject, as neither do the attributes VPinf. If there is a dative correferent with 
+; the subject of the subordinate clause, the latter tends to take a non-flexionate form (VPinf).
+; !!! sentential subjects with null verbs (e.g. ¡(Es) Lástima que no hayas ganado! ¡Qué pena (es) 
+; que no vengas!)
+
+; --- 1.2.9.1. Copula verbs
+""".
 
 v_ap_cop_verbal_subject_synsem := v_cop_verbal_subject_synsem & 
   [ LOCAL [ CAT [ HEAD.TAM #tam,
@@ -875,10 +960,6 @@ v_adv_verbal_subject_synsem := v_cop_verbal_subject_synsem &
                    RELS <! arg2-ev-relation & 
                            [ ARG2 #xarg ] !> ] ] ].
 
-; a)- 'ser': if there is a finite clause, it accepts adjectives, NPs, the adverb "así" (like this), 
-; and "de + VPinf" (or an equivalent adjective ending in -ble); with subject VPinf it accepts 
-; NPs, adjectives, "de + NP" and VPinf
-
 v_cop-id_verbal_subject_synsem := lex-synsem &
   [ LOCAL [ AGR.PNG.PN 3sg,
             CAT [ HEAD.INV -,
@@ -890,7 +971,11 @@ v_cop-id_verbal_subject_synsem := lex-synsem &
                                              QUE 0-dlist & [ LIST < > ] ] ] >,
                         COMPS < [ OPT - ] > ] ],
             CONT.RELS <! arg12-ev-relation !> ],
-    LKEYS.KEYREL.PRED _be_v_id_rel ].
+    LKEYS.KEYREL.PRED _be_v_id_rel ]
+"""; a)- 'ser': if there is a finite clause, it accepts adjectives, NPs, the adverb "así" (like this), 
+; and "de + VPinf" (or an equivalent adjective ending in -ble); with subject VPinf it accepts 
+; NPs, adjectives, "de + NP" and VPinf
+""".
 
 v_np_npsv_cop-id_verbal_subject_synsem := v_cop-id_verbal_subject_synsem &
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL vp_inf_local & 
@@ -948,46 +1033,49 @@ v_cop_ser_cp_p_sbj := v_cop_ser_verb_sbj &
   [ SYNSEM.LOCAL.CAT.VAL.SUBJ < [ LOCAL s_local & 
                                         [ CAT.HEAD.VFORM fin ] ] > ].
 
-; e.g. es imposible vivir en el centro
 v_ap_sbj-vp-inf-ser_lex := v_cop_ser_vp-inf_sbj &
   [ SYNSEM v_ap_cop_verbal_subject_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_ap_cop_verbal_subject_synsem ] ].
+           [ LOCAL.CAT.HEAD.LSYNSEM v_ap_cop_verbal_subject_synsem ] ]
+"""; e.g. es imposible vivir en el centro
+""".
 
-; e.g. rectificar es de sabios 
 v_pp_e-sbj-vp-inf-ser_lex := v_cop_ser_vp-inf_sbj &
   [ SYNSEM v_pp_e_cop_verbal_subject_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_pp_e_cop_verbal_subject_synsem ] ]. 
+           [ LOCAL.CAT.HEAD.LSYNSEM v_pp_e_cop_verbal_subject_synsem ] ]
+"""; e.g. rectificar es de sabios 
+""". 
 
-; e.g. regalar detalles es una cursilería 
 v_np_npsv-sbj-vp-inf-ser_lex := v_cop-id_verb_sbj & 
   [ SYNSEM v_np_npsv_cop-id_verbal_subject_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_np_npsv_cop-id_verbal_subject_synsem ] ]. 
+           [ LOCAL.CAT.HEAD.LSYNSEM v_np_npsv_cop-id_verbal_subject_synsem ] ]
+"""; e.g. regalar detalles es una cursilería 
+""". 
 
-; e.g. Tolerar es simplemente reconocer que el otro existe.
 v_vp_sbj-vp-inf-ser_lex := v_cop-id_verb_sbj & 
   [ SYNSEM v_vp_cop-id_verbal_subject_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_vp_cop-id_verbal_subject_synsem ] ].
+           [ LOCAL.CAT.HEAD.LSYNSEM v_vp_cop-id_verbal_subject_synsem ] ]
+"""; e.g. Tolerar es simplemente reconocer que el otro existe.
+""".
 
-; e.g. es imposible que no venga
 v_ap_sbj-cp-p-ser_lex := v_cop_ser_cp_p_sbj &
   [ SYNSEM v_ap_cop_verbal_subject_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_ap_cop_verbal_subject_synsem ] ].
+           [ LOCAL.CAT.HEAD.LSYNSEM v_ap_cop_verbal_subject_synsem ] ]
+"""; e.g. es imposible que no venga
+""".
 
-; e.g. 
 v_np_sbj-cp-p-ser_lex := v_cop-id_verb_sbj & 
   [ SYNSEM v_np_cop-id_verbal_subject_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_np_cop-id_verbal_subject_synsem ] ].
-
-; e.g. es de agradecer que hayan descubierto una nueva vacuna
+           [ LOCAL.CAT.HEAD.LSYNSEM v_np_cop-id_verbal_subject_synsem ] ]
+"""; e.g. es de agradecer que hayan descubierto una nueva vacuna
 ; e.g. es así
-
-
-; b)- el verbo 'estar' combines with the adjective "claro" (clear) and with the adverbs "bien" (well) 
-; and "mal" (badly). The clause alternates with a VPinf only when the attribute is a participle.
-; e.g. no está claro/bien que ha ocurrido, está prohibido fumar aqui.
+""".
 
 v_cop_estar_verb_sbj := v_cop & 
-  [ SYNSEM v_cop_verbal_subject_synsem ]. 
+  [ SYNSEM v_cop_verbal_subject_synsem ]
+"""; b)- el verbo 'estar' combines with the adjective "claro" (clear) and with the adverbs "bien" (well) 
+; and "mal" (badly). The clause alternates with a VPinf only when the attribute is a participle.
+; e.g. no está claro/bien que ha ocurrido, está prohibido fumar aqui.
+""". 
 
 v_cop_estar_vp-inf_sbj := v_cop_estar_verb_sbj &
   [ SYNSEM.LOCAL.CAT.VAL.SUBJ < [ LOCAL vp_inf_local ] > ].
@@ -996,25 +1084,29 @@ v_cop_estar_cp_p_sbj := v_cop_estar_verb_sbj &
   [ SYNSEM.LOCAL.CAT.VAL.SUBJ < [ LOCAL s_local & 
                                         [ CAT.HEAD.VFORM fin ] ] > ].
 
-; e.g. está prohibido fumar aqui.
 v_ppart_sbj-vp-inf-estar_lex := v_cop_estar_vp-inf_sbj &
   [ SYNSEM v_ppart_cop_verbal_subject_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_ppart_cop_verbal_subject_synsem ] ].
+           [ LOCAL.CAT.HEAD.LSYNSEM v_ppart_cop_verbal_subject_synsem ] ]
+"""; e.g. está prohibido fumar aqui.
+""".
 
-; e.g. no está claro que ha ocurrido
 v_ap_sbj-cp-p-estar_lex := v_cop_estar_cp_p_sbj &
   [ SYNSEM v_ap_cop_verbal_subject_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_ap_cop_verbal_subject_synsem ] ].
+           [ LOCAL.CAT.HEAD.LSYNSEM v_ap_cop_verbal_subject_synsem ] ]
+"""; e.g. no está claro que ha ocurrido
+""".
 
-; e.g. está bien/mal que Guillermo lo haga
 v_adv_sbj-cp-p-estar_lex := v_cop_estar_cp_p_sbj & norm-hook-lex &
   [ SYNSEM v_adv_verbal_subject_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_adv_verbal_subject_synsem ] ].
+           [ LOCAL.CAT.HEAD.LSYNSEM v_adv_verbal_subject_synsem ] ]
+"""; e.g. está bien/mal que Guillermo lo haga
+""".
 
 
 
 #|
 ; --- 1.2.9.2. verbs taking a predicative complement and IO
+
 v_subj_cp_prop_seq_ppa_synsem := lex-synsem &
   [ LOCAL [ AGR.PNG.PN 3sg,
             CAT [ VAL [ SUBJ < [ OPT -,
@@ -1041,7 +1133,9 @@ v_subj_cp_prop_seq_ppa_synsem := lex-synsem &
     LKEYS [ KEYREL arg123-ev-relation & #key & 
                    [ ARG3 #ind3 ],
             --COMPKEY #ckey,
-            --OCOMPKEY #ockey ] ].
+            --OCOMPKEY #ockey ] ]
+"""; --- 1.2.9.2. verbs taking a predicative complement and IO
+""".
 
 v_subj_cp_prop_inf_seq_ppa_synsem := v_subj_cp_prop_seq_ppa_synsem &
   [ LOCAL.CAT.VAL.SUBJ < [ LOCAL vp_inf_local & 
@@ -1117,7 +1211,6 @@ v_np-ap_sbj-cp-p-inf_sor_lex := main-verb & basic-three-arg &
 
 |#
 
-
 ; --- 1.3. Verbs taking nominal subject
 
 nom-subj-synsem := lex-synsem &
@@ -1125,9 +1218,14 @@ nom-subj-synsem := lex-synsem &
             CAT [ VAL.SUBJ < [ LOCAL np_nom_local & 
                                      [ AGR #agr,
                                        CONT.HOOK.INDEX #xarg ] ] > ],
-            CONT.HOOK.XARG #xarg & [ PNG #png ] ] ].
+            CONT.HOOK.XARG #xarg & [ PNG #png ] ] ]
+"""
+; --- 1.3. Verbs taking nominal subject
+
 ; LOCAL.CAT.VAL.SUBJ < [ LOCAL.CAT.HEAD.KEYS.ALTKEY def_or_proper_q_rel / explicit_q_rel 
 ; but: e.g. vecinos de la zona consultados por este diario aseguraron ayer que ...
+
+""".
 
 arg1_lt := nom-subj-synsem & 
   [ LOCAL.CAT.VAL.SUBJ < [ LOCAL.CONT.HOOK.INDEX #ind ] >,
@@ -1139,7 +1237,12 @@ unacc_lt := nom-subj-synsem &
     LKEYS.KEYREL arg2-ev-relation & 
                  [ ARG2 #ind ] ].
 
+; --- 1.3.1. Unaccusative verbs
 
+v_unacc_synsem := unacc_lt & 
+  [ LOCAL.CONT [ RELS <! relation !>,
+                 HCONS <! !> ] ]
+"""
 ; --- 1.3.1. Unaccusative verbs
 ; Their syntactic subject (their notional object (arg2)) can be a bare NP in postverbal position 
 ; (e.g. cae agua, entra frío, vienen mujeres, existen problemas). They can form absolute 
@@ -1147,17 +1250,19 @@ unacc_lt := nom-subj-synsem &
 ; rosal, el jardín parecía más alegre/*ardido el bosque, los animales lo abandonaron). Adjectival 
 ; participles can act as modifiers of a NP functioning as syntactic subject (e.g. un tesoro recientemente 
 ; aparecido)
-
-v_unacc_synsem := unacc_lt & 
-  [ LOCAL.CONT [ RELS <! relation !>,
-                 HCONS <! !> ] ].
+""".
 
 v_unacc:= basic-main-verb & 
   [ ALTS [ RCP -, 
            RFX -,
            VCALT - ] ].
 
+; --- 1.3.1.1. Unaccusative intransitive verbs (verbs of change of state due to internal cause and 
 
+v_unacc_intr_synsem := v_unacc_synsem &
+  [ LOCAL.CAT [ HEAD.INV -,
+                VAL.COMPS < > ] ]
+"""
 ; --- 1.3.1.1. Unaccusative intransitive verbs (verbs of change of state due to internal cause and 
 ; movements verbs denoting a non-agenitive way of moving. Many events due to internal cause can be 
 ; also classified as events of external cause depending on the selected argument: those of internal 
@@ -1165,28 +1270,26 @@ v_unacc:= basic-main-verb &
 ; ha aclarado el jersey)) 
 ; canvio INV + a INV -
 ; !!! pueden llevar un IO (e.g. les nacieron los gemelos)
-v_unacc_intr_synsem := v_unacc_synsem &
-  [ LOCAL.CAT [ HEAD.INV -,
-                VAL.COMPS < > ] ].
+""".
 
-; e.g. florecer (to flower), emerger (to emerge)
 v_-_psv_lex := v_unacc & main-verb & basic-one-arg & 
   [ ALTS [ PASS +,
            IMPERS + ],
     SYNSEM v_unacc_intr_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_unacc_intr_synsem ] ].
+           [ LOCAL.CAT.HEAD.LSYNSEM v_unacc_intr_synsem ] ]
+"""
+; e.g. florecer (to flower), emerger (to emerge)
+""".
 
-; e.g. encogerse (to shrink), enquistarse (to encyst)
 v_-_psv-prn_lex := v_unacc & main-vprn-intr & basic-two-arg & 
   [ ALTS.PASS +,
     SYNSEM v_unacc_intr_synsem &
-           [ LOCAL.CAT.HEAD.LSYNSEM v_unacc_intr_synsem ] ].
+           [ LOCAL.CAT.HEAD.LSYNSEM v_unacc_intr_synsem ] ]
+"""; e.g. encogerse (to shrink), enquistarse (to encyst)
+""".
 
+; --- 1.3.1.2. Unaccusative verbs taking PP complement
 
-; --- 1.3.1.2. Unaccusative verbs taking PP complement (verbs of existence and state and 
-; verbs of movement and direction)
-; canvio INV + a INV -
-; !!! They can take an IO (e.g. se nos escaparon los ladrones, nos llegaron los víveres)
 v_unacc_pp_synsem := v_unacc_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
                   VAL.COMPS < [ LOCAL lcomp_local & 
@@ -1195,134 +1298,157 @@ v_unacc_pp_synsem := v_unacc_synsem &
                                                     XARG #index ] ] ] > ],
             CONT.HOOK [ LTOP #ltop,
                         INDEX #index ] ],
-    LKEYS.--COMPKEY #ckey & dir_or_state_nontemp_rel ].
+    LKEYS.--COMPKEY #ckey & dir_or_state_nontemp_rel ]
+"""; --- 1.3.1.2. Unaccusative verbs taking PP complement (verbs of existence and state and 
+; verbs of movement and direction)
+; canvio INV + a INV -
+; !!! They can take an IO (e.g. se nos escaparon los ladrones, nos llegaron los víveres)
+""".
 
-; e.g. En la Academia existe un autógrafo de Cervantes.
 v_pp_loc_lex := v_unacc & main-verb & basic-two-arg &
   [ ALTS [ PASS -,
            IMPERS + ],
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT - ] > ],
-             LKEYS.--COMPKEY state_loc_rel ] ].
+             LKEYS.--COMPKEY state_loc_rel ] ]
+"""; e.g. En la Academia existe un autógrafo de Cervantes.
+""".
 
-; e.g. permanecer (to stay)
 v_pp*_loc_lex := v_unacc & main-verb & basic-two-arg &
   [ ALTS [ PASS -,
            IMPERS + ],
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT + ] > ],
-             LKEYS.--COMPKEY state_loc_rel ] ].
+             LKEYS.--COMPKEY state_loc_rel ] ]
+"""; e.g. permanecer (to stay)
+""".
 
-; e.g. aterrizar (to land), emerger (to emerge)
 v_pp*_loc-psv_lex := v_unacc & main-verb & basic-two-arg &
   [ ALTS [ PASS +,
            IMPERS + ],
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT + ] > ],
-             LKEYS.--COMPKEY state_loc_rel ] ].
+             LKEYS.--COMPKEY state_loc_rel ] ]
+"""; e.g. aterrizar (to land), emerger (to emerge)
+""".
 
-; e.g. alojarse (to lodge), enmarcarse (to frame), extenderse (to extend)
 v_pp_loc-prn_lex := v_unacc & main-vprn & basic-three-arg &
   [ ALTS.PASS -,
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT - ] > ],
-             LKEYS.--COMPKEY state_loc_rel ] ].
+             LKEYS.--COMPKEY state_loc_rel ] ]
+"""; e.g. alojarse (to lodge), enmarcarse (to frame), extenderse (to extend)
+""".
 
-; e.g. encontrarse (to meet), manifestarse (to manifest)
 v_pp*_loc-prn_lex := v_unacc & main-vprn & basic-three-arg &
   [ ALTS.PASS -,
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT + ] > ],
-             LKEYS.--COMPKEY state_loc_rel ] ].
+             LKEYS.--COMPKEY state_loc_rel ] ]
+"""; e.g. encontrarse (to meet), manifestarse (to manifest)
+""".
 
-; e.g. generarse (to generate), mantenerse (to mantain)
 v_pp*_loc-psv-prn_lex := v_unacc & main-vprn & basic-three-arg &
   [ ALTS.PASS +,
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT + ] > ],
-             LKEYS.--COMPKEY state_loc_rel ] ].
+             LKEYS.--COMPKEY state_loc_rel ] ]
+"""; e.g. generarse (to generate), mantenerse (to mantain)
+""".
 
-; e.g. acudir
 v_pp_dir_lex := v_unacc & main-verb & basic-two-arg &
   [ ALTS [ PASS -,
            IMPERS + ],
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT - ] > ],
-             LKEYS.--COMPKEY dir_rel ] ].
+             LKEYS.--COMPKEY dir_rel ] ]
+"""; e.g. acudir
+""".
 
-; e.g. volver (to return), migrar (to migrate), subir (to go up), 
 v_pp*_dir_lex := v_unacc & main-verb & basic-two-arg &
   [ ALTS [ PASS -,
            IMPERS + ],
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT + ] > ],
-             LKEYS.--COMPKEY dir_rel ] ].
+             LKEYS.--COMPKEY dir_rel ] ]
+"""; e.g. volver (to return), migrar (to migrate), subir (to go up), 
+""".
 
-; e.g. presentarse (to present), desprenderse (to come off)
 v_pp*_dir-prn_lex := v_unacc & main-vprn & basic-three-arg &
   [ ALTS.PASS -,
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT + ] > ],
-             LKEYS.--COMPKEY dir_rel ] ].
+             LKEYS.--COMPKEY dir_rel ] ]
+"""; e.g. presentarse (to present), desprenderse (to come off)
+""".
 
-; e.g. dirigirse (to go)
 v_pp_dir-prn_lex := v_unacc & main-vprn & basic-three-arg &
   [ ALTS.PASS -,
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT - ] > ],
-             LKEYS.--COMPKEY dir_rel ] ].
+             LKEYS.--COMPKEY dir_rel ] ]
+"""; e.g. dirigirse (to go)
+""".
 
-; e.g. bajar (to go down), partir (to part)
 v_pp*_dir-psv_lex := v_unacc & main-verb & basic-two-arg &
   [ ALTS [ PASS +,
            IMPERS + ],
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT + ] > ],
-             LKEYS.--COMPKEY dir_rel ] ].
+             LKEYS.--COMPKEY dir_rel ] ]
+"""; e.g. bajar (to go down), partir (to part)
+""".
 
-; e.g. asomarse (to lean out), deslizarse (to slide), escurrirse (to drain)
 v_pp*_dir-psv-prn_lex := v_unacc & main-vprn & basic-three-arg &
   [ ALTS.PASS +,
     SYNSEM v_unacc_pp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_unacc_pp_synsem, 
                          VAL.COMPS < [ OPT + ] > ],
-             LKEYS.--COMPKEY dir_rel ] ].
+             LKEYS.--COMPKEY dir_rel ] ]
+"""; e.g. asomarse (to lean out), deslizarse (to slide), escurrirse (to drain)
+""".
 
 
 ; --- Locative + subject =>> locative subject + PPen (two lexical entries)
 ; e.g. aquí abundan los insectos =>> este lugar abunda en insectos
-
+;;; OZ: No entries for the above, I think?
 
 ; --- 1.3.2. Intransitive verbs
-; - They have typically agenitive subjects. They do not appear in absolute participle clauses. 
 
 v_intrans_synsem := arg1_lt & 
-  [ LOCAL.CONT.RELS <! relation !> ].
+  [ LOCAL.CONT.RELS <! relation !> ]
+"""
+; --- 1.3.2. Intransitive verbs
+; - They have typically agenitive subjects. They do not appear in absolute participle clauses. 
+""".
 
 v_intrans := basic-main-verb & 
   [ ALTS [ RCP -, 
            RFX - ] ].
 
 ; --- 1.3.2.1. Strict intransitive verbs
-; Subjects must take specifier. Some appear in "locative inversion constructions", but the locative 
-; complement must appear in pre-verbal position and the subject in postverbal position and without 
-; specifier (e.g. en este parque juegan niños)
 
 v_strict_intrans_synsem := v_intrans_synsem & 
   [ LOCAL [ CAT [ HEAD.INV -, 
                   VAL.COMPS < > ],
-            CONT.HCONS <! !> ] ].
+            CONT.HCONS <! !> ] ]
+"""
+; --- 1.3.2.1. Strict intransitive verbs
+; Subjects must take specifier. Some appear in "locative inversion constructions", but the locative 
+; complement must appear in pre-verbal position and the subject in postverbal position and without 
+; specifier (e.g. en este parque juegan niños)
+""".
 
 ;v_strict_intrans_prn_synsem := v_strict_intrans_synsem & 
 ;  [ LOCAL.CAT.VAL.CLTS < [ LOCAL.CONT.HOOK.INDEX #affix ] >,
@@ -1336,22 +1462,23 @@ v_strict_intrans_prn_synsem := v_strict_intrans_synsem &
 v_strict_intrans := v_intrans & 
   [ ALTS.VCALT - ].
 
-; e.g. esquiar (to sky)
 v_-_lex := v_strict_intrans & main-verb & basic-one-arg &
   [ ALTS [ IMPERS +,
            PASS - ],
     SYNSEM v_strict_intrans_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_strict_intrans_synsem ] ].
+           [ LOCAL.CAT.HEAD.LSYNSEM v_strict_intrans_synsem ] ]
+"""; e.g. esquiar (to sky)
+""".
 
-; e.g. rebotarse (to bounce), suicidarse (to commit suicide)
 v_-_prn_lex := v_strict_intrans & main-vprn-intr & basic-two-arg &
   [ ALTS.PASS +,
     SYNSEM v_strict_intrans_prn_synsem & 
-           [ LOCAL.CAT.HEAD.LSYNSEM v_strict_intrans_prn_synsem ] ].
-
+           [ LOCAL.CAT.HEAD.LSYNSEM v_strict_intrans_prn_synsem ] ]
+"""; e.g. rebotarse (to bounce), suicidarse (to commit suicide)
+""".
 
 ; --- 1.3.2.2. Intransitive verbs taking marked NP complement 
-; !!! nos animaba a pensar en la muerte y sobre la conveniencia...
+
 v_intr_mrkd_np_synsem := v_intrans_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
                   VAL.COMPS < [ LOCAL mrkd_np_local &
@@ -1360,42 +1487,49 @@ v_intr_mrkd_np_synsem := v_intrans_synsem &
             CONT.HCONS <! !> ],
     LKEYS [ KEYREL arg12-ev-relation & 
                    [ ARG2 #ind2 ],
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+"""
+; --- 1.3.2.2. Intransitive verbs taking marked NP complement 
+; !!! nos animaba a pensar en la muerte y sobre la conveniencia...
+""".
 
 v_intr_mrkd_np := v_intrans & 
   [ ALTS.VCALT - ].
 
-; e.g. sucumbir a, acertaron a/con
 v_pp_e_lex := v_intr_mrkd_np & main-verb & basic-two-arg &
   [ ALTS [ IMPERS +,
            PASS - ],
     SYNSEM v_intr_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. sucumbir a, acertaron a/con
+""".
 
-;e.g. desertar (de), abusar (de)
 v_pp*_e_lex := v_intr_mrkd_np & main-verb & basic-two-arg &
   [ ALTS [ IMPERS +,
            PASS - ],
     SYNSEM v_intr_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+""";e.g. desertar (de), abusar (de)
+""".
 
-; e.g. meterse con, encapricharse de/con
 v_pp_e-prn_lex := v_intr_mrkd_np & main-vprn & basic-three-arg &
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. meterse con, encapricharse de/con
+""".
 
-; e.g. adaptarse (a), quejarse (de/por)
 v_pp*_e-prn_lex := v_intr_mrkd_np & main-vprn & basic-three-arg &
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""; e.g. adaptarse (a), quejarse (de/por)
+""".
 
-; e.g. entrar en vigor
 v_pp_e-idm_lex := v_intr_mrkd_np & main-verb & basic-two-arg &
   [ ALTS.PASS -,
     SYNSEM v_intr_mrkd_np_synsem & 
@@ -1403,9 +1537,10 @@ v_pp_e-idm_lex := v_intr_mrkd_np & main-verb & basic-two-arg &
                          VAL.COMPS < [ OPT -,
                                        NON-LOCAL [ SLASH 0-dlist,
                                                    REL 0-dlist,
-                                                   QUE 0-dlist ] ] > ] ] ].
+                                                   QUE 0-dlist ] ] > ] ] ]
+"""; e.g. entrar en vigor
+""".
 
-; e.g. encogerse de hombros
 v_pp_e-prn-idm_lex := v_intr_mrkd_np & main-vprn & basic-three-arg &
   [ ALTS.PASS -,
     SYNSEM v_intr_mrkd_np_synsem & 
@@ -1413,7 +1548,9 @@ v_pp_e-prn-idm_lex := v_intr_mrkd_np & main-vprn & basic-three-arg &
                          VAL.COMPS < [ OPT -,
                                        NON-LOCAL [ SLASH 0-dlist,
                                                    REL 0-dlist,
-                                                   QUE 0-dlist ] ] > ] ] ].
+                                                   QUE 0-dlist ] ] > ] ] ]
+"""; e.g. encogerse de hombros
+""".
 
 
 ; --- 1.3.2.3. Intransitive verbs taking marked verbal complement
@@ -1426,7 +1563,9 @@ v_intr_mrkd_cp_prop-or-ques_synsem := v_intrans_synsem &
             CONT.HCONS <! qeq & [ HARG #harg,
                                   LARG #larg ] !> ],
     LKEYS [ KEYREL arg12-ev-relation & [ ARG2 #harg ],
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+"""; --- 1.3.2.3. Intransitive verbs taking marked verbal complement
+""".
 
 v_intr_mrkd_cp_prop-or-ques_fin_synsem := v_intr_mrkd_cp_prop-or-ques_synsem & 
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.E.TENSE tense ] > ].
@@ -1445,13 +1584,15 @@ v_intr_mrkd_cp_prop-or-ques := v_intrans &
 
 
 ; --- 1.3.2.3.1. Verbs taking marked VPinf (s_ctrl)
+
 v_intr_mrkd_cp_prop_inf_synsem := v_intr_mrkd_cp_prop-or-ques_inf_synsem &
-  [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.ALT2KEY prop ] > ].
+  [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.ALT2KEY prop ] > ]
+"""; --- 1.3.2.3.1. Verbs taking marked VPinf (s_ctrl)
+""".
 
 v_intr_mrkd_cp_prop_inf := v_intr_mrkd_cp_prop-or-ques &
   [ ALTS.VCALT - ].
 
-; e.g. aprender a (to learn to), desistir de
 v_pp_e-vp-sc_lex := v_intr_mrkd_cp_prop_inf & cc-two-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_mrkd_cp_prop_inf_synsem &
@@ -1460,9 +1601,10 @@ v_pp_e-vp-sc_lex := v_intr_mrkd_cp_prop_inf & cc-two-arg &
                                COMPS < #comps & 
                                        [ OPT -, LOCAL.CAT.VAL.CLTS #clts ] >,
                                CLTS #clts ] ] ],
-    ARG-ST < #subj . < #comps . #clts > > ].
+    ARG-ST < #subj . < #comps . #clts > > ]
+"""; e.g. aprender a (to learn to), desistir de
+""".
 
-; e.g. dignarse a, abstenerse de 
 v_pp_e-vp-sc-prn_lex := v_intr_mrkd_cp_prop_inf & basic-three-arg & 
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_cp_prop_inf_synsem &
@@ -1471,10 +1613,19 @@ v_pp_e-vp-sc-prn_lex := v_intr_mrkd_cp_prop_inf & basic-three-arg &
                                COMPS < #comps & 
                                        [ OPT -, LOCAL.CAT.VAL.CLTS #clts ] >,
                                CLTS < #clt . #clts > ] ] ],
-    ARG-ST < #subj . < #comps . < #clt . #clts > > > ].
+    ARG-ST < #subj . < #comps . < #clt . #clts > > > ]
+"""; e.g. dignarse a, abstenerse de 
+""".
 
 
 ; --- 1.3.2.3.2. Verbs taking marked finite completive clause 
+
+v_intr_mrkd_cp_prop_fin_synsem := v_intr_mrkd_cp_prop-or-ques_fin_synsem & 
+  [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.HEAD.KEYS.ALT2KEY prop,
+                                    CONT.HOOK.INDEX.SF prop ] ] > ]
+"""
+; --- 1.3.2.3.2. Verbs taking marked finite completive clause 
+
 ; - those movement verbs that take the preposition 'a': perfective or telic mood; the subject must be human, the verb in the subordinate clause must refer to an action and it goes always in the subjunctive mood. It can appear in the infinitive (always ctrl) and does not accept negation or composed form; besides, some admit clitic climbing but others don't. The subordinate clause can alternate with a locative NP.
 ; - those verbs that take the preposition 'a'but are not movement verbs: the semantic restrictions of the subject depend upon each verb. The clause may appear in indicative or subjunctive mood, but some only accept the subjunctive,
 ; this can be substituted by a first or second order NP, or by a (control) VPinf.
@@ -1483,57 +1634,58 @@ v_pp_e-vp-sc-prn_lex := v_intr_mrkd_cp_prop_inf & basic-three-arg &
 ; - those verbs that take the preposition 'en': some verbs do not take the preposition. Most verbs, though not all, have a human subject.The clause can be in indicative or subjunctive and can alternate with a VPinf, if of control (except for apoyarse, centrarse, consistir, estribar, insistir, residir, which do not demand a ctrl VPinf).
 ; The clause also alternates with a non-human NP, though some accept a human one.
 ; - those verbs that take the preposition 'por': the clause, always subjunctive and with a human subject, alternates with a control VPinf whose subject is co-referent with that of the main clause and can be animate or inanimate (e.g. las palabras pugnaban por salir de su boca)
-v_intr_mrkd_cp_prop_fin_synsem := v_intr_mrkd_cp_prop-or-ques_fin_synsem & 
-  [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.HEAD.KEYS.ALT2KEY prop,
-                                    CONT.HOOK.INDEX.SF prop ] ] > ].
+""".
 
 v_intr_mrkd_cp_prop_fin := v_intr_mrkd_cp_prop-or-ques & 
   [ ALTS.VCALT + ].
 
-; e.g. consistir en (to consist on), contribuir a (to contribute to)
 v_pp_e-cp-p_lex := v_intr_mrkd_cp_prop_fin & main-verb & basic-two-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                         VAL.COMPS < [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. consistir en (to consist on), contribuir a (to contribute to)
+""".
 
-; e.g. asustarse de, benecifiarse de
 v_pp_e-cp-p-prn_lex := v_intr_mrkd_cp_prop_fin & main-vprn & basic-three-arg & 
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                         VAL.COMPS < [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. asustarse de, benecifiarse de
+""".
 
-; e.g. 
 v_pp*_e-cp-p_lex := v_intr_mrkd_cp_prop_fin & main-verb & basic-two-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_prop_fin_synsem, 
                          VAL.COMPS < [ OPT +, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
 
-; e.g. quejarse de
 v_pp*_e-cp-p-prn_lex := v_intr_mrkd_cp_prop_fin & main-vprn & basic-three-arg & 
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT +, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                         VAL.COMPS < [ OPT +, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. quejarse de
+""".
 
-; e.g. soñar con (sueño (con) que vendrán)
 v_pp_e*-cp-p_lex := v_intr_mrkd_cp_prop_fin & main-verb & basic-two-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. soñar con (sueño (con) que vendrán)
+""".
 
-; e.g. enterarse (de)
 v_pp_e*-cp-p-prn_lex := v_intr_mrkd_cp_prop_fin & main-vprn & basic-three-arg & 
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. enterarse (de)
+""".
 
 
-; e.g. 
 v_pp_e-cp-p-ind_lex := v_intr_mrkd_cp_prop_fin & main-verb & basic-two-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
@@ -1542,34 +1694,36 @@ v_pp_e-cp-p-ind_lex := v_intr_mrkd_cp_prop_fin & main-verb & basic-two-arg &
                                        LOCAL [ CAT.HEAD.KEYS.KEY selected_rel,
                                                CONT.HOOK.INDEX.E.MOOD ind ] ] > ] ] ].
 
-; e.g. el candidato se conforta con que hizo todo lo posible para obtener el puesto
 v_pp_e-cp-p-ind-prn_lex := v_intr_mrkd_cp_prop_fin & main-vprn & basic-three-arg & 
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_prop_fin_synsem, 
                          VAL.COMPS < [ OPT -, 
                                        LOCAL [ CAT.HEAD.KEYS.KEY selected_rel,
-                                               CONT.HOOK.INDEX.E.MOOD ind ] ] > ] ] ].
+                                               CONT.HOOK.INDEX.E.MOOD ind ] ] > ] ] ]
+"""; e.g. el candidato se conforta con que hizo todo lo posible para obtener el puesto
+""".
 
-; e.g. esperar a
 v_pp_e-cp-p-sub_lex := v_intr_mrkd_cp_prop_fin & main-verb & basic-two-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_prop_fin_synsem, 
                          VAL.COMPS < [ OPT -, 
                                        LOCAL [ CAT.HEAD.KEYS.KEY selected_rel,
-                                               CONT.HOOK.INDEX.E.MOOD sub ] ] > ] ] ].
+                                               CONT.HOOK.INDEX.E.MOOD sub ] ] > ] ] ]
+"""; e.g. esperar a
+""".
 
-; e.g. esforzarse por
 v_pp_e-cp-p-sub-prn_lex := v_intr_mrkd_cp_prop_fin & main-vprn & basic-three-arg & 
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_prop_fin_synsem, 
                          VAL.COMPS < [ OPT -, 
                                        LOCAL [ CAT.HEAD.KEYS.KEY selected_rel,
-                                               CONT.HOOK.INDEX.E.MOOD sub ] ] > ] ] ].
+                                               CONT.HOOK.INDEX.E.MOOD sub ] ] > ] ] ]
+"""; e.g. esforzarse por
+""".
 
-; e.g. 
 v_pp*_e-cp-p-sub-prn_lex := v_intr_mrkd_cp_prop_fin & main-vprn & basic-three-arg & 
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
@@ -1578,47 +1732,54 @@ v_pp*_e-cp-p-sub-prn_lex := v_intr_mrkd_cp_prop_fin & main-vprn & basic-three-ar
                                        LOCAL [ CAT.HEAD.KEYS.KEY selected_rel,
                                                CONT.HOOK.INDEX.E.MOOD sub ] ] > ] ] ].
 
-; e.g. contentarse con
 v_pp_e*-cp-p-sub-prn_lex := v_intr_mrkd_cp_prop_fin & main-vprn & basic-three-arg & 
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_cp_prop_fin_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_prop_fin_synsem, 
                          VAL.COMPS < [ OPT -, 
-                                       LOCAL.CONT.HOOK.INDEX.E.MOOD sub ] > ] ] ].
-
+                                       LOCAL.CONT.HOOK.INDEX.E.MOOD sub ] > ] ] ]
+"""; e.g. contentarse con
+""".
 
 ; --- 1.3.2.3.3. Verbs taking marked (semi) interrogative clause 
-; they are interpreted as assertions. Syntactically, they are not introduced by 'que'
+
 v_intr_mrkd_cp_semi_ques_synsem := v_intr_mrkd_cp_prop-or-ques_fin_synsem & 
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL mrkd_cp_semi_ques_local &
                                   [ CAT.HEAD.KEYS.ALT2KEY ques,
-                                    CONT.HOOK.INDEX.SF prop ] ] > ].
+                                    CONT.HOOK.INDEX.SF prop ] ] > ]
+"""
+; --- 1.3.2.3.3. Verbs taking marked (semi) interrogative clause 
+; they are interpreted as assertions. Syntactically, they are not introduced by 'que'
+""".
 
 v_intr_mrkd_cp_semi_ques := v_intr_mrkd_cp_prop-or-ques & 
   [ ALTS.VCALT + ].
 
-; e.g. depender de
 v_pp_e-cp-q_lex := v_intr_mrkd_cp_semi_ques & main-verb & basic-two-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_mrkd_cp_semi_ques_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_semi_ques_synsem,
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. depender de
+""".
 
-; e.g. interesarse por
 v_pp_e-cp-q-prn_lex := v_intr_mrkd_cp_semi_ques & main-vprn & basic-three-arg & 
   [ ALTS.PASS +,
     SYNSEM v_intr_mrkd_cp_semi_ques_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_mrkd_cp_semi_ques_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. interesarse por
 
+OZ: Not sure if the following comment belongs here or it was a free-standing comment:
 
 ; ----- the verb "fijarse en" in imperative eliminates the preposition
 ; e.g. Fijaos qué cosas dice, Fíjate si será listo que ...
+""".
+
 
 
 ; --- 1.3.2.5. Intransitive verbs taking IO
-; canvio INV + a INV -
-; cliticization/clitic doubling obligatory
+
 v_intr_io_synsem := v_intrans_synsem & 
   [ LOCAL [ CAT [ HEAD.INV -,
                   VAL.COMPS < [ LOCAL dative_local & 
@@ -1627,39 +1788,48 @@ v_intr_io_synsem := v_intrans_synsem &
             CONT.HCONS <! !> ],
     LKEYS [ KEYREL arg12-ev-relation & 
                    [ ARG2 #arg2 ],
-            --COMPKEY #ckey ] ]. 
+            --COMPKEY #ckey ] ]
+"""
+; --- 1.3.2.5. Intransitive verbs taking IO
+; canvio INV + a INV -
+; cliticization/clitic doubling obligatory
+""". 
 
 v_intrans_io := v_intrans & 
   [ ALTS [ IMPERS -,
            VCALT - ] ].
 
-; e.g. le consume la duda, le pertenece a Juan
 v_ppa_lex := v_intrans_io & main-verb & basic-two-arg &
   [ ALTS.PASS -,
     SYNSEM v_intr_io_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_io_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. le consume la duda, le pertenece a Juan
+""". 
 
-; e.g. gustar (no *(me) gustan (las acelgas))
 v_ppa*_lex := v_intrans_io & main-verb & basic-two-arg &
   [ ALTS.PASS -,
     SYNSEM v_intr_io_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_io_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""; e.g. gustar (no *(me) gustan (las acelgas))
+""". 
 
-; e.g. se le acercó
 v_ppa_prn_lex := v_intrans_io & main-vprn & basic-three-arg &
   [ ALTS.PASS +,
     SYNSEM v_intr_io_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_io_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. se le acercó
+""". 
 
-; e.g. se le declaró, se le indigestó la comida
 v_ppa*_prn_lex := v_intrans_io & main-vprn & basic-three-arg &
   [ ALTS.PASS +,
     SYNSEM v_intr_io_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_io_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""; e.g. se le declaró, se le indigestó la comida
+""". 
 
 
 
@@ -1679,34 +1849,38 @@ v_intr_io_mrkd_np_synsem := v_intrans_synsem &
                    [ ARG2 #arg2,
                      ARG3 #arg3 ],
             --COMPKEY #ckey,
-            --OCOMPKEY #ockey ] ]. 
+            --OCOMPKEY #ockey ] ]
+"""; --- 1.3.2.6. Intransitive verbs taking IO and marked NP
+""". 
 
 v_intr_io_mrkd_np := v_intrans & 
   [ ALTS [ IMPERS +,
            VCALT - ] ].
 
-; e.g. le sucedió (en el trono)
 v_ppa-pp*_e_lex := v_intr_io_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_io_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_io_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+"""; e.g. le sucedió (en el trono)
+""". 
 
-; e.g. (le) preguntó por tí
 v_ppa*-pp_e_lex := v_intr_io_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_io_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_io_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""; e.g. (le) preguntó por tí
+""". 
 
-; e.g. (le) hablé (de tí)
 v_ppa*-pp*_e_lex := v_intr_io_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_io_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_io_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]
+"""; e.g. (le) hablé (de tí)
+""". 
 
-; e.g. le echaba en falta
 v_ppa-pp_e-idm_lex := v_intr_io_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS.PASS -,
     SYNSEM v_intr_io_mrkd_np_synsem & 
@@ -1716,7 +1890,9 @@ v_ppa-pp_e-idm_lex := v_intr_io_mrkd_np & main-verb & basic-three-arg &
                                        LOCAL.CONT.RELS <! relation !>,
                                        NON-LOCAL [ SLASH 0-dlist,
                                                    REL 0-dlist,
-                                                   QUE 0-dlist ] ] > ] ] ]. 
+                                                   QUE 0-dlist ] ] > ] ] ]
+"""; e.g. le echaba en falta
+""". 
 
 
 
@@ -1743,13 +1919,14 @@ v_intr_two_mrkd_np_idm_synsem := v_intrans_synsem &
                    [ ARG2 #arg2,
                      ARG3 #arg3 ],
             --COMPKEY #ckey,
-            --OCOMPKEY #ockey ] ]. 
+            --OCOMPKEY #ockey ] ]
+"""; --- 1.3.2.7. Intransitive verbs taking two marked NPs
+""". 
 
 v_intr_two_mrkd_np_idm := v_intrans & 
   [ ALTS [ IMPERS -,
            VCALT - ] ].
 
-; e.g. ponerse en contacto con
 v_pp-pp_e-e-prn-idm_lex := v_intr_two_mrkd_np_idm & norm-pronominal-verb & 
   [ ALTS.PASS -,
     SYNSEM v_intr_two_mrkd_np_idm_synsem &
@@ -1758,12 +1935,11 @@ v_pp-pp_e-e-prn-idm_lex := v_intr_two_mrkd_np_idm & norm-pronominal-verb &
                                COMPS < #comp1 & [ OPT - ] , 
                                        #comp2 & [ OPT - ] >,
                                CLTS < #clt > ] ] ],
-    ARG-ST < #subj , #comp1 , #comp2 , #clt > ].
-
+    ARG-ST < #subj , #comp1 , #comp2 , #clt > ]
+"""; e.g. ponerse en contacto con
+""".
 
 ; --- 1.3.2.7. intransitive subject to subject raising verbs
-; - clitic climbing only with modal and aspectual auxiliaries (i.e. building infinitival 
-; and gerundive periphrasis (e.g. te lo puedo/debo dar))
 
 v_intr_ssr_synsem := lex-synsem & 
   [ LOCAL [ AGR #ind, 
@@ -1785,7 +1961,12 @@ v_intr_ssr_synsem := lex-synsem &
                    HCONS <! qeq & [ HARG #harg,
                                     LARG #larg ] !> ] ],
     LKEYS [ KEYREL #keyrel & arg1-ev-relation &  [ ARG1 #harg ] ,
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+"""
+; --- 1.3.2.7. intransitive subject to subject raising verbs
+; - clitic climbing only with modal and aspectual auxiliaries (i.e. building infinitival 
+; and gerundive periphrasis (e.g. te lo puedo/debo dar))
+""".
 
 v_intr_ssr := basic-verb-lex & 
   [ ALTS [ RCP -, 
@@ -1809,52 +1990,61 @@ vprn_intr_ssr := norm-pronominal-verb &
                            CLTS < #clt & clitic-synsem . #clts > ],
     ARG-ST < #subj . < #comps. < #clt. #clts > > > ].
 
-; a)- taking VPinf
-; e.g. poder, soler, deber (deberían hacerlo (ellos), puede terminar ardiendo Troya)
 v_vp_inf-ssr_lex := v_intr_ssr & cc-two-arg & 
   [ SYNSEM v_intr_ssr_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_ssr_synsem, 
                          VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX ref-ind & #ind ] >,
                                COMPS < [ LOCAL vp_inf_local & 
-                                               [ CAT.VAL.SUBJ < [ LOCAL.CONT.HOOK.INDEX #ind ] > ] ] > ] ] ] ]. 
+                                               [ CAT.VAL.SUBJ < [ LOCAL.CONT.HOOK.INDEX #ind ] > ] ] > ] ] ] ]
+"""; a)- taking VPinf
+; e.g. poder, soler, deber (deberían hacerlo (ellos), puede terminar ardiendo Troya)
+""". 
 
-; b)- taking marked VPinf
-; e.g. acostubrar a, deber de, haber de, ir a, ... (he de hacerlo)
-; !!! missing: estar a punto de, no tener/haber por qué
 v_pp_e-vp-inf-ssr_lex := v_intr_ssr & cc-two-arg & 
   [ SYNSEM v_intr_ssr_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_ssr_synsem, 
                          VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX ref-ind & #ind ] >,
                                COMPS < [ LOCAL mrkd_cp_prop_inf_local & 
-                                               [ CONT.HOOK.XARG #ind ] ] > ] ] ] ]. 
+                                               [ CONT.HOOK.XARG #ind ] ] > ] ] ] ]
+"""
+; b)- taking marked VPinf
+; e.g. acostubrar a, deber de, haber de, ir a, ... (he de hacerlo)
+; !!! missing: estar a punto de, no tener/haber por qué
+""". 
 
-; e.g. echarse (se echó a llorar)
 v_pp_e-vp-inf-ssr-prn_lex := vprn_intr_ssr & cc-three-arg & 
   [ SYNSEM v_intr_ssr_synsem & 
            [ LOCAL [ CAT [ HEAD.LSYNSEM v_intr_ssr_synsem, 
                            VAL.COMPS < [ LOCAL mrkd_cp_prop_inf_local & 
                                                [ CONT.HOOK.XARG #ctrl ] ] > ],
-                     CONT.HOOK.XARG #ctrl ] ] ]. 
+                     CONT.HOOK.XARG #ctrl ] ] ]
+"""
+; e.g. echarse (se echó a llorar)
+""". 
 
-; c)- taking VPger
-; e.g. andar (anda cantando)
 v_vp_ger-ssr_lex := v_intr_ssr & cc-two-arg & 
   [ SYNSEM v_intr_ssr_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_ssr_synsem, 
                          VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX ref-ind & #ind ] >,
                                COMPS < [ LOCAL vp_ger_local & 
-                                               [ CAT.VAL.SUBJ < [ LOCAL.CONT.HOOK.INDEX #ind ] > ] ] > ] ] ] ]. 
+                                               [ CAT.VAL.SUBJ < [ LOCAL.CONT.HOOK.INDEX #ind ] > ] ] > ] ] ] ]
+"""
+; c)- taking VPger
+; e.g. andar (anda cantando)
+""". 
 
-; e.g. quedarse (se quedó llorando)
 v_vp_ger-ssr-prn_lex := vprn_intr_ssr & cc-three-arg & 
   [ SYNSEM v_intr_ssr_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_ssr_synsem, 
                          VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX ref-ind & #ind ] >,
                                COMPS < [ LOCAL vp_ger_local & 
-                                               [ CAT.VAL.SUBJ < [ LOCAL.CONT.HOOK.INDEX #ind ] > ] ] > ] ] ] ]. 
+                                               [ CAT.VAL.SUBJ < [ LOCAL.CONT.HOOK.INDEX #ind ] > ] ] > ] ] ] ]
+"""; e.g. quedarse (se quedó llorando)
+""". 
 
 
 ; --- 1.3.2.8. Intransitive verbs taking adverbial phrases
+
 v_intr_advp_synsem := v_intrans_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
                   VAL.COMPS < [ LOCAL [ CAT.HEAD adv & [ KEYS.KEY #ckey ],
@@ -1864,7 +2054,10 @@ v_intr_advp_synsem := v_intrans_synsem &
     LKEYS [ KEYREL arg1-ev-relation & 
                    [ LBL #ltop,
                      ARG0 #index ],
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+"""
+; --- 1.3.2.8. Intransitive verbs taking adverbial phrases
+""".
 
 v_intr_advp_io_synsem := v_intr_advp_synsem &
   [ LOCAL.CAT.VAL.COMPS < [ ],
@@ -1891,27 +2084,32 @@ v_intr_advp := v_intrans &
            VCALT -,
            PASS - ] ].
 
-; e.g. hacer bien/mal
 v_adv_lex := v_intr_advp & main-verb & basic-two-arg & 
   [ SYNSEM v_intr_advp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_advp_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""
+; e.g. hacer bien/mal
+""".
 
 
-; e.g. portarse (to behave) (el niño se porta bien)
 v_adv_prn_lex := v_intr_advp & main-vprn & basic-three-arg & 
   [ SYNSEM v_intr_advp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_advp_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""
+; e.g. portarse (to behave) (el niño se porta bien)
+""".
 
-; e.g. conservarse 
 v_adv*_prn_lex := v_intr_advp & main-vprn & basic-three-arg & 
   [ SYNSEM v_intr_advp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_advp_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""
+; e.g. conservarse 
+""".
 
 
-; e.g. llevarse bien/mal con
 v_adv-pp_e-prn-idm_lex := v_intr_advp & norm-pronominal-verb & 
   [ SYNSEM v_intr_advp_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_advp_mrkd_np_synsem, 
@@ -1919,7 +2117,10 @@ v_adv-pp_e-prn-idm_lex := v_intr_advp & norm-pronominal-verb &
                                COMPS < #comp1 & [ OPT - ] , 
                                        #comp2 & [ OPT - ] >,
                                CLTS < #clt > ] ] ],
-    ARG-ST < #subj , #comp1 , #comp2 , #clt > ].
+    ARG-ST < #subj , #comp1 , #comp2 , #clt > ]
+"""
+; e.g. llevarse bien/mal con
+""".
 
 ;-- 
 
@@ -1953,17 +2154,21 @@ v_intr_io_modnp_synsem := v_intr_io_advp_synsem &
                      ARG0 #index ],
             --COMPKEY #ckey ] ].
 
-; e.g. salir, sentar, sonar (le) sentó bien
 v_adv-ppa*_lex := v_intr_advp & main-verb & basic-three-arg & 
   [ SYNSEM v_intr_io_adv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_io_adv_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""
+; e.g. salir, sentar, sonar (le) sentó bien
+""".
 
-; e.g. dar igual
 v_modnp-ppa*_idm_lex := v_intr_advp & main-verb & basic-three-arg & 
   [ SYNSEM v_intr_io_modnp_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_intr_io_modnp_synsem,
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""
+; e.g. dar igual
+""".
 
 
 ; --- 1.3.3. Transitive verbs
@@ -1971,15 +2176,22 @@ v_modnp-ppa*_idm_lex := v_intr_advp & main-verb & basic-three-arg &
 v_trans_synsem := arg1_lt & transitive_verb_synsem &
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY #ckey ],... >,
     LKEYS [ KEYREL arg12-ev-relation,
-            --COMPKEY #ckey ] ].
+            --COMPKEY #ckey ] ]
+"""
+; --- 1.3.3. Transitive verbs
+""".
 
 
 ; --- 1.3.3.1. Transitive verbs taking NP
+
 v_trans_np_synsem := v_trans_synsem & 
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local & 
                                   [ CONT.HOOK.INDEX #ind2 ],
                             NON-LOCAL.REL 0-dlist & [ LIST < > ] ],... >,
-    LKEYS.KEYREL.ARG2 #ind2 ].
+    LKEYS.KEYREL.ARG2 #ind2 ]
+"""
+; --- 1.3.3.1. Transitive verbs taking NP
+""".
 
 v_trans_np := basic-main-verb & 
   [ ALTS.VCALT - ].
@@ -1991,7 +2203,11 @@ v_np_ntr_synsem := v_trans_np_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
                   VAL.COMPS < [ LOCAL np_acc_local ] > ],
             CONT [ RELS <! relation !>,
-                   HCONS <! !> ] ] ].
+                   HCONS <! !> ] ] ]
+"""
+; --- 1.3.3.1.1. Transitive verbs taking nominal complements that don't passivize 
+; (including verbs taking measure NPs)
+""".
 
 v_np_id_synsem := v_np_ntr_synsem.
 
@@ -2015,58 +2231,67 @@ v_np_ntr := v_trans_np &
            RFX -,
            PASS - ] ].
 
-; e.g. querer (to want) (¿quieres algo?), durar (to last) (la reunión duró tres horas)
 v_np_npsv_lex := v_np_ntr & main-verb & basic-two-arg &
   [ ALTS.IMPERS +,
     SYNSEM v_np_ntr_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_np_ntr_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""
+; e.g. querer (to want) (¿quieres algo?), durar (to last) (la reunión duró tres horas)
+""".
 
-; e.g. adelgazar (to lose weight)
 v_np*_npsv_lex := v_np_ntr & main-verb & basic-two-arg &
   [ ALTS.IMPERS +,
     SYNSEM v_np_ntr_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_np_ntr_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""
+; e.g. adelgazar (to lose weight)
+""".
 
-; e.g. jugarse (to bet)
 v_np_npsv-prn_lex := v_np_ntr & main-vprn & basic-three-arg &
   [ SYNSEM v_np_ntr_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_np_ntr_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""
+; e.g. jugarse (to bet)
+""".
 
-; e.g. adelgazar (to lose weight)
 v_np*_npsv-prn_lex := v_np_ntr & main-vprn & basic-three-arg &
   [ SYNSEM v_np_ntr_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_np_ntr_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""
+OZ: The below comment is a duplicate for the comment for v_np*_npsv_lex; not sure why.
+; e.g. adelgazar (to lose weight)
+""".
 
-; for locuciones verbales, e.g. tener lugar, tirar la toalla
 v_np_npsv-idm_lex := v_np_ntr & main-verb & basic-two-arg &
   [ ALTS.IMPERS -,
     SYNSEM v_np_ntr-idm_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_np_ntr-idm_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; for locuciones verbales, e.g. tener lugar, tirar la toalla
+""".
 
-
-; e.g. devenir
 v_np_npsv-id_lex := v_np_ntr & main-verb & basic-two-arg &
   [ ALTS.IMPERS -,
     SYNSEM v_np_id_synsem & 
            [ LOCAL [ AGR.PNG #png,
                      CAT [ HEAD.LSYNSEM v_np_id_synsem, 
                            VAL.COMPS < [ OPT -,
-                                         LOCAL.AGR.PNG #png ] > ] ] ] ].
+                                         LOCAL.AGR.PNG #png ] > ] ] ] ]
+"""; e.g. devenir
+""".
 
-; e.g. me llamo Montserrat.
 v_np_npsv-id-prn_lex := v_np_ntr & main-vprn & basic-three-arg &
   [ ALTS.IMPERS -,
     SYNSEM v_np_id_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_np_id_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. me llamo Montserrat.
+""".
 
-
-; e.g. ser
 v_np_npsv_id_synsem := v_trans_synsem &
   [ LOCAL [ AGR.PNG #png,
             CAT [ HEAD.INV -, 
@@ -2084,7 +2309,9 @@ v_np_npsv_id_synsem := v_trans_synsem &
                                   NON-LOCAL.REL 0-dlist ] > ] ],
             CONT [ RELS <! relation !>,
                    HCONS <! !> ] ],
-    LKEYS.KEYREL.ARG2 #ind2 ].
+    LKEYS.KEYREL.ARG2 #ind2 ]
+"""; e.g. ser
+""".
 
 v_np_npsv-id-ser_lex := v_np_ntr & main-verb & basic-two-arg &
   [ ALTS.IMPERS -,
@@ -2098,7 +2325,9 @@ v_trans_np_psv_synsem := v_trans_np_synsem &
   [ LOCAL [ CAT [ HEAD.INV -,
                   VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY non_modable_rel ] > ],
             CONT [ RELS <! relation !>,
-                   HCONS <! !> ] ] ].
+                   HCONS <! !> ] ] ]
+"""; --- 1.3.3.1.2. Transitive verbs taking NP that can be passivized
+""".
 
 v_trans_np_psv := v_trans_np &
   [ ALTS [ PASS +,
@@ -2109,73 +2338,77 @@ vprn_trans_np_psv := v_trans_np &
            RCP -, 
            RFX - ] ].
 
-; e.g. pintar (Montse pintó la casa)
 v_np_lex := v_trans_np_psv & main-verb & basic-two-arg &
   [ ALTS [ RCP -, RFX - ],
     SYNSEM v_trans_np_psv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_psv_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. pintar (Montse pintó la casa)
+""". 
 
-; e.g. comer (mañana comeré (paella) en casa de mis padres)
 v_np*_lex := v_trans_np_psv & main-verb & basic-two-arg & 
   [ ALTS [ RCP -, RFX - ],
     SYNSEM v_trans_np_psv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_psv_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""; e.g. comer (mañana comeré (paella) en casa de mis padres)
+""". 
 
-; e.g. secar (to dry)
 v_np_rfx_lex := v_trans_np_psv & main-verb & basic-two-arg & 
   [ ALTS [ RCP -, RFX + ],
     SYNSEM v_trans_np_psv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_psv_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. secar (to dry)
+""". 
 
-; e.g. 
 v_np*_rfx_lex := v_trans_np_psv & main-verb & basic-two-arg & 
   [ ALTS [ RCP -, RFX + ],
     SYNSEM v_trans_np_psv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_psv_synsem, 
                          VAL.COMPS < [ OPT + ] > ] ] ]. 
 
-; e.g. abrazar (to hug) (Juan y María se abrazan (Juan and María hug each other))
 v_np_rcp_lex := v_trans_np_psv & main-verb & basic-two-arg & 
   [ ALTS [ RCP +, RFX - ],
     SYNSEM v_trans_np_psv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_psv_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. abrazar (to hug) (Juan y María se abrazan (Juan and María hug each other))
+""". 
 
-; e.g. desobedecer
 v_np*_rcp_lex := v_trans_np_psv & main-verb & basic-two-arg & 
   [ ALTS [ RCP +, RFX - ],
     SYNSEM v_trans_np_psv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_psv_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ].
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""; e.g. desobedecer
+""".
 
-; e.g. 
 v_np_rfx-rcp_lex := v_trans_np_psv & main-verb & basic-two-arg & 
   [ ALTS [ RCP +, RFX + ],
     SYNSEM v_trans_np_psv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_psv_synsem, 
                          VAL.COMPS < [ OPT - ] > ] ] ]. 
 
-; e.g. 
 v_np*_rfx-rcp_lex := v_trans_np_psv & main-verb & basic-two-arg & 
   [ ALTS [ RCP +, RFX + ],
     SYNSEM v_trans_np_psv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_psv_synsem, 
                          VAL.COMPS < [ OPT + ] > ] ] ].
 
-; e.g. saltarse (el alumno se saltó la clase)
 v_np_prn_lex := vprn_trans_np_psv & main-vprn & basic-three-arg & 
   [ SYNSEM v_trans_np_psv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_psv_synsem, 
-                         VAL.COMPS < [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ] > ] ] ]
+"""; e.g. saltarse (el alumno se saltó la clase)
+""". 
 
-; e.g. peinarse (María se peina (el pelo))
 v_np*_prn_lex := vprn_trans_np_psv & main-vprn & basic-three-arg & 
   [ SYNSEM v_trans_np_psv_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_psv_synsem, 
-                         VAL.COMPS < [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ] > ] ] ]
+"""; e.g. peinarse (María se peina (el pelo))
+""". 
 
 ; --- transitive verbs that participate in 'causative alternation'
 ; May take adjunts like "él solo, por sí mismo, por sí solo (by itself,...) (e.g. las puertas se cerraron 
@@ -2195,10 +2428,8 @@ v_np*_prn_lex := vprn_trans_np_psv & main-vprn & basic-three-arg &
 ; (e.g. una vez hubiaron secado el río/el río fue secado;*una vez se secó el río). In the other cases, 
 ; there's an ambiguity between the unaccusative and the participle's passive transitive 
 
-
 ; --- 1.3.3.2. Transitive verbs taking DO and oblique nominal complements
-; --- régimen verbal de preposición fija (verbal government with fixed preposition) 
-; (a, de, en, con, por) & variable preposition (a/para, de/con, de/por, en/contra/sobre)
+
 v_trans_np_mrkd_np_synsem := v_trans_np_synsem & 
   [ LOCAL [ CAT [ HEAD.INV -, 
                   VAL.COMPS < [ ], 
@@ -2208,7 +2439,12 @@ v_trans_np_mrkd_np_synsem := v_trans_np_synsem &
             CONT [ RELS <! arg123-ev-relation !>,
                    HCONS <! !> ] ], 
     LKEYS [ KEYREL.ARG3 #ind3,
-            --OCOMPKEY #ockey ] ].
+            --OCOMPKEY #ockey ] ]
+"""
+; --- 1.3.3.2. Transitive verbs taking DO and oblique nominal complements
+; --- régimen verbal de preposición fija (verbal government with fixed preposition) 
+; (a, de, en, con, por) & variable preposition (a/para, de/con, de/por, en/contra/sobre)
+""".
 
 v_trans_np_mrkd_np := v_trans_np. 
 
@@ -2219,118 +2455,134 @@ vprn_trans_np_mrkd_np := v_trans_np & norm-pronominal-verb &
     ARG-ST < #subj , #comp1, #comp2,  #clt > ]. 
 
 
-; e.g. distar
 v_np-pp*_npsv-e_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg &
   [ ALTS [ IMPERS +, PASS -, RCP -, RFX - ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+"""; e.g. distar
+""". 
 
-; e.g. sé que esto me ha privado de una amplia gama de experiencias
 v_np-pp_e_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP -, RFX - ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]
+"""; e.g. sé que esto me ha privado de una amplia gama de experiencias
+""". 
 
-; e.g. he roto (las relaciones) con mi novio
 v_np*-pp_e_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP -, RFX - ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""; e.g. he roto (las relaciones) con mi novio
+""". 
 
-; e.g. incorporaremos todos los nombres (a la lista)
 v_np-pp*_e_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP -, RFX - ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+"""; e.g. incorporaremos todos los nombres (a la lista)
+""". 
 
-; e.g. he invertido tres millones (en bolsa)/he invertido (tres millones) en bolsa
 v_np*-pp*_e_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP -, RFX - ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]
+"""; e.g. he invertido tres millones (en bolsa)/he invertido (tres millones) en bolsa
+""". 
 
-; e.g. turnarse ... con ...
 v_np*-pp_e-prn_lex := vprn_trans_np_mrkd_np & basic-four-arg & 
   [ ALTS [ PASS +, RCP -, RFX - ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""; e.g. turnarse ... con ...
+""". 
 
-; e.g. atraer (to attrack)
 v_np-pp_e-rcp_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP +, RFX - ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]
+"""; e.g. atraer (to attrack)
+""".
 
-; e.g. retar (to challenge)
 v_np*-pp_e-rcp_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP +, RFX - ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""; e.g. retar (to challenge)
+""". 
 
-; e.g. recubrir
 v_np-pp*_e-rcp_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP +, RFX - ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+"""; e.g. recubrir
+""". 
 
-; e.g. invitar (to invite)
 v_np*-pp*_e-rcp_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP +, RFX - ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]
+"""; e.g. invitar (to invite)
+""". 
 
-
-; e.g. acostumbrar(se) a
 v_np-pp_e-rfx_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP -, RFX + ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]
+"""; e.g. acostumbrar(se) a
+""".
 
-; e.g. prevenir(se) de
 v_np*-pp_e-rfx_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP -, RFX + ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""; e.g. prevenir(se) de
+""". 
 
-; e.g. convencer(se) de
 v_np-pp*_e-rfx_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP -, RFX + ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+"""; e.g. convencer(se) de
+""". 
 
-; e.g. comparar(se) a
 v_np*-pp*_e-rfx_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP -, RFX + ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]
+"""; e.g. comparar(se) a
+""". 
 
-; e.g. informar(se) de
 v_np-pp_e-rfx-rcp_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP +, RFX + ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]
+"""
+; e.g. informar(se) de
+""". 
 
-; e.g. atar(se) a
 v_np-pp*_e-rfx-rcp_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP +, RFX + ],
     SYNSEM v_trans_np_mrkd_np_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+"""; e.g. atar(se) a
+""". 
 
 v_np*-pp*_e-rfx-rcp_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP +, RFX + ],
@@ -2338,13 +2590,14 @@ v_np*-pp*_e-rfx-rcp_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_synsem, 
                          VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]. 
 
-; --- locuciones verbales
-; e.g. dar a alguien de alta, echar a alguien de menos, tomar nota de algo. 
 v_trans_np_mrkd_np_idm_synsem := v_trans_np_mrkd_np_synsem &
   [ LOCAL.CAT.VAL.COMPS < [ ], 
                           [ NON-LOCAL [ SLASH 0-dlist,
                                         REL 0-dlist,
-                                        QUE 0-dlist ] ] > ]. 
+                                        QUE 0-dlist ] ] > ]
+"""; --- locuciones verbales
+; e.g. dar a alguien de alta, echar a alguien de menos, tomar nota de algo. 
+""". 
 
 v_np-pp_e-idm_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg & 
   [ ALTS [ IMPERS +, PASS +, RCP -, RFX - ],
@@ -2352,20 +2605,20 @@ v_np-pp_e-idm_lex := v_trans_np_mrkd_np & main-verb & basic-three-arg &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_idm_synsem, 
                          VAL.COMPS < [ OPT - ], [ OPT - ] > ] ] ]. 
 
-; e.g. darse cuenta de algo
 v_np-pp*_e-npsv-prn-idm_lex := vprn_trans_np_mrkd_np & basic-four-arg & 
   [ ALTS [ IMPERS -, PASS -, RCP -, RFX - ],
     SYNSEM v_trans_np_mrkd_np_idm_synsem & 
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_np_idm_synsem, 
-                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]. 
+                         VAL.COMPS < [ OPT - ], [ OPT + ] > ] ] ]
+"""; e.g. darse cuenta de algo
+""". 
 
 ; --- verbs that participate in 'locative alternation' (llenar (to fill), cargar (to load))
 ; e.g. cargó el carro de heno -> cargó heno en el carro.
 ; !!! now 2 entries
 
-
 ; --- 1.3.3.3. transitive verb taking DO and oblique verbal complement 
-; !!! repassar
+
 v_trans_np_mrkd_cp_synsem := v_trans_np_synsem & 
   [ LOCAL [ CAT [ HEAD.INV -,
                   VAL.COMPS < [ LOCAL.CAT.HEAD.KEYS.KEY non_modable_rel ], 
@@ -2376,182 +2629,207 @@ v_trans_np_mrkd_cp_synsem := v_trans_np_synsem &
                    HCONS <! qeq & [ HARG #harg,
                                     LARG #larg ] !> ] ],
     LKEYS [ KEYREL.ARG3 #harg,
-            --OCOMPKEY #ockey ] ].
+            --OCOMPKEY #ockey ] ]
+"""
+; --- 1.3.3.3. transitive verb taking DO and oblique verbal complement 
+; !!! repassar
+""".
 
 v_trans_np_mrkd_cp := basic-main-verb & 
   [ ALTS.IMPERS + ]. 
 
 
 ; --- 1.3.3.3.1. transitive verbs taking DO and marked finite completive clause
+
 v_trans_np_mrkd_cp_prop_fin_synsem := v_trans_np_mrkd_cp_synsem & 
   [ LOCAL.CAT.VAL.COMPS < synsem,
                           [ LOCAL [ CAT.MC -,
                                     CONT.HOOK.INDEX [ E.TENSE tense,
-                                                      SF prop ] ] ] > ].
+                                                      SF prop ] ] ] > ]
+"""; --- 1.3.3.3.1. transitive verbs taking DO and marked finite completive clause
+""".
 
-; -- a)- taking clauses in indicative/subjunctive
-; e.g. reducen el problema a que ...
 v_np-pp_e-cp-p_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_synsem, 
                          VAL.COMPS < [ OPT - ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; -- a)- taking clauses in indicative/subjunctive
+; e.g. reducen el problema a que ...
+""".
 
-; e.g. habrá que acostumbrar a esos niños a que su padre llegue/llega siempre tarde a casa; 
-;      los niños se acostumbraron a que su padre llegara tarde
 v_np-pp_e-cp-p-rfx_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX +, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_synsem, 
                          VAL.COMPS < [ OPT - ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. habrá que acostumbrar a esos niños a que su padre llegue/llega siempre tarde a casa; 
+;      los niños se acostumbraron a que su padre llegara tarde
+""".
 
-; e.g. prevenir, advertir
 v_np*-pp_e*-cp-p_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""; e.g. prevenir, advertir
+""".
 
-; e.g. informar 
 v_np-pp_e*-cp-p-rfx-rcp_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP +, RFX +, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""; e.g. informar 
+""".
 
-; -- b)- taking clauses in indicative
 v_trans_np_mrkd_cp_prop_fin_ind_synsem := v_trans_np_mrkd_cp_prop_fin_synsem & 
   [ LOCAL.CAT.VAL.COMPS < synsem,
-                          [ LOCAL.CONT.HOOK.INDEX.E.MOOD ind ] > ].
+                          [ LOCAL.CONT.HOOK.INDEX.E.MOOD ind ] > ]
+"""; -- b)- taking clauses in indicative
+""".
 
-; e.g. basó su defensa/se basó en que no tenía testigos
 v_np-pp_e-cp-p-ind-rfx_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -,  RFX +, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_ind_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_ind_synsem, 
                          VAL.COMPS < [ OPT - ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. basó su defensa/se basó en que no tenía testigos
+""".
 
-; e.g. apostó conmigo una cena a que entraba/*entrara en la sala sin invitación.
 v_np-pp_npsv-e-cp-p-ind_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX -, PASS - ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_ind_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_ind_synsem, 
                          VAL.COMPS < [ OPT - ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. apostó conmigo una cena a que entraba/*entrara en la sala sin invitación.
+""".
 
-; e.g. (los) avisó (de) que llegarán mañana
 v_np*-pp_e*-cp-p-ind_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_ind_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_ind_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ].
+                         VAL.COMPS < [ OPT + ], [ OPT - ] > ] ] ]
+"""; e.g. (los) avisó (de) que llegarán mañana
+""".
 
 
-; c)- taking clauses in subjunctive
-; - they can appear with a VPinf when there is co-reference between the DO and the subject of the clause
 v_trans_np_mrkd_cp_prop_fin_sub_synsem := v_trans_np_mrkd_cp_prop_fin_synsem & 
   [ LOCAL.CAT.VAL.COMPS < synsem,
-                          [ LOCAL.CONT.HOOK.INDEX.E.MOOD sub ] > ].
+                          [ LOCAL.CONT.HOOK.INDEX.E.MOOD sub ] > ]
+"""; c)- taking clauses in subjunctive
+; - they can appear with a VPinf when there is co-reference between the DO and the subject of the clause
+""".
 
-; e.g. las prefiere a que ...
 v_np-pp_npsv-e-cp-p-sub_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX -, PASS - ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
                          VAL.COMPS < [ OPT - ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. las prefiere a que ...
+""".
 
-; e.g. (las) apremia a que vengan/*vienen/venir
 v_np*-pp_npsv-e-cp-p-sub_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX -, PASS - ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
                          VAL.COMPS < [ OPT + ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. (las) apremia a que vengan/*vienen/venir
+""".
 
-; e.g. la sentenció a que venga/*viene/venir
 v_np-pp_e-cp-p-sub_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
                          VAL.COMPS < [ OPT - ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. la sentenció a que venga/*viene/venir
+""".
 
-; e.g. (los) alentó a que participaran
 v_np*-pp_e-cp-p-sub_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
                          VAL.COMPS < [ OPT + ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. (los) alentó a que participaran
+""".
 
-; e.g. *(las) encargó de que fueran
 v_np-pp_e-cp-p-sub-rfx_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -,  RFX +, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
                          VAL.COMPS < [ OPT - ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. *(las) encargó de que fueran
+""".
 
-; e.g. (los) animó a que participaran
 v_np*-pp_e-cp-p-sub-rfx_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX +, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
                          VAL.COMPS < [ OPT + ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. (los) animó a que participaran
+""".
 
-; e.g. retar a
 v_np-pp_e-cp-p-sub-rcp_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP +, RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
                          VAL.COMPS < [ OPT - ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. retar a
+""".
 
-; e.g. invitar
 v_np*-pp_e-cp-p-sub-rcp_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP +, RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
                          VAL.COMPS < [ OPT + ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. invitar
+""".
 
-; e.g. responsabilizar
 v_np-pp_e-cp-p-sub-rfx-rcp_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP +, RFX +, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
                          VAL.COMPS < [ OPT - ], 
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. responsabilizar
+""".
 
-; e.g. culpar
 v_np*-pp_e-cp-p-sub-rfx-rcp_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP +, RFX +, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                         VAL.COMPS < [ OPT + ], [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. culpar
+""".
 
-; e.g. persuadir
 v_np*-pp_e*-cp-p-sub_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ].
+                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]
+"""; e.g. persuadir
+""".
 
-; e.g. (nos) convenció (de) que vendiesemos la casa
 v_np*-pp_e*-cp-p-sub-rfx_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +, RCP -, RFX +, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_synsem, 
-                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ].
+                         VAL.COMPS < [ OPT + ], [ OPT + ] > ] ] ]
+"""; e.g. (nos) convenció (de) que vendiesemos la casa
+""".
 
-; -- verbs of movement may also take VPinf subject control (e.g. la amenazó con ir a la policía) and 
-; object control in the sub. clause (e.g. envía las camisas a planchar a madrid, llévala a arreglar)
-; these entries are generated by LR
 v_trans_np_mrkd_cp_prop_fin_sub_mov_synsem := v_trans_np_mrkd_cp_synsem & 
   [ LOCAL [ CAT.VAL.COMPS < synsem,
                             [ LOCAL [ CAT.MC -,
@@ -2560,91 +2838,107 @@ v_trans_np_mrkd_cp_prop_fin_sub_mov_synsem := v_trans_np_mrkd_cp_synsem &
                                                           E [ TENSE tense, MOOD sub ] ] ] ] ] >, 
             CONT.HCONS <! qeq & [ HARG #harg,
                                   LARG #larg ] !> ],
-    LKEYS.KEYREL.ARG3 #harg ].
+    LKEYS.KEYREL.ARG3 #harg ]
+"""; -- verbs of movement may also take VPinf subject control (e.g. la amenazó con ir a la policía) and 
+; object control in the sub. clause (e.g. envía las camisas a planchar a madrid, llévala a arreglar)
+; these entries are generated by LR
+""".
 
-; e.g. (la) arrastra a pelear
 v_np*-pp_e-cp-p-sub-mv_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +,  RCP -, RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_mov_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_mov_synsem, 
                          VAL.COMPS < [ OPT + ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. (la) arrastra a pelear
+""".
  
-; e.g. se/nos encaminó a luchar
 v_np*-pp_e-cp-p-sub-mv-rfx_lex := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS [ VCALT +,  RCP -, RFX +, PASS + ],
     SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_mov_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_cp_prop_fin_sub_mov_synsem, 
                          VAL.COMPS < [ OPT + ],
-                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ].
-
+                                     [ OPT -, LOCAL.CAT.HEAD.KEYS.KEY selected_rel ] > ] ] ]
+"""; e.g. se/nos encaminó a luchar
+""".
 
 
 ; ---- 1.3.3.3.2. transitive verbs taking DO and marked Vinf complement
+
 v_trans_np_mrkd_vp_inf_synsem := v_trans_np_mrkd_cp_synsem & 
   [ LOCAL.CAT.VAL.COMPS < synsem,
                           [ LOCAL mrkd_cp_prop_inf_local &
                                   [ CAT [ MC -,
                                           VAL.CLTS < > ],
-                                    CONT.HOOK.INDEX.SF prop ] ] > ].
+                                    CONT.HOOK.INDEX.SF prop ] ] > ]
+"""; ---- 1.3.3.3.2. transitive verbs taking DO and marked Vinf complement
+""".
 
 v_trans_np_mrkd_vp_inf := v_trans_np_mrkd_cp & main-verb & basic-three-arg & 
   [ ALTS.VCALT - ].
 
-; a)- subject control
 v_trans_np_mrkd_vp_inf_sc_synsem := v_trans_np_mrkd_vp_inf_synsem & 
   [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #ctrl ] >,
                     COMPS < synsem,
-                            [ LOCAL.CONT.HOOK.XARG #ctrl ] > ] ].
+                            [ LOCAL.CONT.HOOK.XARG #ctrl ] > ] ]
+"""; a)- subject control
+""".
 
-; e.g. preferir
 v_np-pp_e-vp-inf-sc_lex := v_trans_np_mrkd_vp_inf & 
   [ ALTS [ RCP -, RFX -, PASS - ],
     SYNSEM v_trans_np_mrkd_vp_inf_sc_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_vp_inf_sc_synsem,
-                         VAL.COMPS < [ OPT - ], synsem > ] ] ].
+                         VAL.COMPS < [ OPT - ], synsem > ] ] ]
+"""; e.g. preferir
+""".
 
-; e.g. (la) amenazó con ir a la policía
 v_np*-pp_e-vp-inf-sc_lex := v_trans_np_mrkd_vp_inf & 
   [ ALTS [ RCP -, RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_vp_inf_sc_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_vp_inf_sc_synsem,
-                         VAL.COMPS < [ OPT + ], synsem > ] ] ].
+                         VAL.COMPS < [ OPT + ], synsem > ] ] ]
+"""; e.g. (la) amenazó con ir a la policía
+""".
 
 
-; b)- object control (with VPtrans whose DO is different from that of the main clause, the agent 
-; of the VPinf is co-referent with the object of the main clause)
 v_trans_np_mrkd_vp_inf_oc_synsem := v_trans_np_mrkd_vp_inf_synsem & 
   [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX #ctrl ],
-                          [ LOCAL.CONT.HOOK.XARG #ctrl ] > ].
+                          [ LOCAL.CONT.HOOK.XARG #ctrl ] > ]
+"""; b)- object control (with VPtrans whose DO is different from that of the main clause, the agent 
+; of the VPinf is co-referent with the object of the main clause)
+""".
 
-; e.g. la culparon de causar el accidente 
 v_np-pp_e-vp-inf-oc_lex := v_trans_np_mrkd_vp_inf & 
   [ ALTS [ RCP -,  RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_vp_inf_oc_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_vp_inf_oc_synsem,
-                         VAL.COMPS < [ OPT - ], synsem > ] ] ].
+                         VAL.COMPS < [ OPT - ], synsem > ] ] ]
+"""; e.g. la culparon de causar el accidente 
+""".
 
-; e.g. nos retaron a jugar un partido
 v_np*-pp_e-vp-inf-oc_lex := v_trans_np_mrkd_vp_inf & 
   [ ALTS [ RCP -,  RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_vp_inf_oc_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_vp_inf_oc_synsem,
-                         VAL.COMPS < [ OPT + ], synsem > ] ] ].
+                         VAL.COMPS < [ OPT + ], synsem > ] ] ]
+"""; e.g. nos retaron a jugar un partido
+""".
 
-; e.g. todos se han comprometido a hacerlo
 v_np*-pp_e-vp-inf-oc-rfx_lex := v_trans_np_mrkd_vp_inf & 
   [ ALTS [ RCP -,  RFX +, PASS + ],
     SYNSEM v_trans_np_mrkd_vp_inf_oc_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_vp_inf_oc_synsem,
-                         VAL.COMPS < [ OPT + ], synsem > ] ] ].
+                         VAL.COMPS < [ OPT + ], synsem > ] ] ]
+"""; e.g. todos se han comprometido a hacerlo
+""".
 
-; e.g. relevar
 v_np-pp_e-vp-inf-oc-rcp_lex := v_trans_np_mrkd_vp_inf & 
   [ ALTS [ RCP +,  RFX -, PASS + ],
     SYNSEM v_trans_np_mrkd_vp_inf_oc_synsem &
            [ LOCAL.CAT [ HEAD.LSYNSEM v_trans_np_mrkd_vp_inf_oc_synsem,
-                         VAL.COMPS < [ OPT - ], synsem > ] ] ].
+                         VAL.COMPS < [ OPT - ], synsem > ] ] ]
+"""; e.g. relevar
+""".
 
 ; e.g. ayudar
 v_np*-pp_e-vp-inf-oc-rcp_lex := v_trans_np_mrkd_vp_inf & 

--- a/lrtypes.tdl
+++ b/lrtypes.tdl
@@ -1636,254 +1636,323 @@ v_reflex-vprd_dlr := comp-clt-lex-rule &
 ; a sintagmas con para en oraciones impersonales con "ser/resultar + adjetivo" (le es fácil 
 ; conducir, le resulta divertido).
 
-; intransitive verbs
-v_dat-cmp-clt_dlr := comp-clt-lex-rule & 
+
+v_dat-cmp-clt_dlr := comp-clt-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
                                             CONT.HOOK.INDEX #ind2 ] ] >,
                    CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ] > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ] > ]
+  """
+  intransitive verbs
+  """.
 
-; ditransitive verbs (e.g. le prometió que iría/venir)
-v_dat-1st-cmp-clt_dlr := comp-clt-lex-rule & 
+
+v_dat-1st-cmp-clt_dlr := comp-clt-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
                                             CONT.HOOK.INDEX #ind3 ] ] >,
                    CONT.RELS.LIST.FIRST [ ARG2 #ind2,
                                           ARG3 #ind3 ] ],
     DTR.SYNSEM.LOCAL [ CAT.VAL.COMPS < [ LOCAL dative_local ], [ ] >,
-                       CONT.RELS.LIST.FIRST arg123-ev-relation & 
-                                            [ ARG2 #ind2 ] ] ].
+                       CONT.RELS.LIST.FIRST arg123-ev-relation & [ ARG2 #ind2 ] ] ]
+  """
+  ditransitive verbs (e.g. le prometió que iría/venir)
+  """.
 
-; ditransitive verbs (e.g. les compró caramelos)
-v_dat-2nd-cmp-clt_dlr := 2nd-comp-clt-lex-rule & 
+
+v_dat-2nd-cmp-clt_dlr := 2nd-comp-clt-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
                                             CONT.HOOK.INDEX #ind3 ] ] >,
                    CONT.RELS.LIST.FIRST [ ARG2 #ind2,
                                           ARG3 #ind3 ] ],
     DTR.SYNSEM.LOCAL [ CAT.VAL.COMPS < [ ], [ LOCAL dative_local ] >,
-                       CONT.RELS.LIST.FIRST [ ARG2 #ind2 ] ] ].
-
+                       CONT.RELS.LIST.FIRST.ARG2 #ind2 ] ]
+  """
+  ditransitive verbs (e.g. les compró caramelos)
+  """.
 
 ; -- multiple complement cliticization (including pronominal verbs)
-; ditransitive verbs taking DO and IO (e.g. se los compró) and ditransitive verbs taking IO 
-; and verbal complement (e.g. se lo prometió)
-; order: - 2nd+1st (te me fuiste) / 1st/2nd+3rd (me/te lo dieron)  
-;        - reflexive benefactive dative accusative
-; !!! no pueden coaparecer un clitico dativo de tercera persona y uno acusativo de primera o segunda persona
-; (e.g. se le entregó, *me le entregaron)
 
-v_mult-cmp-clt_dlr := comp-clt-lex-rule & 
+v_mult-cmp-clt_dlr := comp-clt-lex-rule &
   [ ALTS.PASS -,
     SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE acc,
-                                            CONT.HOOK.INDEX #ind2 ] ], 
+                                            CONT.HOOK.INDEX #ind2 ] ],
                                   [ LOCAL.CAT.HEAD.CASE rflx ] >,
                    CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ],... >  ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ], ... > ]
+  """
+  -- multiple complement cliticization (including pronominal verbs)
+  ditransitive verbs taking DO and IO (e.g. se los compró) and ditransitive verbs taking IO
+  and verbal complement (e.g. se lo prometió)
+  order: - 2nd+1st (te me fuiste) / 1st/2nd+3rd (me/te lo dieron)
+         - reflexive benefactive dative accusative
+  !!! no pueden coaparecer un clitico dativo de tercera persona y uno acusativo de primera o segunda persona
+  (e.g. se le entregó, *me le entregaron)
+  """.
 
-v_mult-cmp-clt-prn_dlr := comp-clt-lex-rule & 
+
+v_mult-cmp-clt-prn_dlr := comp-clt-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL [ SUBJ < [ LOCAL.CAT.HEAD noun ] >,
                              CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
-                                              CONT.HOOK.INDEX #ind2 ] ], 
+                                              CONT.HOOK.INDEX #ind2 ] ],
                                     [ LOCAL.CAT.HEAD.CASE rflx ] > ],
                    CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ], ... > ]
+  """
+  
+  """.
 
-; actually, impersonal o passive; e.g. se le atribuyen cuatro accidentes mortales.
-v_mult-cmp-clt-imp_dlr := comp-clt-lex-rule & 
+
+v_mult-cmp-clt-imp_dlr := comp-clt-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
-                                            CONT.HOOK.INDEX #ind3 ] ], 
+                                            CONT.HOOK.INDEX #ind3 ] ],
                                   [ LOCAL.CAT.HEAD.CASE none ] >,
                    CONT.RELS.LIST.FIRST.ARG3 #ind3 ],
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ], ... > ]
+  """
+  actually, impersonal o passive; e.g. se le atribuyen cuatro accidentes mortales.
+  """.
 
-;; clitic climbing with causative verbs
-v_mult-cmp-clt-cc_dlr := comp-enclt-lex-rule & 
+; ; clitic climbing with causative verbs
+
+v_mult-cmp-clt-cc_dlr := comp-enclt-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL.CAT.HEAD.CASE acc ],
                                   [ LOCAL [ CAT.HEAD.CASE dat,
                                             CONT.HOOK.INDEX #ind3 ] ] >,
                    CONT.RELS.LIST.FIRST.ARG3 #ind3 ],
     DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ],
-                                     [ LOCAL.CAT.HEAD +vpc ] > ].
+                                     [ LOCAL.CAT.HEAD +vpc ] > ]
+  """
+  ; clitic climbing with causative verbs
+  """.
 
 ; rules for enclitics
-v_mult-cmp-enclt_dlr := comp-enclt-lex-rule & 
+
+v_mult-cmp-enclt_dlr := comp-enclt-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL.CAT.HEAD.CASE rflx ],
                                   [ LOCAL [ CAT.HEAD.CASE acc,
                                             CONT.HOOK.INDEX #ind2 ] ] >,
                    CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ], ... > ]
+  """
+  rules for enclitics
+  """.
 
-v_mult-cmp-enclt-prn_dlr := comp-enclt-lex-rule & 
+
+v_mult-cmp-enclt-prn_dlr := comp-enclt-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL.CAT.HEAD.CASE rflx ],
                                   [ LOCAL [ CAT.HEAD.CASE dat,
                                             CONT.HOOK.INDEX #ind2 ] ] >,
                    CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ], ... > ]
+  """
+  
+  """.
 
-v_dat-enclt_dlr := comp-enclt-lex-rule & 
+
+v_dat-enclt_dlr := comp-enclt-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL.CAT.HEAD.CASE rflx ],
                                   [ LOCAL [ CAT.HEAD.CASE dat,
                                             CONT.HOOK.INDEX #ind2 ] ] >,
-                   CONT.RELS.LIST.FIRST.ARG2 #ind2 ] ].
+                   CONT.RELS.LIST.FIRST.ARG2 #ind2 ] ]
+  """
+  
+  """.
 
-v_mult-cmp-enclt-imp_dlr := comp-enclt-lex-rule & 
+
+v_mult-cmp-enclt-imp_dlr := comp-enclt-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL.CAT.HEAD.CASE none ],
                                   [ LOCAL [ CAT.HEAD.CASE dat,
                                             CONT.HOOK.INDEX #ind2 ] ] >,
                    CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ],... > ].
-
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local ], ... > ]
+  """
+  
+  """.
 
 ; --- Clitic doubling
-; !!! when the canonic object, both direct and indirect, is a pronoun (except "usted" and "ello"), 
-; clitic doubling is obligatory (e.g. *(me) ha visto a mí; (le) agradezco a usted; dedicaré a ello 
-; el siguiente capítulo)
 
-; - clitic-doubling the first element in the COMPS list (e.g. le ordenó al chico salir)
 basic-1st-clt-doubl-lex-rule := cliticization-lex-rule &
   [ SYNSEM.LOCAL [ CAT.VAL.COMPS < [ OPT -,
                                      CLTCZD -,
-				     LOCAL #local,
-                                     NON-LOCAL #nonloc ]
-                                   . #comps >,
+                                     LOCAL #local,
+                                     NON-LOCAL #nonloc ] . #comps >,
                    CONT #cont ],
     DTR.SYNSEM.LOCAL [ CAT.VAL.COMPS < [ CLTCZD +,
-				         LOCAL #local,
-                                         NON-LOCAL #nonloc ]
-                                     . #comps >,
-                      CONT #cont ] ].
+                                         LOCAL #local,
+                                         NON-LOCAL #nonloc ] . #comps >,
+                       CONT #cont ] ]
+  """
+  --- Clitic doubling
+  !!! when the canonic object, both direct and indirect, is a pronoun (except "usted" and "ello"),
+  clitic doubling is obligatory (e.g. *(me) ha visto a mí; (le) agradezco a usted; dedicaré a ello
+  el siguiente capítulo)
+  - clitic-doubling the first element in the COMPS list (e.g. le ordenó al chico salir)
+  """.
+
 
 1st-clt-doubl-lex-rule := basic-1st-clt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT [ HEAD.CLIT #case,
-                       VAL.CLTS < #clt & clitic-synsem & 
-                                  [ OPT -,
-                                    LOCAL.CAT.HEAD.CASE #case ] 
-                                  . #clts > ],
-    ARG-ST < #argst . < #clt > >,
+                       VAL.CLTS < #clt & clitic-synsem & [ OPT -,
+                                                           LOCAL.CAT.HEAD.CASE #case ] . #clts > ],
+    ARG-ST < #argst, #clt . < #clt > >,
     DTR [ SYNSEM.LOCAL.CAT.VAL.CLTS #clts,
-          ARG-ST #argst ] ].
+          ARG-ST #argst ] ]
+  """
+  
+  """.
+
 
 1st-enclt-doubl-lex-rule := basic-1st-clt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT [ HEAD.CLIT #case,
                        VAL.CLTS < #clts,
-                                  #clt & clitic-synsem & 
-                                  [ OPT -,
-                                    LOCAL.CAT.HEAD.CASE #case ] > ],
-    ARG-ST < #argst . < #clt > >,
+                                  #clt & clitic-synsem & [ OPT -,
+                                                           LOCAL.CAT.HEAD.CASE #case ] > ],
+    ARG-ST < #argst, #clt . < #clt > >,
     DTR [ SYNSEM.LOCAL.CAT.VAL.CLTS < #clts >,
-          ARG-ST #argst ] ].
+          ARG-ST #argst ] ]
+  """
+  
+  """.
 
-; -- clitic-doubling the second element in the COMPS list 
-; e.g. le envió cartas a su padre
+
 2nd-clt-doubl-lex-rule := cliticization-lex-rule &
   [ SYNSEM.LOCAL [ CAT [ HEAD.CLIT #case,
                          VAL [ COMPS < #comp,
                                        [ OPT -,
                                          CLTCZD -,
-				         LOCAL #local,
+                                         LOCAL #local,
                                          NON-LOCAL #nonloc ] >,
-                               CLTS < #clt & clitic-synsem & 
-                                      [ OPT -,
-                                        LOCAL [ CAT.HEAD.CASE #case,
-                                                CONT.HOOK.INDEX.PNG #aff ] ]
-                                      . #clts > ] ],
+                               CLTS < #clt & clitic-synsem & [ OPT -,
+                                                               LOCAL [ CAT.HEAD.CASE #case,
+                                                                       CONT.HOOK.INDEX.PNG #aff ] ] . #clts > ] ],
                    CONT #cont ],
-    ARG-ST < #argst . < #clt > >,
-    DTR [ SYNSEM.LOCAL [ CAT.VAL [ COMPS < #comp, 
+    ARG-ST < #argst, #clt . < #clt > >,
+    DTR [ SYNSEM.LOCAL [ CAT.VAL [ COMPS < #comp,
                                            [ CLTCZD +,
-				             LOCAL #local & [ CAT.HEAD.CASE #case,
+                                             LOCAL #local & [ CAT.HEAD.CASE #case,
                                                               CONT.HOOK.INDEX.PNG #aff ],
                                              NON-LOCAL #nonloc ] >,
                                    CLTS #clts ],
                          CONT #cont ],
-          ARG-ST #argst ] ].
-
+          ARG-ST #argst ] ]
+  """
+  -- clitic-doubling the second element in the COMPS list
+  e.g. le envió cartas a su padre
+  """.
 
 ; -- accusative clitic doubling lexical rule
-; transitive verbs when the DO is a quantifier (e.g. lo sé todo, los conozco a todos) or 
-; takes a numeral (e.g. los conozco a los tres), though we may also find examples like: la ayudo 
-; a mi madre, lo sé que te sientes mal, therefore, I don't specify restrictions when it takes a 
-; single complement
-; !!! dislocated DOs require clitics, unless it's indefinite (e.g. esa película la ví hace tres años, 
-; unos libros compré ayer)
-v_acc-clt-doubl_dlr := 1st-clt-doubl-lex-rule & 
+
+v_acc-clt-doubl_dlr := 1st-clt-doubl-lex-rule &
   [ ALTS.PASS -,
     SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE acc_or_dat,
                                           CONT.HOOK.INDEX.PNG #index ] ] >,
-    DTR.SYNSEM [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local & 
-                                               [ CONT.HOOK.INDEX.PNG #index ] ],... > ] ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local & [ CONT.HOOK.INDEX.PNG #index ] ], ... > ]
+  """
+  -- accusative clitic doubling lexical rule
+  transitive verbs when the DO is a quantifier (e.g. lo sé todo, los conozco a todos) or
+  takes a numeral (e.g. los conozco a los tres), though we may also find examples like: la ayudo
+  a mi madre, lo sé que te sientes mal, therefore, I don't specify restrictions when it takes a
+  single complement
+  !!! dislocated DOs require clitics, unless it's indefinite (e.g. esa película la ví hace tres años,
+  unos libros compré ayer)
+  """.
 
 ; -- dative clitic doubling lexical rule
-; for ditrans verbs (e.g. les compró caramelos a los niños, le dijeron a Juan que viniera)
-; !!! dative clitic doubling is always possible. With ditransitive verbs it's optional 
-; (e.g. (le) dieron el premio al escritor, (le) dijeron a Juan que viniera), it's obligatory with 
-; dativos experimentantes (*(le) gusta el cine a Juan), beneficiarios ((*le) preparó un brevaje al 
-; enfermo, *(le) hice los deberes a los niños), poseedor inelienable (*(le) cortaron las uñas al 
-; niño, *(le) le duele la pierna a Pedro). El clitico dativo de tercera persona puede perder la 
-; marca de plural cuando está reduplicado (no le tiene miedo a las balas)
-v_dat-clt-doubl_dlr := 1st-clt-doubl-lex-rule & 
+
+v_dat-clt-doubl_dlr := 1st-clt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
                                           CONT.HOOK.INDEX.PNG #index ] ] >,
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local & 
-                                             [ CONT.HOOK.INDEX.PNG #index ] ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local & [ CONT.HOOK.INDEX.PNG #index ] ], ... > ]
+  """
+  -- dative clitic doubling lexical rule
+  for ditrans verbs (e.g. les compró caramelos a los niños, le dijeron a Juan que viniera)
+  !!! dative clitic doubling is always possible. With ditransitive verbs it's optional
+  (e.g. (le) dieron el premio al escritor, (le) dijeron a Juan que viniera), it's obligatory with
+  dativos experimentantes (*(le) gusta el cine a Juan), beneficiarios ((*le) preparó un brevaje al
+  enfermo, *(le) hice los deberes a los niños), poseedor inelienable (*(le) cortaron las uñas al
+  niño, *(le) le duele la pierna a Pedro). El clitico dativo de tercera persona puede perder la
+  marca de plural cuando está reduplicado (no le tiene miedo a las balas)
+  """.
 
-v_dat-1st-clt-doubl_dlr := 1st-clt-doubl-lex-rule & 
+
+v_dat-1st-clt-doubl_dlr := 1st-clt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
                                           CONT.HOOK.INDEX.PNG #index ] ] >,
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local & 
-                                             [ CONT.HOOK.INDEX.PNG #index ] ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local & [ CONT.HOOK.INDEX.PNG #index ] ], ... > ]
+  """
+  
+  """.
 
-v_dat-2nd-clt-doubl_dlr := 2nd-clt-doubl-lex-rule & 
+
+v_dat-2nd-clt-doubl_dlr := 2nd-clt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
                                           CONT.HOOK.INDEX.PNG #index ] ] >,
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < synsem, 
-                                     [ LOCAL dative_local & 
-                                             [ CONT.HOOK.INDEX.PNG #index ] ] > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < synsem,
+                                     [ LOCAL dative_local & [ CONT.HOOK.INDEX.PNG #index ] ] > ]
+  """
+  
+  """.
 
 
-; -- multiple clitic doubling
-; ditransitive verbs taking DO and IO (e.g. se los compró al chico) & ditransitive verbs 
-; taking IO and verbal complement (e.g. se lo prometió al chico)
-v_mult-clt-doubl_dlr := 1st-clt-doubl-lex-rule & 
+v_mult-clt-doubl_dlr := 1st-clt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE acc,
-                                          CONT.HOOK.INDEX.PNG #index ] ], 
+                                          CONT.HOOK.INDEX.PNG #index ] ],
                                 [ LOCAL.CAT.HEAD.CASE rflx ] >,
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local & 
-                                             [ CONT.HOOK.INDEX.PNG #index ] ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local & [ CONT.HOOK.INDEX.PNG #index ] ], ... > ]
+  """
+  -- multiple clitic doubling
+  ditransitive verbs taking DO and IO (e.g. se los compró al chico) & ditransitive verbs
+  taking IO and verbal complement (e.g. se lo prometió al chico)
+  """.
 
-v_mult-clt-doubl-prn_dlr := 1st-clt-doubl-lex-rule & 
+
+v_mult-clt-doubl-prn_dlr := 1st-clt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
-                                          CONT.HOOK.INDEX.PNG #index ] ], 
+                                          CONT.HOOK.INDEX.PNG #index ] ],
                                 [ LOCAL.CAT.HEAD.CASE rflx ] >,
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local &
-                                             [ CONT.HOOK.INDEX.PNG #index ] ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local & [ CONT.HOOK.INDEX.PNG #index ] ], ... > ]
+  """
+  
+  """.
 
-v_mult-clt-doubl-imp_dlr := 1st-clt-doubl-lex-rule & 
+
+v_mult-clt-doubl-imp_dlr := 1st-clt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
-                                          CONT.HOOK.INDEX.PNG #index ] ], 
+                                          CONT.HOOK.INDEX.PNG #index ] ],
                                 [ LOCAL.CAT.HEAD.CASE none ] >,
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local &
-                                             [ CONT.HOOK.INDEX.PNG #index ] ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local & [ CONT.HOOK.INDEX.PNG #index ] ], ... > ]
+  """
+  
+  """.
 
-v_2nd-mult-clt-doubl-imp_dlr := 2nd-clt-doubl-lex-rule & 
+
+v_2nd-mult-clt-doubl-imp_dlr := 2nd-clt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE dat,
-                                          CONT.HOOK.INDEX.PNG #index ] ], 
+                                          CONT.HOOK.INDEX.PNG #index ] ],
                                 [ LOCAL.CAT.HEAD.CASE none ] >,
     DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < synsem,
-                                     [ LOCAL dative_local &
-                                             [ CONT.HOOK.INDEX.PNG #index ] ] > ].
+                                     [ LOCAL dative_local & [ CONT.HOOK.INDEX.PNG #index ] ] > ]
+  """
+  
+  """.
 
-; enclitics
-v_mult-enclt-doubl_dlr := 1st-enclt-doubl-lex-rule & 
+
+v_mult-enclt-doubl_dlr := 1st-enclt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL.CAT.HEAD.CASE rflx ],
                                 [ LOCAL [ CAT.HEAD.CASE acc,
                                           CONT.HOOK.INDEX.PNG #index ] ] >,
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local & 
-                                             [ CONT.HOOK.INDEX.PNG #index ] ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local & [ CONT.HOOK.INDEX.PNG #index ] ], ... > ]
+  """
+  enclitics
+  """.
 
-v_mult-enclt-doubl-prn_dlr := 1st-enclt-doubl-lex-rule & 
+
+v_mult-enclt-doubl-prn_dlr := 1st-enclt-doubl-lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL.CAT.HEAD.CASE rflx ],
                                 [ LOCAL [ CAT.HEAD.CASE rflx,
                                           CONT.HOOK.INDEX.PNG #index ] ] >,
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local &
-                                             [ CONT.HOOK.INDEX.PNG #index ] ],... > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL dative_local & [ CONT.HOOK.INDEX.PNG #index ] ], ... > ]
+  """
+  
+  """.
 

--- a/lrtypes.tdl
+++ b/lrtypes.tdl
@@ -587,9 +587,6 @@ v_pron_mrkd_cp_prop-or-ques_dlr := vintr_mrkd_cp_prop-or-ques_lex-rule &
   """.
 
 
-; b)- transitive verbs taking finite/infinitival completive clause (clit. climbing) or indirect questions
-; e.g. ¿has intentado que lo hagan? => ¿lo has intentado hacer tú?,
-;      A y B acordaron no hablar => que no hablarían
 #|
 v_trans_cp_prop-or-ques_dlr := vcomp_vfin_vinf-lex-rule & 
   [ SYNSEM v_trans_cp_prop-or-ques_inf_synsem &
@@ -609,6 +606,7 @@ v_trans_cp_prop-or-ques_dlr := vcomp_vfin_vinf-lex-rule &
           ARG-ST #arg-st ],
     ARG-ST < #arg-st . #clts >  ].
 |#
+
 v_trans_cp_prop-or-ques_dlr := vcomp_vfin_vinf-lex-rule & 
   [ SYNSEM v_trans_cp_prop-or-ques_inf_synsem &
            [ LOCAL [ AGR #agr,
@@ -625,206 +623,224 @@ v_trans_cp_prop-or-ques_dlr := vcomp_vfin_vinf-lex-rule &
                                              NON-LOCAL #nloc ] >,
                                    CLTS < > ] ],
           ARG-ST #arg-st ],
-    ARG-ST < #arg-st . #clts >  ].
+    ARG-ST < #arg-st . #clts >  ]
+"""
+; b)- transitive verbs taking finite/infinitival completive clause (clit. climbing) or indirect questions
+; e.g. ¿has intentado que lo hagan? => ¿lo has intentado hacer tú?,
+;      A y B acordaron no hablar => que no hablarían
+""".
 
-; c)- ditransitive verbs taking finite/infinitival completive clause or indirect questions
-; - si el verbo principal lleva un clítico: si el acusativo incrustado es personal, este no puede 
-; elevarse (*me la permitieron educar), si se trata de no animados, puede elevarse 
-; (me lo permitieron corregir)
-v_ditrans_cp_prop-or-ques_lex-rule := vcomp_vfin_vinf-lex-rule & 
-  [ SYNSEM v_ditrans_cp_prop-or-ques_inf_synsem &
-           [ LOCAL [ AGR #agr,
-                     CAT.VAL [ COMPS < [ LOCAL #local,
-                                         NON-LOCAL #nloc1 ],
-                                       [ OPT -,
-                                         LOCAL [ CAT [ HEAD.KEYS #keys, 
-                                                       VAL.CLTS #clts ],
-                                                 CONT.HOOK.INDEX.SF #sf ],
-                                         NON-LOCAL #nloc ] >,
-                               CLTS #clts ],
-                     CONT.HOOK.XARG #agr ] ],
-    DTR [ SYNSEM v_ditrans_cp_prop-or-ques_fin_synsem &
-                 [ LOCAL.CAT.VAL [ COMPS < [ LOCAL #local,
-                                             NON-LOCAL #nloc1 ],
-                                           [ LOCAL [ CAT.HEAD.KEYS #keys,
-                                                 CONT.HOOK.INDEX.SF #sf ],
-                                             NON-LOCAL #nloc ] >,
-                                   CLTS < > ] ],
+
+v_ditrans_cp_prop-or-ques_lex-rule := vcomp_vfin_vinf-lex-rule &
+  [ SYNSEM v_ditrans_cp_prop-or-ques_inf_synsem & [ LOCAL [ AGR #agr,
+                                                            CAT.VAL [ COMPS < [ LOCAL #local,
+                                                                                NON-LOCAL #nloc1 ],
+                                                                              [ OPT -,
+                                                                                LOCAL [ CAT [ HEAD.KEYS #keys,
+                                                                                              VAL.CLTS #clts ],
+                                                                                        CONT.HOOK.INDEX.SF #sf ],
+                                                                                NON-LOCAL #nloc ] >,
+                                                                      CLTS #clts ],
+                                                            CONT.HOOK.XARG #agr ] ],
+    DTR [ SYNSEM v_ditrans_cp_prop-or-ques_fin_synsem & [ LOCAL.CAT.VAL [ COMPS < [ LOCAL #local,
+                                                                                    NON-LOCAL #nloc1 ],
+                                                                                  [ LOCAL [ CAT.HEAD.KEYS #keys,
+                                                                                            CONT.HOOK.INDEX.SF #sf ],
+                                                                                    NON-LOCAL #nloc ] >,
+                                                                          CLTS < > ] ],
           ARG-ST #arg-st ],
-    ARG-ST < #arg-st . #clts > ].
+    ARG-ST < #arg-st . #clts > ]
+  """
+  c)- ditransitive verbs taking finite/infinitival completive clause or indirect questions
+  - si el verbo principal lleva un clítico: si el acusativo incrustado es personal, este no puede
+  elevarse (*me la permitieron educar), si se trata de no animados, puede elevarse
+  (me lo permitieron corregir)
+  """.
 
-; e.g. prometí a María que volverían temprano => prometí a María volver temprano
+
 v_ditrans_cp_prop-or-ques_sc_dlr := v_ditrans_cp_prop-or-ques_lex-rule &
-  [ SYNSEM.LOCAL.CAT.VAL [ SUBJ  < [ LOCAL.CONT.HOOK.INDEX ref-ind & #ind1 ] >,
+  [ SYNSEM.LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX ref-ind & #ind1 ] >,
                            COMPS < [ OPT #opt ],
                                    [ LOCAL.CONT.HOOK.XARG #ind1 ] > ],
     DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ OPT #opt ],
-                                     [ LOCAL.CAT.HEAD.TAM.MOOD ind ] > ].
+                                     [ LOCAL.CAT.HEAD.TAM.MOOD ind ] > ]
+  """
+  e.g. prometí a María que volverían temprano => prometí a María volver temprano
+  """.
 
-; e.g. ordené a María que volviesen temprano => ordené a María volver temprano
+
 v_ditrans_cp_prop-or-ques_oc_dlr := v_ditrans_cp_prop-or-ques_lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX ref-ind & #ind2 ],
                                  [ LOCAL.CONT.HOOK.XARG #ind2 ] >,
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < synsem,
-                                     [ LOCAL.CAT.HEAD.TAM.MOOD sub ] > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < synsem, [ LOCAL.CAT.HEAD.TAM.MOOD sub ] > ]
+  """
+  e.g. ordené a María que volviesen temprano => ordené a María volver temprano
+  """.
 
 
-; d)- transitive verbs taking DO and marked finite/infinitival completive clause (only verbs of movement)
-v_trans_np_mrkd_cp_prop_lex-rule := vcomp_vfin_vinf-lex-rule & 
-  [ SYNSEM v_trans_np_mrkd_vp_inf_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ NON-LOCAL #nloc1 ],
-                                   [ OPT -,
-                                     LOCAL.CAT.HEAD.KEYS.KEY #prep,
-                                     NON-LOCAL #nloc ] > ],
-    DTR.SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_mov_synsem &
-               [ LOCAL.CAT.VAL.COMPS < [ NON-LOCAL #nloc1 ],
-                                       [ LOCAL.CAT.HEAD.KEYS.KEY #prep,
-                                         NON-LOCAL #nloc ] > ] ].
+v_trans_np_mrkd_cp_prop_lex-rule := vcomp_vfin_vinf-lex-rule &
+  [ SYNSEM v_trans_np_mrkd_vp_inf_synsem & [ LOCAL.CAT.VAL.COMPS < [ NON-LOCAL #nloc1 ],
+                                                                   [ OPT -,
+                                                                     LOCAL.CAT.HEAD.KEYS.KEY #prep,
+                                                                     NON-LOCAL #nloc ] > ],
+    DTR.SYNSEM v_trans_np_mrkd_cp_prop_fin_sub_mov_synsem & [ LOCAL.CAT.VAL.COMPS < [ NON-LOCAL #nloc1 ],
+                                                                                    [ LOCAL.CAT.HEAD.KEYS.KEY #prep,
+                                                                                      NON-LOCAL #nloc ] > ] ]
+  """
+  d)- transitive verbs taking DO and marked finite/infinitival completive clause (only verbs of movement)
+  """.
 
-; -- subject control (no clitic climbing)
-; e.g. la amenazó con ir a la policía
+
 v_trans_np_mrkd_cp_prop_sc_dlr := v_trans_np_mrkd_cp_prop_lex-rule &
-  [ SYNSEM.LOCAL.CAT.VAL [ SUBJ  < [ LOCAL.CONT.HOOK.INDEX ref-ind & #ind1 ] >,
+  [ SYNSEM.LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX ref-ind & #ind1 ] >,
                            COMPS < [ OPT + ],
                                    [ LOCAL [ CAT.VAL.CLTS < >,
                                              CONT.HOOK.XARG #ind1 ] ] >,
                            CLTS #clts ],
     DTR [ SYNSEM.LOCAL.CAT.VAL.CLTS #clts & < >,
           ARG-ST #arg-st ],
-    ARG-ST #arg-st ].
+    ARG-ST #arg-st ]
+  """
+  -- subject control (no clitic climbing)
+  e.g. la amenazó con ir a la policía
+  """.
 
-;; --- two-object control (with VPtrans sharing the same DO with the main clause) (ONLY IN LRs)
-; e.g. envía las camisas a planchar a madrid, llévala a arreglar.
+
 v_trans_np_mrkd_cp_prop_2oc_dlr := v_trans_np_mrkd_cp_prop_lex-rule &
-  [ SYNSEM.LOCAL.CAT.VAL [ COMPS < [ OPT -, LOCAL.CONT.HOOK.INDEX #ctrl ],
+  [ SYNSEM.LOCAL.CAT.VAL [ COMPS < [ OPT -,
+                                     LOCAL.CONT.HOOK.INDEX #ctrl ],
                                    [ LOCAL [ CAT.VAL.CLTS #clt,
-                                             CONT.RELS.LIST < arg12-ev-relation & [ ARG2 #ctrl ],... > ] ] >,
+                                             CONT.RELS.LIST < arg12-ev-relation & [ ARG2 #ctrl ], ... > ] ] >,
                            CLTS #clt ],
     DTR [ SYNSEM.LOCAL.CAT.VAL.CLTS < >,
           ARG-ST #arg-st ],
-    ARG-ST < #arg-st . #clt > ].
+    ARG-ST < #arg-st . #clt > ]
+  """
+  ; --- two-object control (with VPtrans sharing the same DO with the main clause) (ONLY IN LRs)
+   e.g. envía las camisas a planchar a madrid, llévala a arreglar.
+  """.
 
-; f)- transitive symmetric verbs taking marked NP and completive clause (inf/fin) (s_ctrl) / 
-;     pl. subject and completive clause 
-; e.g. A acordó con B no hablar/que no hablarían
-v_sym_trans_cp_prop_mrkd_np_dlr := vcomp_vfin_vinf-lex-rule & 
-  [ SYNSEM v_sym_trans_cp_prop_inf_mrkd_np_synsem &
-           [ LOCAL [ CAT.VAL [ COMPS < #synsem, 
-                                       [ OPT -,
-                                         LOCAL [ CAT.VAL.CLTS #clts ],
-                                         NON-LOCAL #nloc ] >,
-                               CLTS #clts ] ] ],
-    DTR [ SYNSEM v_sym_trans_cp_prop_fin_mrkd_np_synsem &
-                 [ LOCAL.CAT.VAL [ COMPS < #synsem, [ NON-LOCAL #nloc ] >,
-                                   CLTS < > ] ],
+
+v_sym_trans_cp_prop_mrkd_np_dlr := vcomp_vfin_vinf-lex-rule &
+  [ SYNSEM v_sym_trans_cp_prop_inf_mrkd_np_synsem & [ LOCAL.CAT.VAL [ COMPS < #synsem,
+                                                                              [ OPT -,
+                                                                                LOCAL.CAT.VAL.CLTS #clts,
+                                                                                NON-LOCAL #nloc ] >,
+                                                                      CLTS #clts ] ],
+    DTR [ SYNSEM v_sym_trans_cp_prop_fin_mrkd_np_synsem & [ LOCAL.CAT.VAL [ COMPS < #synsem,
+                                                                                    [ NON-LOCAL #nloc ] >,
+                                                                            CLTS < > ] ],
           ARG-ST #arg-st ],
-    ARG-ST < #arg-st . #clts > ].
+    ARG-ST < #arg-st . #clts > ]
+  """
+  f)- transitive symmetric verbs taking marked NP and completive clause (inf/fin) (s_ctrl) /
+      pl. subject and completive clause
+  e.g. A acordó con B no hablar/que no hablarían
+  """.
 
 
-; e)- intransitive symmetric verbs taking marked NP and marked completive clause (inf/fin) (s_ctrl) /
-; pl. subject and marked completive clause 
-; e.g. quedé con ella en ir al cine / quedamos en ir al cine
-v_sym_intr_mrkd_np_mrkd_cp_prop_dlr := vcomp_vfin_vinf-lex-rule & 
-   [ SYNSEM v_sym_intr_mrkd_np_mrkd_cp_prop_inf_synsem &
-            [ LOCAL [ CAT.VAL [ COMPS < #synsem, 
-                                        [ OPT -,
-                                          LOCAL.CAT.VAL.CLTS #clts,
-                                          NON-LOCAL #nloc ] >,
-                                CLTS #clts ] ] ],
-     DTR [ SYNSEM v_sym_intr_mrkd_np_mrkd_cp_prop_fin_synsem &
-                  [ LOCAL.CAT.VAL [ COMPS < #synsem, [ NON-LOCAL #nloc ] >,
-                                    CLTS < > ] ],
-           ARG-ST < #arg-st > ],
-     ARG-ST < #arg-st . #clts > ].
+v_sym_intr_mrkd_np_mrkd_cp_prop_dlr := vcomp_vfin_vinf-lex-rule &
+  [ SYNSEM v_sym_intr_mrkd_np_mrkd_cp_prop_inf_synsem & [ LOCAL.CAT.VAL [ COMPS < #synsem,
+                                                                                  [ OPT -,
+                                                                                    LOCAL.CAT.VAL.CLTS #clts,
+                                                                                    NON-LOCAL #nloc ] >,
+                                                                          CLTS #clts ] ],
+    DTR [ SYNSEM v_sym_intr_mrkd_np_mrkd_cp_prop_fin_synsem & [ LOCAL.CAT.VAL [ COMPS < #synsem,
+                                                                                        [ NON-LOCAL #nloc ] >,
+                                                                                CLTS < > ] ],
+          ARG-ST < #arg-st > ],
+    ARG-ST < #arg-st . #clts > ]
+  """
+  e)- intransitive symmetric verbs taking marked NP and marked completive clause (inf/fin) (s_ctrl) /
+  pl. subject and marked completive clause
+  e.g. quedé con ella en ir al cine / quedamos en ir al cine
+  """.
 
 
-; --- LR type for adjectives taking finite/infinitival completive clause or questions
-; e.g. es partidario (de) que cambien al entrenador/de cambiar al entrenador
-a_mrkd_prop-or-ques_dlr := vfin_vinf-lex-rule & 
-  [ SYNSEM a_mrkd_cp_prop-or-ques_inf_synsem &
-           [ LOCAL [ CAT [ VAL [ CLTS < >,
-                                 SUBJ #subj,
-                                 COMPS < [ OPT -,
-                                           LOCAL [ CAT.HEAD.KEYS #keys, 
-                                                   CONT.HOOK.LTOP #larg ],
-                                           NON-LOCAL #nlocal ] > ] ],
-                     CONT [ RELS <! adj-arg12-relation !>,
-                            HCONS <! qeq & [ HARG #harg,
-                                             LARG #larg ] !> ] ],
-             LKEYS.KEYREL #keyrel & [ ARG2 #harg ] ],
+a_mrkd_prop-or-ques_dlr := vfin_vinf-lex-rule &
+  [ SYNSEM a_mrkd_cp_prop-or-ques_inf_synsem & [ LOCAL [ CAT.VAL [ CLTS < >,
+                                                                   SUBJ #subj,
+                                                                   COMPS < [ OPT -,
+                                                                             LOCAL [ CAT.HEAD.KEYS #keys,
+                                                                                     CONT.HOOK.LTOP #larg ],
+                                                                             NON-LOCAL #nlocal ] > ],
+                                                         CONT [ RELS <! adj-arg12-relation !>,
+                                                                HCONS <! qeq & [ HARG #harg,
+                                                                                 LARG #larg ] !> ] ],
+                                                 LKEYS.KEYREL #keyrel & [ ARG2 #harg ] ],
     DTR [ INFLECTED -,
-          SYNSEM a_mrkd_cp_prop-or-ques_fin_synsem &
-                 [ LOCAL.CAT [ HEAD adj,
-                               VAL [ SUBJ #subj,
-                                     COMPS < [ LOCAL.CAT.HEAD.KEYS #keys,
-                                               NON-LOCAL #nlocal ] > ] ],
-                   LKEYS.KEYREL #keyrel ] ] ].
+          SYNSEM a_mrkd_cp_prop-or-ques_fin_synsem & [ LOCAL.CAT [ HEAD adj,
+                                                                   VAL [ SUBJ #subj,
+                                                                         COMPS < [ LOCAL.CAT.HEAD.KEYS #keys,
+                                                                                   NON-LOCAL #nlocal ] > ] ],
+                                                       LKEYS.KEYREL #keyrel ] ] ]
+  """
+  --- LR type for adjectives taking finite/infinitival completive clause or questions
+  e.g. es partidario (de) que cambien al entrenador/de cambiar al entrenador
+  """.
 
 
-; --- LR types for nouns 
-
-; a)- taking finite/infinitival completive clause & interrogative clauses 
-; e.g. una ventaja (de) que no llueva es que no hay ocasión de perder el paraguas => 
-;      otra ventaja de viajar en tren es que se pueden cargar más bultos   
-n_cp_inf_dlr := vfin_vinf-lex-rule & 
-  [ SYNSEM n_prop-or-ques_inf_synsem &
-           [ LOCAL [ CAT.VAL [ CLTS < >,
-                               SUBJ #subj,
-                               COMPS < [ OPT -,
-                                         LOCAL [ CAT.HEAD.KEYS #keys, 
-                                                 CONT.HOOK [ LTOP #larg,
-                                                             INDEX.SF #sf ] ],
-                                          NON-LOCAL #nlocal ] > ],
-                     CONT [ RELS #rels & <! noun-arg1-relation !>,
-                            HCONS <! qeq & [ HARG #harg,
-                                             LARG #larg ] !> ] ],
-             LKEYS.KEYREL #keyrel & [ ARG1 #harg ] ],
+n_cp_inf_dlr := vfin_vinf-lex-rule &
+  [ SYNSEM n_prop-or-ques_inf_synsem & [ LOCAL [ CAT.VAL [ CLTS < >,
+                                                           SUBJ #subj,
+                                                           COMPS < [ OPT -,
+                                                                     LOCAL [ CAT.HEAD.KEYS #keys,
+                                                                             CONT.HOOK [ LTOP #larg,
+                                                                                         INDEX.SF #sf ] ],
+                                                                     NON-LOCAL #nlocal ] > ],
+                                                 CONT [ RELS #rels & <! noun-arg1-relation !>,
+                                                        HCONS <! qeq & [ HARG #harg,
+                                                                         LARG #larg ] !> ] ],
+                                         LKEYS.KEYREL #keyrel & [ ARG1 #harg ] ],
     DTR [ INFLECTED -,
-          SYNSEM n_prop-or-ques_fin_synsem &
-                 [ LOCAL [ CAT [ HEAD noun,
-                                 VAL [ SUBJ #subj,
-                                       COMPS < [ LOCAL [ CAT.HEAD.KEYS #keys,
-                                                         CONT.HOOK.INDEX.SF #sf ],
-                                                 NON-LOCAL #nlocal ] > ] ],
-                           CONT.RELS #rels ],
-                   LKEYS.KEYREL #keyrel ] ] ].
+          SYNSEM n_prop-or-ques_fin_synsem & [ LOCAL [ CAT [ HEAD noun,
+                                                             VAL [ SUBJ #subj,
+                                                                   COMPS < [ LOCAL [ CAT.HEAD.KEYS #keys,
+                                                                                     CONT.HOOK.INDEX.SF #sf ],
+                                                                             NON-LOCAL #nlocal ] > ] ],
+                                                       CONT.RELS #rels ],
+                                               LKEYS.KEYREL #keyrel ] ] ]
+  """
+  --- LR types for nouns
+  a)- taking finite/infinitival completive clause & interrogative clauses
+  e.g. una ventaja (de) que no llueva es que no hay ocasión de perder el paraguas =>
+       otra ventaja de viajar en tren es que se pueden cargar más bultos
+  """.
 
-; b)- taking PPde + finite completive clause/VPinf_ctrl
-; e.g. la necesidad (de la empresa) (de) que lleguen a un acuerdo/de llegar a un acuerdo 
-n_pp-vp_dlr := vfin_vinf-lex-rule & 
-  [ SYNSEM n_ppde_prop-inf_synsem &
-           [ LOCAL [ CAT.VAL [ CLTS < >,
-                               SUBJ #subj,
-                               COMPS < #synsem & [ LOCAL.CONT.HOOK.INDEX #ctrl ],
-                                       [ OPT -,
-                                         LOCAL [ CAT.HEAD.KEYS #keys,
-                                                 CONT.HOOK [ LTOP #larg,
-                                                             XARG #ctrl,
-                                                             INDEX.SF #sf ] ],
-                                        NON-LOCAL #nlocal ] > ],
-                     CONT [ RELS #rels & <! noun-arg12-relation !>,
-                            HCONS <! qeq & [ HARG #harg,
-                                             LARG #larg ] !> ] ],
-             LKEYS.KEYREL #keyrel & [ ARG2 #harg ] ],
+
+n_pp-vp_dlr := vfin_vinf-lex-rule &
+  [ SYNSEM n_ppde_prop-inf_synsem & [ LOCAL [ CAT.VAL [ CLTS < >,
+                                                        SUBJ #subj,
+                                                        COMPS < #synsem & [ LOCAL.CONT.HOOK.INDEX #ctrl ],
+                                                                [ OPT -,
+                                                                  LOCAL [ CAT.HEAD.KEYS #keys,
+                                                                          CONT.HOOK [ LTOP #larg,
+                                                                                      XARG #ctrl,
+                                                                                      INDEX.SF #sf ] ],
+                                                                  NON-LOCAL #nlocal ] > ],
+                                              CONT [ RELS #rels & <! noun-arg12-relation !>,
+                                                     HCONS <! qeq & [ HARG #harg,
+                                                                      LARG #larg ] !> ] ],
+                                      LKEYS.KEYREL #keyrel & [ ARG2 #harg ] ],
     DTR [ INFLECTED -,
-          SYNSEM n_ppde_prop-fin_synsem & 
-                 [ LOCAL [ CAT [ HEAD noun,
-                                 VAL [ SUBJ #subj,
-                                       COMPS < #synsem,
-                                               [ LOCAL [ CAT.HEAD.KEYS #keys,
-                                                         CONT.HOOK.INDEX.SF #sf ],
-                                                 NON-LOCAL #nlocal ] > ] ],
-                           CONT.RELS #rels ],
-                   LKEYS.KEYREL #keyrel ] ] ].
+          SYNSEM n_ppde_prop-fin_synsem & [ LOCAL [ CAT [ HEAD noun,
+                                                          VAL [ SUBJ #subj,
+                                                                COMPS < #synsem,
+                                                                        [ LOCAL [ CAT.HEAD.KEYS #keys,
+                                                                                  CONT.HOOK.INDEX.SF #sf ],
+                                                                          NON-LOCAL #nlocal ] > ] ],
+                                                    CONT.RELS #rels ],
+                                            LKEYS.KEYREL #keyrel ] ] ]
+  """
+  b)- taking PPde + finite completive clause/VPinf_ctrl
+  e.g. la necesidad (de la empresa) (de) que lleguen a un acuerdo/de llegar a un acuerdo
+  """.
 
 
-; --- LR types for participles
-
-; -- LR type building pastparts for passive constructions
-ppart-lex-rule := const-ltol-rule & 
+ppart-lex-rule := const-ltol-rule &
   [ ALTS.PASS -,
     SYNSEM [ PUNCT #punct,
-             SLSHD #slshd, 
+             SLSHD #slshd,
              LOCAL [ CAT [ MC #mc,
                            HEAD verb & [ AUX -,
                                          VFORM part,
@@ -832,7 +848,7 @@ ppart-lex-rule := const-ltol-rule &
                                          TAM #tam & [ MOOD #mood ],
                                          KEYS.KEY #key,
                                          MOD < >,
-                                         LSYNSEM #lsynsem ], 
+                                         LSYNSEM #lsynsem ],
                            VAL.SPR < [ OPT +,
                                        LOCAL [ CAT [ HEAD.KEYS.KEY degree_rel,
                                                      MC na ],
@@ -846,20 +862,19 @@ ppart-lex-rule := const-ltol-rule &
                             HCONS #hcons,
                             RELS #rels & [ LIST < [ ARG0 #index & [ E.MOOD #mood ] ], ... > ] ],
                      CTXT #ctxt ],
-            LKEYS #lkeys,
-            NON-LOCAL #nonloc ],
+             LKEYS #lkeys,
+             NON-LOCAL #nonloc ],
     DTR [ INFLECTED +,
           ALTS.PASS +,
           SYNSEM [ PUNCT #punct & [ RPUNCT no_punct ],
-                   SLSHD #slshd, 
+                   SLSHD #slshd,
                    LOCAL [ CAT [ MC #mc,
-                                 HEAD verb &
-                                      [ PRD non-prd,
-                                        VFORM part,
-                                        VOICE active,
-                                        TAM #tam,
-                                        KEYS.KEY #key,
-                                        LSYNSEM #lsynsem ],
+                                 HEAD verb & [ PRD non-prd,
+                                               VFORM part,
+                                               VOICE active,
+                                               TAM #tam,
+                                               KEYS.KEY #key,
+                                               LSYNSEM #lsynsem ],
                                  VAL.SPR < > ],
                            CONT [ HOOK [ LTOP #hand,
                                          XARG #xarg ],
@@ -868,68 +883,75 @@ ppart-lex-rule := const-ltol-rule &
                            CTXT #ctxt ],
                    LKEYS #lkeys,
                    NON-LOCAL #nonloc ] ],
-    C-CONT.RELS <! !> ].
+    C-CONT.RELS <! !> ]
+  """
+  --- LR types for participles
+  -- LR type building pastparts for passive constructions
+  """.
 
-; -- with transitive verbs
+
 v_pastpart-trans_dlr := ppart-lex-rule &
   [ SYNSEM.LOCAL [ CAT [ HEAD [ INV -,
-                                PRD prd & [ COPV ser ] ],         
-                         VAL [ SUBJ < unexpressed & 
-                                      [ OPT +, 
-                                        LOCAL np_nom_local & 
-                                              [ CONT #objcont & [ HOOK.INDEX #arg2 ] ], 
-                                        NON-LOCAL #ononloc ] >,
+                                PRD prd & [ COPV ser ] ],
+                         VAL [ SUBJ < unexpressed & [ OPT +,
+                                                      LOCAL np_nom_local & [ CONT #objcont & [ HOOK.INDEX #arg2 ] ],
+                                                      NON-LOCAL #ononloc ] >,
                                COMPS < [ OPT +,
-                                         LOCAL mrkd_np_local & 
-                                               [ CAT.HEAD.KEYS.KEY _por_p_sel_rel, 
-                                                 CONT.HOOK.INDEX #subjind ],
-                                         NON-LOCAL #snonloc ]. #comps >,
+                                         LOCAL mrkd_np_local & [ CAT.HEAD.KEYS.KEY _por_p_sel_rel,
+                                                                 CONT.HOOK.INDEX #subjind ],
+                                         NON-LOCAL #snonloc ] . #comps >,
                                CLTS #clts ] ],
                    CONT.RELS.LIST < [ ARG2 #arg2 ], ... > ],
     DTR [ INFLECTED +,
           SYNSEM.LOCAL.CAT.VAL [ SUBJ < [ LOCAL np_nom_local & [ CONT.HOOK.INDEX #subjind ],
                                           NON-LOCAL #snonloc ] >,
                                  COMPS [ FIRST [ LOCAL np_acc_local & [ CONT #objcont ],
-                                                 NON-LOCAL #ononloc ], 
+                                                 NON-LOCAL #ononloc ],
                                          REST #comps ],
-                                 CLTS #clts ] ] ].
+                                 CLTS #clts ] ] ]
+  """
+  -- with transitive verbs
+  """.
 
-; For "construcciones de participio absoluto". Verb (transitive/unaccusative) passive participle + non-pronominal NP (subject)
-; e.g. acabada *ella/la reunión, todos se pusieron a trabajar. 
+
 v_pastpart-unacc_dlr := ppart-lex-rule &
   [ SYNSEM.LOCAL [ AGR #agr,
                    CAT [ HEAD [ INV +,
                                 PRD non-prd ],
-                         VAL [ SUBJ < [ OPT +, 
-                                        LOCAL #slocal & np_nom_local & 
-                                              [ AGR #agr & [ PRONTYPE not_pron ] ], 
+                         VAL [ SUBJ < [ OPT +,
+                                        LOCAL #slocal & np_nom_local & [ AGR #agr & [ PRONTYPE not_pron ] ],
                                         NON-LOCAL #snonloc & [ SLASH 0-dlist ] ] >,
                                COMPS #comps,
                                CLTS #clts ] ] ],
     DTR [ INFLECTED +,
-          SYNSEM unacc_lt & 
-                 [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL #slocal,
-                                            NON-LOCAL #snonloc ] >,
-                                   COMPS #comps,
-                                   CLTS #clts ] ] ] ].
+          SYNSEM unacc_lt & [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL #slocal,
+                                                       NON-LOCAL #snonloc ] >,
+                                              COMPS #comps,
+                                              CLTS #clts ] ] ] ]
+  """
+  For "construcciones de participio absoluto". Verb (transitive/unaccusative) passive participle + non-pronominal NP (subject)
+  e.g. acabada *ella/la reunión, todos se pusieron a trabajar.
+  """.
 
-; for intransitive pronominal verbs
+
 v_pastpart-pron_dlr := ppart-lex-rule &
   [ SYNSEM.LOCAL [ AGR #agr,
                    CAT [ HEAD [ INV +,
                                 PRD non-prd ],
-                         VAL [ SUBJ < [ OPT +, 
-                                        LOCAL #slocal & np_nom_local & 
-                                              [ AGR #agr & [ PRONTYPE not_pron ] ], 
+                         VAL [ SUBJ < [ OPT +,
+                                        LOCAL #slocal & np_nom_local & [ AGR #agr & [ PRONTYPE not_pron ] ],
                                         NON-LOCAL #snonloc & [ SLASH 0-dlist ] ] >,
                                COMPS #comps,
                                CLTS < > ] ] ],
     DTR [ INFLECTED +,
-          SYNSEM v_intrans_synsem &
-                 [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL #slocal,
-                                            NON-LOCAL #snonloc ] >,
-                                   COMPS #comps,
-                                   CLTS < [ LOCAL.CAT.HEAD.CASE rflx ] > ] ] ] ].
+          SYNSEM v_intrans_synsem & [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL #slocal,
+                                                               NON-LOCAL #snonloc ] >,
+                                                      COMPS #comps,
+                                                      CLTS < [ LOCAL.CAT.HEAD.CASE rflx ] > ] ] ] ]
+  """
+  for intransitive pronominal verbs
+  """.
+
 
 ; --- 2.2. LR type building pastpart in predicative position co-occuring with "estar"
 ; e.g. la sopa está comida (*por los chicos)

--- a/lrtypes.tdl
+++ b/lrtypes.tdl
@@ -1090,28 +1090,22 @@ v_pastpart-attr-intr_dlr := const-ltol-rule  &
     C-CONT.RELS <! !> ].
 |#
 
-; --- LR types building indef. adjectives
-; for "evaluativos" quantifiers (otro, mucho/poco, bastante,...). These may co-occur in 
-; predicative constructions (e.g. sus problemas eran demasiados) or as pre-nominal adjectives 
-; (e.g. sus demasiados problemas).
-indef-adj-lex-rule := tmt-lex-rule & phrase-or-lexrule & 
+
+indef-adj-lex-rule := tmt-lex-rule & phrase-or-lexrule &
   [ STEM #stem,
     INFLECTED #infl,
     SYNSEM [ PUNCT #punct,
-             SLSHD #slshd, 
+             SLSHD #slshd,
              LOCAL [ AGR #agr,
                      CAT [ POSTHEAD -,
                            MC na,
-                           HEAD adj &
-                                [ KEYS.KEY #pred,
-                                  TAM #tam,
-                                  MOD < [ LOCAL intersective-mod & 
-                                           [ CAT [ HEAD noun & [ KEYS.KEY non_elliptical_n_rel ],
-                                                   VAL [ SPR < expressed-synsem & 
-                                                               [ LOCAL.CAT.HEAD.KEYS.KEY quant_or_deg_rel ] >,
-                                                         SUBJ < >,
-                                                         SPEC < > ] ],
-                                             CONT.HOOK.INDEX #agr ] ] > ],
+                           HEAD adj & [ KEYS.KEY #pred,
+                                        TAM #tam,
+                                        MOD < [ LOCAL intersective-mod & [ CAT [ HEAD noun & [ KEYS.KEY non_elliptical_n_rel ],
+                                                                                 VAL [ SPR < expressed-synsem & [ LOCAL.CAT.HEAD.KEYS.KEY quant_or_deg_rel ] >,
+                                                                                       SUBJ < >,
+                                                                                       SPEC < > ] ],
+                                                                           CONT.HOOK.INDEX #agr ] ] > ],
                            VAL [ SPR < >,
                                  SUBJ < >,
                                  COMPS < >,
@@ -1119,63 +1113,81 @@ indef-adj-lex-rule := tmt-lex-rule & phrase-or-lexrule &
                      CONT [ HOOK [ LTOP #ltop,
                                    INDEX #arg0,
                                    XARG #agr ],
-                            RELS <! #key & adj-arg1-relation & 
-                                    [ ARG0.E #tam ] !> ] ],
-            LKEYS.KEYREL #key & [ PRED #pred,
-                                  LBL #ltop,
-                                  ARG0 #arg0,
-                                  ARG1 #agr ],
-            NON-LOCAL #nonloc ],
+                            RELS <! #key & adj-arg1-relation & [ ARG0.E #tam ] !> ] ],
+             LKEYS.KEYREL #key & [ PRED #pred,
+                                   LBL #ltop,
+                                   ARG0 #arg0,
+                                   ARG1 #agr ],
+             NON-LOCAL #nonloc ],
     DTR [ STEM #stem,
           INFLECTED #infl,
-          SYNSEM [ SLSHD #slshd, 
+          SYNSEM [ SLSHD #slshd,
                    PUNCT #punct & [ RPUNCT no_punct ],
                    LOCAL [ AGR #agr,
                            CAT.HEAD det,
                            CONT.RELS <! relation, relation !> ],
                    LKEYS.ALTKEYREL.PRED card_or_undef_q_rel & #pred,
                    NON-LOCAL #nonloc & non-local-none ] ],
-    C-CONT.RELS <! !> ].
+    C-CONT.RELS <! !> ]
+  """
+  --- LR types building indef. adjectives
+  for "evaluativos" quantifiers (otro, mucho/poco, bastante,...). These may co-occur in
+  predicative constructions (e.g. sus problemas eran demasiados) or as pre-nominal adjectives
+  (e.g. sus demasiados problemas).
+  """.
 
 
-; otro
 a_indef-otro_dlr := indef-adj-lex-rule &
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD.KEYS.ALTKEY pre_otro_q_rel,
                                               VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY pre_otro_q_rel ] > ] ] >,
-    DTR.SYNSEM.LKEYS.ALTKEYREL.PRED otro_q_rel ].
+    DTR.SYNSEM.LKEYS.ALTKEYREL.PRED otro_q_rel ]
+  """
+  otro
+  """.
 
-; mucho
+
 a_indef-mucho_dlr := indef-adj-lex-rule &
-  [ SYNSEM.LOCAL.CAT.HEAD.MOD < [LOCAL.CAT [ HEAD.KEYS.ALTKEY pre_otro_q_rel,
-                                             VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY pre_much_or_poc_q_rel ] > ] ] >,
-    DTR.SYNSEM.LKEYS.ALTKEYREL.PRED mucho_q_rel ].
+  [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD.KEYS.ALTKEY pre_otro_q_rel,
+                                              VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY pre_much_or_poc_q_rel ] > ] ] >,
+    DTR.SYNSEM.LKEYS.ALTKEYREL.PRED mucho_q_rel ]
+  """
+  mucho
+  """.
 
-; poco
+
 a_indef-poco_dlr := indef-adj-lex-rule &
-  [ SYNSEM.LOCAL.CAT.HEAD.MOD < [LOCAL.CAT [ HEAD.KEYS.ALTKEY pre_otro_q_rel,
-                                             VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY pre_much_or_poc_q_rel ] > ] ] >,
-    DTR.SYNSEM.LKEYS.ALTKEYREL.PRED poco_q_rel ].
+  [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD.KEYS.ALTKEY pre_otro_q_rel,
+                                              VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY pre_much_or_poc_q_rel ] > ] ] >,
+    DTR.SYNSEM.LKEYS.ALTKEYREL.PRED poco_q_rel ]
+  """
+  poco
+  """.
 
-; varios, bastante, demasiado, numeroso, determinado, distinto, diverso, escaso, cierto, raro
+
 a_indef-undf-q_dlr := indef-adj-lex-rule &
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD.KEYS.ALTKEY pre_otro_q_rel,
                                               VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY def_q_rel ] > ] ] >,
-    DTR.SYNSEM.LKEYS.ALTKEYREL.PRED undef_q_rel ].
+    DTR.SYNSEM.LKEYS.ALTKEYREL.PRED undef_q_rel ]
+  """
+  varios, bastante, demasiado, numeroso, determinado, distinto, diverso, escaso, cierto, raro
+  """.
 
-; cardinals
+
 a_indef-nu-card_dlr := indef-adj-lex-rule &
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD.KEYS.ALTKEY pre_otro_q_rel,
                                               VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY pre_card_q_rel ] > ] ] >,
     DTR [ INFLECTED -,
-          SYNSEM.LKEYS.ALTKEYREL.PRED card_q_rel ] ].
+          SYNSEM.LKEYS.ALTKEYREL.PRED card_q_rel ] ]
+  """
+  cardinals
+  """.
 
 
-; --- LR types for determiners/quantifiers following the noun
-quant-or-det_postn_lex-rule := tmt-lex-rule & phrase-or-lexrule & 
+quant-or-det_postn_lex-rule := tmt-lex-rule & phrase-or-lexrule &
   [ STEM #stem,
     INFLECTED #infl,
     ALTS #alts,
-    SYNSEM [ SLSHD #slshd, 
+    SYNSEM [ SLSHD #slshd,
              MODIFIED #modified,
              PUNCT #punct,
              LOCAL [ COORD #coord,
@@ -1187,11 +1199,11 @@ quant-or-det_postn_lex-rule := tmt-lex-rule & phrase-or-lexrule &
                                  SUBJ < >,
                                  COMPS < >,
                                  CLTS < > ] ] ],
-            NON-LOCAL #nonloc ],
+             NON-LOCAL #nonloc ],
     DTR [ STEM #stem,
           INFLECTED #infl & +,
           ALTS #alts,
-          SYNSEM [ SLSHD #slshd, 
+          SYNSEM [ SLSHD #slshd,
                    MODIFIED #modified,
                    PUNCT #punct,
                    LOCAL [ COORD #coord,
@@ -1199,29 +1211,34 @@ quant-or-det_postn_lex-rule := tmt-lex-rule & phrase-or-lexrule &
                            COORD-STRAT #coord-strat,
                            CAT.HEAD det ],
                    NON-LOCAL #nonloc & non-local-none ] ],
-    C-CONT.RELS <! !> ].
+    C-CONT.RELS <! !> ]
+  """
+  --- LR types for determiners/quantifiers following the noun
+  """.
+
 
 det_postn_lex-rule := quant-or-det_postn_lex-rule &
   [ SYNSEM [ LOCAL [ AGR #agr,
                      CAT [ MC na,
-                           HEAD adj &
-                              [ TAM #tam,
-                                KEYS.KEY #pred,
-                                MOD < [ LOCAL intersective-mod & 
-                                              [ CAT [ HEAD noun,
-                                                      VAL [ SUBJ < >,
-                                                            SPEC < > ] ],
-                                                CONT.HOOK.INDEX #agr ] ] > ] ],
+                           HEAD adj & [ TAM #tam,
+                                        KEYS.KEY #pred,
+                                        MOD < [ LOCAL intersective-mod & [ CAT [ HEAD noun,
+                                                                                 VAL [ SUBJ < >,
+                                                                                       SPEC < > ] ],
+                                                                           CONT.HOOK.INDEX #agr ] ] > ] ],
                      CONT [ HOOK [ INDEX #arg0,
                                    LTOP #ltop,
                                    XARG #agr ],
-                            RELS <! #key & adj-arg1-relation & 
-                                    [ ARG0.E #tam ] !> ] ],
-            LKEYS.KEYREL #key & [ PRED #pred,
-                                  ARG0 #arg0,
-                                  LBL #ltop,
-                                  ARG1 #agr ] ],
-    DTR.SYNSEM.LOCAL.AGR #agr ].
+                            RELS <! #key & adj-arg1-relation & [ ARG0.E #tam ] !> ] ],
+             LKEYS.KEYREL #key & [ PRED #pred,
+                                   ARG0 #arg0,
+                                   LBL #ltop,
+                                   ARG1 #agr ] ],
+    DTR.SYNSEM.LOCAL.AGR #agr ]
+  """
+  
+  """.
+
 
 quant_postn_lex-rule := quant-or-det_postn_lex-rule &
   [ SYNSEM [ LOCAL [ AGR #agr,
@@ -1232,24 +1249,38 @@ quant_postn_lex-rule := quant-or-det_postn_lex-rule &
                          CAT [ POSTHEAD -,
                                HEAD #head ],
                          CONT #cont ],
-                 LKEYS #lkey ] ].
+                 LKEYS #lkey ] ]
+  """
+  
+  """.
 
-; - demonstratives: when they follow the noun, they are modifiers and they require 
-; the definite article (e.g. la canción esa me gustó)
+
 d_pstn-demons_dlr := det_postn_lex-rule &
   [ SYNSEM [ LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD.KEYS.ALTKEY _el_q_rel,
                                                 VAL.SPR < [ LOCAL.CAT.HEAD.KEYS.KEY quant_rel ] > ] ] >,
              LKEYS.KEYREL.PRED dem_adj_rel ],
     DTR.SYNSEM [ LOCAL.CAT.POSTHEAD -,
-                 LKEYS.KEYREL.PRED dem_q_rel ] ].
+                 LKEYS.KEYREL.PRED dem_q_rel ] ]
+  """
+  - demonstratives: when they follow the noun, they are modifiers and they require
+  the definite article (e.g. la canción esa me gustó)
+  """.
 
-; - alguno/ninguno always follow the noun (e.g. no tengo miedo alguno) and 
-; alguna/os/as, ninguna may precede and follow the noun
+
 d_pstn-idf-algun_dlr := quant_postn_lex-rule &
-  [ DTR.SYNSEM.LKEYS.KEYREL.PRED _alguno_q_rel ].
+  [ DTR.SYNSEM.LKEYS.KEYREL.PRED _alguno_q_rel ]
+  """
+  - alguno/ninguno always follow the noun (e.g. no tengo miedo alguno) and
+  alguna/os/as, ninguna may precede and follow the noun
+  """.
+
 
 d_pstn-idf-ningun_dlr := quant_postn_lex-rule &
-  [ DTR.SYNSEM.LKEYS.KEYREL.PRED _ninguno_q_rel ].
+  [ DTR.SYNSEM.LKEYS.KEYREL.PRED _ninguno_q_rel ]
+  """
+  
+  """.
+
 
 
 ; --- LR types for partitive pronouns/quantifying nouns
@@ -1515,70 +1546,88 @@ comp-enclt-lex-rule := basic-comp-clt-lex-rule &
 
 ; -- accusative complement cliticization
 
-; transitive verbs taking NPs (e.g. lo come, lo invierte (en bolsa), los amenaza con llorar, los pone 
-; en el tren,...) and finite completive clauses and/or VPinf (e.g. lo quiere) or interrogative clauses 
-; (e.g. lo sabe) and for impersonal transitive verbs 
-; With ditransitive verbs, you can't cliticize only the DO (e.g. *lo di a María, *lo dije a Juan). 
-; !!! indefinite DO can't be cliticized (e.g. ¿compraste flores? *Sí, las compré; *¿A quién lo viste?), 
-; but I can't control this.
-v_acc-cmp-clt_dlr := comp-clt-lex-rule & 
-  [ ALTS [ RCP -, RFX -, PASS - ],
+
+v_acc-cmp-clt_dlr := comp-clt-lex-rule &
+  [ ALTS [ RCP -,
+           RFX -,
+           PASS - ],
     SYNSEM.LOCAL [ CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE acc_or_dat,
                                             CONT.HOOK.INDEX #ind2 ] ] >,
                    CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
-    DTR.SYNSEM transitive_verb_synsem  & 
-               [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.CASE acc ],... > ] ].
+    DTR.SYNSEM transitive_verb_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.CASE acc ], ... > ] ]
+  """
+  transitive verbs taking NPs (e.g. lo come, lo invierte (en bolsa), los amenaza con llorar, los pone
+  en el tren,...) and finite completive clauses and/or VPinf (e.g. lo quiere) or interrogative clauses
+  (e.g. lo sabe) and for impersonal transitive verbs
+  With ditransitive verbs, you can't cliticize only the DO (e.g. *lo di a María, *lo dije a Juan).
+  !!! indefinite DO can't be cliticized (e.g. ¿compraste flores? *Sí, las compré; *¿A quién lo viste?),
+  but I can't control this.
+  """.
 
-; predicative complements, e.g. la considero muy capaz
-v_acc-cmp-clt-vprd_dlr := comp-clt-lex-rule & 
-  [ ALTS [ RCP -, RFX -, PASS - ],
+
+v_acc-cmp-clt-vprd_dlr := comp-clt-lex-rule &
+  [ ALTS [ RCP -,
+           RFX -,
+           PASS - ],
     SYNSEM.LOCAL.CAT.VAL.CLTS < [ LOCAL [ CAT.HEAD.CASE acc_or_dat,
                                           CONT.HOOK.INDEX #ind2 ] ] >,
-    DTR.SYNSEM v_np-xp_synsem & 
-               [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.CASE acc ], 
-                                       [ LOCAL.CONT.HOOK.XARG #ind2 ] > ] ].
+    DTR.SYNSEM v_np-xp_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.CASE acc ],
+                                                        [ LOCAL.CONT.HOOK.XARG #ind2 ] > ] ]
+  """
+  predicative complements, e.g. la considero muy capaz
+  """.
 
-; reciprocal verbs
- v_recip_dlr := comp-clt-lex-rule & 
-   [ ALTS [ RCP -, RFX -, PASS - ],
-     SYNSEM.LOCAL [ AGR.PNG #agr & [ PN plur ],
-                    CAT.VAL [ SUBJ < [ LOCAL.AGR.PNG #agr ] >,
-                              CLTS < [ LOCAL [ CAT.HEAD.CASE rcp,
-                                               CONT.HOOK.INDEX #ind2 & 
-                                                               [ PNG #agr,
-                                                                 PRONTYPE std_or_recip_or_refl_pron ] ] ] > ],
-                    CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
-     DTR [ ALTS.RCP +,
-           SYNSEM transitive_verb_synsem &
-                  [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ],... > ] ] ].
 
-; reflexive verbs
- v_reflex_dlr := comp-clt-lex-rule & 
-   [ ALTS [ RCP -, RFX -, PASS - ],
-     SYNSEM.LOCAL [ AGR.PNG #agr,
-                    CAT.VAL [ SUBJ < [ LOCAL.AGR.PNG #agr ] >,
-                              CLTS < [ LOCAL [ CAT.HEAD.CASE rflx,
-                                               CONT.HOOK.INDEX #ind2 & 
-                                                               [ PNG #agr,
-                                                                 PRONTYPE std_or_recip_or_refl_pron ] ] ] > ],
-                    CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
-     DTR [ ALTS.RFX +,
-           SYNSEM transitive_verb_synsem &
-                  [ LOCAL [ CAT.VAL.COMPS < [ LOCAL np_acc_local ],... > ] ] ] ].
+v_recip_dlr := comp-clt-lex-rule &
+  [ ALTS [ RCP -,
+           RFX -,
+           PASS - ],
+    SYNSEM.LOCAL [ AGR.PNG #agr & [ PN plur ],
+                   CAT.VAL [ SUBJ < [ LOCAL.AGR.PNG #agr ] >,
+                             CLTS < [ LOCAL [ CAT.HEAD.CASE rcp,
+                                              CONT.HOOK.INDEX #ind2 & [ PNG #agr,
+                                                                        PRONTYPE std_or_recip_or_refl_pron ] ] ] > ],
+                   CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
+    DTR [ ALTS.RCP +,
+          SYNSEM transitive_verb_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ], ... > ] ] ]
+  """
+  reciprocal verbs
+  """.
 
-; reflexive verbs with predicative complements, e.g. se considero muy capaz
-v_reflex-vprd_dlr := comp-clt-lex-rule & 
-   [ ALTS [ RCP -, RFX -, PASS - ],
-     SYNSEM.LOCAL [ AGR.PNG #agr,
-                    CAT.VAL [ SUBJ < [ LOCAL.AGR.PNG #agr ] >,
-                              CLTS < [ LOCAL [ CAT.HEAD.CASE rflx,
-                                               CONT.HOOK.INDEX #ind2 & 
-                                                               [ PNG #agr,
-                                                                 PRONTYPE std_or_recip_or_refl_pron ] ] ] > ] ],
-     DTR [ ALTS.RFX +,
-           SYNSEM v_np-xp_synsem & 
-                  [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ], 
-                                       [ LOCAL.CONT.HOOK.XARG #ind2 ] > ] ] ].
+
+v_reflex_dlr := comp-clt-lex-rule &
+  [ ALTS [ RCP -,
+           RFX -,
+           PASS - ],
+    SYNSEM.LOCAL [ AGR.PNG #agr,
+                   CAT.VAL [ SUBJ < [ LOCAL.AGR.PNG #agr ] >,
+                             CLTS < [ LOCAL [ CAT.HEAD.CASE rflx,
+                                              CONT.HOOK.INDEX #ind2 & [ PNG #agr,
+                                                                        PRONTYPE std_or_recip_or_refl_pron ] ] ] > ],
+                   CONT.RELS.LIST.FIRST.ARG2 #ind2 ],
+    DTR [ ALTS.RFX +,
+          SYNSEM transitive_verb_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ], ... > ] ] ]
+  """
+  reflexive verbs
+  """.
+
+
+v_reflex-vprd_dlr := comp-clt-lex-rule &
+  [ ALTS [ RCP -,
+           RFX -,
+           PASS - ],
+    SYNSEM.LOCAL [ AGR.PNG #agr,
+                   CAT.VAL [ SUBJ < [ LOCAL.AGR.PNG #agr ] >,
+                             CLTS < [ LOCAL [ CAT.HEAD.CASE rflx,
+                                              CONT.HOOK.INDEX #ind2 & [ PNG #agr,
+                                                                        PRONTYPE std_or_recip_or_refl_pron ] ] ] > ] ],
+    DTR [ ALTS.RFX +,
+          SYNSEM v_np-xp_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ],
+                                                          [ LOCAL.CONT.HOOK.XARG #ind2 ] > ] ] ]
+  """
+  reflexive verbs with predicative complements, e.g. se considero muy capaz
+  """.
+
 
 
 ; -- dative complement cliticization

--- a/lrtypes.tdl
+++ b/lrtypes.tdl
@@ -31,18 +31,18 @@ basic-valence-alt-lex-rule := const-ltol-rule &
                                        SPR #spr ] ], 
                            CTXT #ctxt ] ] ] ].
 
-; --- LR types for symmetric predicates
-basic-sym_pred-lex-rule := basic-valence-alt-lex-rule & 
+
+basic-sym_pred-lex-rule := basic-valence-alt-lex-rule &
   [ ALTS [ RCP #rcp,
            RFX #rfx ],
     SYNSEM [ SLSHD #slshd,
              LOCAL [ CAT [ MC #mc,
-                           HEAD.LSYNSEM #lsynsem, 
+                           HEAD.LSYNSEM #lsynsem,
                            VAL.CLTS #clts ],
                      CONT [ HOOK [ LTOP #ltop,
                                    INDEX #index ],
-			    RELS.LIST.FIRST #keyrel,
-			    HCONS #hcons ] ],
+                            RELS.LIST.FIRST #keyrel,
+                            HCONS #hcons ] ],
              NON-LOCAL #nonlocal,
              LKEYS.KEYREL #keyrel & [ PRED #pred,
                                       LBL #ltop,
@@ -52,23 +52,25 @@ basic-sym_pred-lex-rule := basic-valence-alt-lex-rule &
                  RFX #rfx ],
           SYNSEM [ SLSHD #slshd,
                    LOCAL [ CAT [ MC #mc,
-                                 HEAD verb & [ LSYNSEM #lsynsem, 
+                                 HEAD verb & [ LSYNSEM #lsynsem,
                                                CLIT none ],
                                  VAL.CLTS #clts ],
                            CONT [ HOOK [ LTOP #ltop,
                                          INDEX #index ],
-			          HCONS #hcons ] ],
+                                  HCONS #hcons ] ],
                    NON-LOCAL #nonlocal,
                    LKEYS.KEYREL.PRED #pred ] ],
-    C-CONT.RELS <! !> ].
+    C-CONT.RELS <! !> ]
+  """
+  --- LR types for symmetric predicates
+  """.
 
-; -- symmetric verbs taking marked NP / plural (or coord.) subject 
-sym_pred_pl_subj-lex-rule := basic-sym_pred-lex-rule & 
+
+sym_pred_pl_subj-lex-rule := basic-sym_pred-lex-rule &
   [ ALTS [ PASS -,
            IMPERS - ],
     SYNSEM [ LOCAL [ AGR #agr,
-                     CAT.VAL [ SUBJ < [ LOCAL np_nom_local & 
-                                              [ AGR #agr & [ PNG.PN plur ] ],
+                     CAT.VAL [ SUBJ < [ LOCAL np_nom_local & [ AGR #agr & [ PNG.PN plur ] ],
                                         NON-LOCAL #nlocal ] >,
                                COMPS #rest ],
                      CONT.HOOK.XARG #agr ],
@@ -76,90 +78,95 @@ sym_pred_pl_subj-lex-rule := basic-sym_pred-lex-rule &
     DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL mrkd_np_local,
                                        NON-LOCAL #nlocal & [ SLASH 0-dlist,
                                                              REL 0-dlist,
-                                                             QUE 0-dlist ] ]
-                                     . #rest > ].
+                                                             QUE 0-dlist ] ] . #rest > ]
+  """
+  -- symmetric verbs taking marked NP / plural (or coord.) subject
+  """.
 
-; e.g. conversar (to chat) (A conversa con B/A y B conversan)
+
 v_-_subj-plur-sym_dlr := sym_pred_pl_subj-lex-rule &
   [ ALTS.VCALT -,
     SYNSEM v_strict_intrans_synsem,
-    DTR.SYNSEM v_sym_intr_mrkd_np_synsem ].
+    DTR.SYNSEM v_sym_intr_mrkd_np_synsem ]
+  """
+  e.g. conversar (to chat) (A conversa con B/A y B conversan)
+  """.
 
-; e.g. quedé con ella en no hablar/en que no hablarían / quedamos en no hablar/en que no hablarían
+
 v_pp_e-cp-p-subj-plur-sym_dlr := sym_pred_pl_subj-lex-rule &
   [ ALTS.VCALT #vfalt,
-    SYNSEM v_intr_mrkd_cp_prop_fin_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ NON-LOCAL [ SLASH 0-dlist,
-                                                 REL 0-dlist,
-                                                 QUE 0-dlist ] ] >,
-             LKEYS.KEYREL.ARG2 #arg2 ],
+    SYNSEM v_intr_mrkd_cp_prop_fin_synsem & [ LOCAL.CAT.VAL.COMPS < [ NON-LOCAL [ SLASH 0-dlist,
+                                                                                  REL 0-dlist,
+                                                                                  QUE 0-dlist ] ] >,
+                                              LKEYS.KEYREL.ARG2 #arg2 ],
     DTR [ ALTS.VCALT #vfalt,
-          SYNSEM v_sym_intr_mrkd_np_mrkd_cp_prop_fin_synsem &
-                 [ LKEYS.KEYREL.ARG2 #arg2 ] ] ].
+          SYNSEM v_sym_intr_mrkd_np_mrkd_cp_prop_fin_synsem & [ LKEYS.KEYREL.ARG2 #arg2 ] ] ]
+  """
+  e.g. quedé con ella en no hablar/en que no hablarían / quedamos en no hablar/en que no hablarían
+  """.
 
-; e.g. A acordó con B no hablar/que no hablarían -> A y B acordaron no hablar/que no hablarían
+
 v_cp_p-subj-plur-sym_dlr := sym_pred_pl_subj-lex-rule &
   [ ALTS.VCALT #vfalt,
-    SYNSEM v_trans_cp_prop-or-ques_fin_synsem &
-           [ LOCAL.CAT.VAL.COMPS < [ NON-LOCAL [ SLASH 0-dlist,
-                                                 REL 0-dlist,
-                                                 QUE 0-dlist ] ] >,
-             LKEYS.KEYREL.ARG2 #arg2 ],
+    SYNSEM v_trans_cp_prop-or-ques_fin_synsem & [ LOCAL.CAT.VAL.COMPS < [ NON-LOCAL [ SLASH 0-dlist,
+                                                                                      REL 0-dlist,
+                                                                                      QUE 0-dlist ] ] >,
+                                                  LKEYS.KEYREL.ARG2 #arg2 ],
     DTR [ ALTS.VCALT #vfalt,
-          SYNSEM v_sym_trans_cp_prop_fin_mrkd_np_synsem &
-                 [ LKEYS.KEYREL.ARG2 #arg2 ] ] ].
+          SYNSEM v_sym_trans_cp_prop_fin_mrkd_np_synsem & [ LKEYS.KEYREL.ARG2 #arg2 ] ] ]
+  """
+  e.g. A acordó con B no hablar/que no hablarían -> A y B acordaron no hablar/que no hablarían
+  """.
 
-; -- transitive symmetric verbs taking DO and marked NP / plural (or coord.) Subj and DO
-; e.g. Ambos grupos comparten un fondo genético común.
-v_np_subj-plur-sym_dlr := basic-sym_pred-lex-rule & 
+
+v_np_subj-plur-sym_dlr := basic-sym_pred-lex-rule &
   [ ALTS [ PASS +,
            VCALT -,
            IMPERS + ],
-    SYNSEM v_trans_np_synsem &
-           [ LOCAL [ AGR #agr,
-                     CAT.VAL [ SUBJ < [ LOCAL np_nom_local & 
-                                              [ AGR #agr & [ PNG.PN plur ] ],
-                                        NON-LOCAL #nlocal ] >,
-                               COMPS < #comp > ],
-                     CONT.HOOK.XARG #agr ],
-             LKEYS.KEYREL.ARG1 #agr ],
-    DTR.SYNSEM v_sym_trans_np_mrkd_np_pl_subj_synsem &
-               [ LOCAL [ AGR #agr,
-                         CAT.VAL.COMPS < #comp, 
-                                         [ LOCAL mrkd_np_local,
-                                           NON-LOCAL #nlocal & 
-                                                     [ SLASH 0-dlist,
-                                                       REL 0-dlist,
-                                                       QUE 0-dlist ] ] >, 
-                         CONT.RELS <! arg123-ev-relation !> ] ] ].
+    SYNSEM v_trans_np_synsem & [ LOCAL [ AGR #agr,
+                                         CAT.VAL [ SUBJ < [ LOCAL np_nom_local & [ AGR #agr & [ PNG.PN plur ] ],
+                                                            NON-LOCAL #nlocal ] >,
+                                                   COMPS < #comp > ],
+                                         CONT.HOOK.XARG #agr ],
+                                 LKEYS.KEYREL.ARG1 #agr ],
+    DTR.SYNSEM v_sym_trans_np_mrkd_np_pl_subj_synsem & [ LOCAL [ AGR #agr,
+                                                                 CAT.VAL.COMPS < #comp,
+                                                                                 [ LOCAL mrkd_np_local,
+                                                                                   NON-LOCAL #nlocal & [ SLASH 0-dlist,
+                                                                                                         REL 0-dlist,
+                                                                                                         QUE 0-dlist ] ] >,
+                                                                 CONT.RELS <! arg123-ev-relation !> ] ] ]
+  """
+  -- transitive symmetric verbs taking DO and marked NP / plural (or coord.) Subj and DO
+  e.g. Ambos grupos comparten un fondo genético común.
+  """.
 
-; -- transitive symmetric verbs taking DO and marked NP / plural (or coord.) DO
-; e.g. polarización que confrontará [la docencia a/con la investigación/la docencia y la investigación]
-v_np_plur-sym_dlr := basic-sym_pred-lex-rule & 
+
+v_np_plur-sym_dlr := basic-sym_pred-lex-rule &
   [ ALTS [ PASS +,
            VCALT -,
            IMPERS + ],
-    SYNSEM v_trans_np_synsem &
-           [ LOCAL [ AGR #agr,
-                     CAT.VAL [ SUBJ #subj,
-                               COMPS < [ OPT -,
-                                         LOCAL np_acc_local & 
-                                               [ CONT.HOOK.INDEX ref-ind & #arg2 & [ PNG.PN plur ] ],
-                                         NON-LOCAL #nlocal ] > ],
-                     CONT.HOOK.XARG #agr ],
-             LKEYS.KEYREL.ARG2 #arg2 ],
-    DTR.SYNSEM v_sym_trans_np_mrkd_np_pl_do_synsem &
-               [ LOCAL [ AGR #agr,
-                         CAT.VAL [ SUBJ #subj,
-                                   COMPS < [ LOCAL np_acc_local,
-                                             NON-LOCAL #nlocal & [ SLASH 0-dlist,
-                                                                   REL 0-dlist,
-                                                                   QUE 0-dlist ] ], 
-                                           [ LOCAL mrkd_np_local ] > ],
-                         CONT.RELS <! arg123-ev-relation !> ] ] ].
+    SYNSEM v_trans_np_synsem & [ LOCAL [ AGR #agr,
+                                         CAT.VAL [ SUBJ #subj,
+                                                   COMPS < [ OPT -,
+                                                             LOCAL np_acc_local & [ CONT.HOOK.INDEX ref-ind & #arg2 & [ PNG.PN plur ] ],
+                                                             NON-LOCAL #nlocal ] > ],
+                                         CONT.HOOK.XARG #agr ],
+                                 LKEYS.KEYREL.ARG2 #arg2 ],
+    DTR.SYNSEM v_sym_trans_np_mrkd_np_pl_do_synsem & [ LOCAL [ AGR #agr,
+                                                               CAT.VAL [ SUBJ #subj,
+                                                                         COMPS < [ LOCAL np_acc_local,
+                                                                                   NON-LOCAL #nlocal & [ SLASH 0-dlist,
+                                                                                                         REL 0-dlist,
+                                                                                                         QUE 0-dlist ] ],
+                                                                                 [ LOCAL mrkd_np_local ] > ],
+                                                               CONT.RELS <! arg123-ev-relation !> ] ] ]
+  """
+  -- transitive symmetric verbs taking DO and marked NP / plural (or coord.) DO
+  e.g. polarización que confrontará [la docencia a/con la investigación/la docencia y la investigación]
+  """.
 
 
-; --- LR types for impersonal forms
 basic-se-constructions-lex-rule := basic-valence-alt-lex-rule &
   [ ALTS [ PASS -,
            VCALT -,
@@ -173,147 +180,154 @@ basic-se-constructions-lex-rule := basic-valence-alt-lex-rule &
                                 MOD #mod,
                                 LSYNSEM #lsynsem ],
                      CONT #cont ],
-            LKEYS #lkeys,
-            NON-LOCAL #nonlocal ],
-    DTR.SYNSEM [ LOCAL [ CAT.HEAD verb & 
-                                  [ AUX #aux,
-                                    VFORM #vform,
-                                    TAM #tam,
-                                    PRD #prd,
-                                    KEYS #keys,
-                                    MOD #mod,
-                                    LSYNSEM #lsynsem ],
+             LKEYS #lkeys,
+             NON-LOCAL #nonlocal ],
+    DTR.SYNSEM [ LOCAL [ CAT.HEAD verb & [ AUX #aux,
+                                           VFORM #vform,
+                                           TAM #tam,
+                                           PRD #prd,
+                                           KEYS #keys,
+                                           MOD #mod,
+                                           LSYNSEM #lsynsem ],
                          CONT #cont ],
                  LKEYS #lkeys,
                  NON-LOCAL #nonlocal ],
-    C-CONT.RELS <! !> ].
+    C-CONT.RELS <! !> ]
+  """
+  --- LR types for impersonal forms
+  """.
 
-; -- Impersonal constructions with "se"
-; - In this constructions the verb appears in 3sg and the complement is the arg2, (this is generally an 
-; animate entity singular o plural (e.g. a los hijos no se les escoge), or inanimate with verbs taking 
-; marked NP (e.g. de las drogas se depende fácilmente))
-; - They co-occur with: transitive and ditransitive verbs where the DO may or may not be introduced by "a" 
-; (e.g. se reclutó (a los) soldados, se envió un regalo a los novios), verbs taking marked NPs (e.g. se 
-; cree en milagros), perception verbs (e.g. se ve caer las gotas de agua), causative verbs (e.g. se 
-; hizo/dejó a Núria asistir a la reunión), verbos taking reduced clauses (e.g. se considera invalidas 
-; las pruebas) and unaccusative verbs (e.g. siempre se llega tarde)
+
 v_impers-se_dlr := basic-se-constructions-lex-rule &
   [ ALTS.IMPERS -,
-    SYNSEM [ SLSHD #slshd, 
+    SYNSEM [ SLSHD #slshd,
              LOCAL [ AGR #agr & [ PNG.PN 3sg ],
-                   CAT [ HEAD [ VOICE #voice,
-                                INV #inv,
-                                CLIT #case ], 
-                         VAL [ SUBJ #subj & < unexpressed >,
-                               COMPS #comps,
-                               CLTS < #clt & clitic-synsem &
-                                      [ LOCAL [ AGR.PRONTYPE impers,
-                                                CAT.HEAD.CASE #case & none ] ] > ] ] ] ],
+                     CAT [ HEAD [ VOICE #voice,
+                                  INV #inv,
+                                  CLIT #case ],
+                           VAL [ SUBJ #subj & < unexpressed >,
+                                 COMPS #comps,
+                                 CLTS < #clt & clitic-synsem & [ LOCAL [ AGR.PRONTYPE impers,
+                                                                         CAT.HEAD.CASE #case & none ] ] > ] ] ] ],
     DTR [ INFLECTED -,
           ALTS.IMPERS +,
-          SYNSEM [ SLSHD #slshd, 
+          SYNSEM [ SLSHD #slshd,
                    LOCAL [ AGR #agr,
-                         CAT [ HEAD [ VFORM fin,
-                                      VOICE #voice,
-                                      INV #inv ],
-                               VAL [ SUBJ #subj, 
-                                     COMPS #comps,
-                                     CLTS < > ] ] ] ],
+                           CAT [ HEAD [ VFORM fin,
+                                        VOICE #voice,
+                                        INV #inv ],
+                                 VAL [ SUBJ #subj,
+                                       COMPS #comps,
+                                       CLTS < > ] ] ] ],
           ARG-ST #arg-st ],
     ARG-ST < #arg-st . #clt >,
-    C-CONT.HCONS <! !> ].
+    C-CONT.HCONS <! !> ]
+  """
+  -- Impersonal constructions with "se"
+  - In this constructions the verb appears in 3sg and the complement is the arg2, (this is generally an
+  animate entity singular o plural (e.g. a los hijos no se les escoge), or inanimate with verbs taking
+  marked NP (e.g. de las drogas se depende fácilmente))
+  - They co-occur with: transitive and ditransitive verbs where the DO may or may not be introduced by "a"
+  (e.g. se reclutó (a los) soldados, se envió un regalo a los novios), verbs taking marked NPs (e.g. se
+  cree en milagros), perception verbs (e.g. se ve caer las gotas de agua), causative verbs (e.g. se
+  hizo/dejó a Núria asistir a la reunión), verbos taking reduced clauses (e.g. se considera invalidas
+  las pruebas) and unaccusative verbs (e.g. siempre se llega tarde)
+  """.
 
-
-; -- passive/medium constructions with "se"
-; -- passive constructions
-; - tienen como sujeto gramatical el objeto nocional del verbo, este suele aparecer pospuesto, 
-; y puede ser indeterminado (sin determinado, con determinantes indefinidos y numerales 
-; (se quemaron los bosques para acabar con la plaga, se venden casas)). Cuando aparece antepuesto 
-; es foco, y puede ser indeterminado.
-; - a veces no concuerda el sujeto con el verbo, como con los SN plurales sin det. (se vende pisos) 
-; pero deben concordar con SN determinados con art. definidos o demostrativos, cuando el suj. se 
-; antepone, ... (pp. 1676)
-; - pueden aparecer con todo tipo de verbos transitivos, ditransitivos y verbos que alternan 
-; usos transitivos e intransitivos en los que en la oración transitiva con suj. explícito 
-; correspondiente el CD de persona (anim) no va introducido por "a" (i.e. no lleva determinante 
-; o este es indef. (e.g. se necesitan (unos/varios/muchos...) estudiantes)), verbos con complementos 
-; oracionales (e.g. se cree que, se afirma que...), y verbos con objetos oracionales infinitivos 
-; (e.g. se prohíbe fumar). 
-; -- medium constructions
-; - no muestran restricciones aspectuales
-; - expresa una acción verbal que 'afecta' al sujeto gramatical
-; - tienen como sujeto gramatical el objeto nocional del verbo, este suele aparecer antepuesto,  
-; desempeñando la función de tema o tópico, tiene el rasgo determinado (aparece con art. 
-; definidos, demostrativos, etc.), y es un ente generalmente inanimado, singular o plural 
-; (en verano los bosques se queman fácilmente) o animado plural (los hijos no se escogen). 
-; - con verbos transitivos cuyo sujeto nocional tiene el papel temático de agente y no puede especificarse  
-; - con verbos con valor imperfectivo (i.e. presente o pretérito imperfecto).
-; -- also for events of change of state (or location) having external cause (with 'se')
-; e.g. Juan rompió la mesa (causative) / la mesa se rompió (unaccusative)
 
 passive-lex-rule := basic-se-constructions-lex-rule &
   [ ALTS.IMPERS -,
-    SYNSEM [ SLSHD +, 
+    SYNSEM [ SLSHD +,
              LOCAL [ AGR.PNG.PN #pn,
-                   CAT [ HEAD verb & 
-                              [ INV +,
-                                AUX -,
-                                VOICE #voice,
-                                VFORM #vform,
-                                TAM.MOOD #mood,
-                                CLIT #case ], 
-                         VAL.CLTS #clt & 
-                                  < clitic-synsem & 
-                                    [ OPT -,
-                                      LOCAL [ AGR.PRONTYPE impers,
-                                              CAT.HEAD.CASE #case & none,
-                                              CONT.HOOK.INDEX ref-ind ] ] > ],
-                   CONT.HOOK.INDEX.E.MOOD #mood ] ],
+                     CAT [ HEAD verb & [ INV +,
+                                         AUX -,
+                                         VOICE #voice,
+                                         VFORM #vform,
+                                         TAM.MOOD #mood,
+                                         CLIT #case ],
+                           VAL.CLTS #clt & < clitic-synsem & [ OPT -,
+                                                               LOCAL [ AGR.PRONTYPE impers,
+                                                                       CAT.HEAD.CASE #case & none,
+                                                                       CONT.HOOK.INDEX ref-ind ] ] > ],
+                     CONT.HOOK.INDEX.E.MOOD #mood ] ],
     DTR [ INFLECTED -,
           SYNSEM.LOCAL [ AGR.PNG.PN #pn & 3per,
-                         CAT [ HEAD verb &
-                                    [ AUX -,
-                                      VOICE #voice,
-                                      VFORM #vform ],
+                         CAT [ HEAD verb & [ AUX -,
+                                             VOICE #voice,
+                                             VFORM #vform ],
                                VAL [ SUBJ < [ LOCAL np_nom_local ] >,
                                      CLTS < > ] ] ],
           ARG-ST #arg-st ],
-    ARG-ST < #arg-st . #clt > ].
+    ARG-ST < #arg-st . #clt > ]
+  """
+  -- passive/medium constructions with "se"
+  -- passive constructions
+  - tienen como sujeto gramatical el objeto nocional del verbo, este suele aparecer pospuesto,
+  y puede ser indeterminado (sin determinado, con determinantes indefinidos y numerales
+  (se quemaron los bosques para acabar con la plaga, se venden casas)). Cuando aparece antepuesto
+  es foco, y puede ser indeterminado.
+  - a veces no concuerda el sujeto con el verbo, como con los SN plurales sin det. (se vende pisos)
+  pero deben concordar con SN determinados con art. definidos o demostrativos, cuando el suj. se
+  antepone, ... (pp. 1676)
+  - pueden aparecer con todo tipo de verbos transitivos, ditransitivos y verbos que alternan
+  usos transitivos e intransitivos en los que en la oración transitiva con suj. explícito
+  correspondiente el CD de persona (anim) no va introducido por "a" (i.e. no lleva determinante
+  o este es indef. (e.g. se necesitan (unos/varios/muchos...) estudiantes)), verbos con complementos
+  oracionales (e.g. se cree que, se afirma que...), y verbos con objetos oracionales infinitivos
+  (e.g. se prohíbe fumar).
+  -- medium constructions
+  - no muestran restricciones aspectuales
+  - expresa una acción verbal que 'afecta' al sujeto gramatical
+  - tienen como sujeto gramatical el objeto nocional del verbo, este suele aparecer antepuesto,
+  desempeñando la función de tema o tópico, tiene el rasgo determinado (aparece con art.
+  definidos, demostrativos, etc.), y es un ente generalmente inanimado, singular o plural
+  (en verano los bosques se queman fácilmente) o animado plural (los hijos no se escogen).
+  - con verbos transitivos cuyo sujeto nocional tiene el papel temático de agente y no puede especificarse
+  - con verbos con valor imperfectivo (i.e. presente o pretérito imperfecto).
+  -- also for events of change of state (or location) having external cause (with 'se')
+  e.g. Juan rompió la mesa (causative) / la mesa se rompió (unaccusative)
+  """.
 
-v_trans-passive-lex-rule := passive-lex-rule & 
-  [ SYNSEM.LOCAL.CAT.VAL.SUBJ < synsem &
-                                [ LOCAL.CONT #objcont & [ HOOK.INDEX #objind ],
-                                  NON-LOCAL #ononloc ] >,
+
+v_trans-passive-lex-rule := passive-lex-rule &
+  [ SYNSEM.LOCAL.CAT.VAL.SUBJ < synsem & [ LOCAL.CONT #objcont & [ HOOK.INDEX #objind ],
+                                           NON-LOCAL #ononloc ] >,
     DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT #objcont & [ HOOK.INDEX #objind ],
-                                       NON-LOCAL #ononloc ],... > ].
+                                       NON-LOCAL #ononloc ], ... > ]
+  """
+  
+  """.
 
 
-; transitive verbs (e.g. se necesitan (unos/varios/muchos...) estudiantes)
-; - to avoid overgeneration with causatives, this rule only applies to not causative verbs
 v_np_passive-se_dlr := v_trans-passive-lex-rule &
   [ SYNSEM.LOCAL [ AGR #ind,
-                   CAT.VAL [ SUBJ < [ LOCAL np_nom_local & 
-                                            [ AGR #ind,
-                                              CAT.HEAD.KEYS [ KEY nom_rel ],
-                                              CONT.HOOK.INDEX ref-ind ] ] >,
+                   CAT.VAL [ SUBJ < [ LOCAL np_nom_local & [ AGR #ind,
+                                                             CAT.HEAD.KEYS.KEY nom_rel,
+                                                             CONT.HOOK.INDEX ref-ind ] ] >,
                              COMPS #comps ] ],
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ]. #comps > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL np_acc_local ] . #comps > ]
+  """
+  transitive verbs (e.g. se necesitan (unos/varios/muchos...) estudiantes)
+  - to avoid overgeneration with causatives, this rule only applies to not causative verbs
+  """.
 
-; verbs taking finite completive clauses (e.g. se cree que fue así, se
-; afirma que...) and/or VPinf (e.g. se prohíbe fumar, se podían ver
-; las hojas del árbol) 
-; trec 'DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SF
-; prop' per cubrir 'no se sabe dónde puede llegar'
+
 v_cp_passive-se_dlr := v_trans-passive-lex-rule &
   [ SYNSEM.LOCAL.CAT [ HEAD.INV +,
                        VAL [ SUBJ < [ LOCAL.CAT #cat,
                                       NON-LOCAL.SLASH 0-dlist ] >,
                              COMPS < > ] ],
-    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL v_local & 
-                                             [ CAT #cat ] ] > ].
+    DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL v_local & [ CAT #cat ] ] > ]
+  """
+  verbs taking finite completive clauses (e.g. se cree que fue así, se
+  afirma que...) and/or VPinf (e.g. se prohíbe fumar, se podían ver
+  las hojas del árbol)
+  trec 'DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SF
+  prop' per cubrir 'no se sabe dónde puede llegar'
+  """.
 
-; ditransitive verbs (e.g. se le prometió ir/que irían)
-v_ppa-cp_passive-se_dlr := passive-lex-rule & 
+
+v_ppa-cp_passive-se_dlr := passive-lex-rule &
   [ SYNSEM.LOCAL.CAT [ HEAD.INV +,
                        VAL [ SUBJ < [ OPT -,
                                       LOCAL [ CAT #cat,
@@ -321,16 +335,13 @@ v_ppa-cp_passive-se_dlr := passive-lex-rule &
                                       NON-LOCAL #ononloc & [ SLASH 0-dlist ] ] >,
                              COMPS < #comp > ] ],
     DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < #comp & [ LOCAL dative_local ],
-                                     [ LOCAL v_local & 
-                                             [ CAT #cat,
-                                               CONT #objcont & [ HOOK.INDEX #objind & [ SF prop ] ] ],
-                                       NON-LOCAL #ononloc ] > ].
+                                     [ LOCAL v_local & [ CAT #cat,
+                                                         CONT #objcont & [ HOOK.INDEX #objind & [ SF prop ] ] ],
+                                       NON-LOCAL #ononloc ] > ]
+  """
+  ditransitive verbs (e.g. se le prometió ir/que irían)
+  """.
 
-
-
-; --- LR types for finite clause / VPinf alternation
-;; OZ 2023-01-09 This used to inherit from basic-lex-rule.
-;; I am not sure whether that was intentional and I don't have treebanks setup yet to be able to test well.
 
 vfin_vinf-lex-rule := tmt-lex-rule & phrase-or-lexrule &
   [ STEM #stem,
@@ -338,7 +349,7 @@ vfin_vinf-lex-rule := tmt-lex-rule & phrase-or-lexrule &
     ALTS [ VCALT -,
            PASS #pass,
            IMPERS #impers ],
-    SYNSEM [ SLSHD #slshd, 
+    SYNSEM [ SLSHD #slshd,
              MODIFIED #modified,
              PUNCT #punct,
              LOCAL [ COORD #coord,
@@ -356,7 +367,7 @@ vfin_vinf-lex-rule := tmt-lex-rule & phrase-or-lexrule &
           ALTS [ VCALT +,
                  PASS #pass,
                  IMPERS #impers ],
-          SYNSEM [ SLSHD #slshd, 
+          SYNSEM [ SLSHD #slshd,
                    MODIFIED #modified,
                    PUNCT #punct & [ RPUNCT no_punct ],
                    LOCAL [ COORD #coord,
@@ -369,7 +380,13 @@ vfin_vinf-lex-rule := tmt-lex-rule & phrase-or-lexrule &
                                        SPEC #spec ] ],
                            CTXT #ctxt ],
                    NON-LOCAL #nonloc ] ],
-    C-CONT.RELS <! !> ].
+    C-CONT.RELS <! !> ]
+  """
+   --- LR types for finite clause / VPinf alternation
+  ; OZ 2023-01-09 This used to inherit from basic-lex-rule.
+  ; I am not sure whether that was intentional and I don't have treebanks setup yet to be able to test well.
+  """.
+
 
 
 ; --- LR types for verbs 
@@ -415,97 +432,103 @@ subj_vfin_vinf-lex-rule := vfin_vinf-lex-rule &
 
 ; a)- intransitive verbs taking finite/infinitival completive clause subjects and IO 
 
-; - "verbos de incumbencia": when the IO is present, it is interpreted as the subject 
-; of the infinitive, when it is not, the construction has a generic interpretation.
-; e.g. me conviene que vengas => (me) conviene ir
-v_subj_cp_prop_inf_or_fin_io*_dlr := subj_vfin_vinf-lex-rule & 
-  [ SYNSEM v_subj_cp_prop_inf_io_synsem &
-           [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
-                             COMPS < [ OPT +,
-                                       LOCAL #lcomp & [ CONT.HOOK.INDEX #ind ],
-                                       NON-LOCAL #nlcomp ] > ] ],
-    DTR.SYNSEM v_subj_cp_prop_inf_or_fin_io*_synsem &
-               [ LOCAL.CAT.VAL.COMPS < [ LOCAL #lcomp,
-                                         NON-LOCAL #nlcomp ] > ] ].
 
-; - with "parecer" and psychological verbs the IO is obligatory when it takes a VPinf subject
-; e.g. me gustó que viniese => *(me) gusta llorar
-v_subj_cp_prop_inf_or_fin_sub_io_dlr := subj_vfin_vinf-lex-rule & 
-  [ SYNSEM v_subj_cp_prop_inf_io_synsem &
-           [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
-                             COMPS < [ OPT -,
-                                       LOCAL #lcomp & [ CONT.HOOK.INDEX #ind ],
-                                       NON-LOCAL #nlcomp ] > ] ],
-    DTR.SYNSEM v_subj_cp_prop_fin_sub_io*_synsem &
-               [ LOCAL.CAT.VAL.COMPS < [ LOCAL #lcomp,
-                                         NON-LOCAL #nlcomp ] > ] ].
+v_subj_cp_prop_inf_or_fin_io*_dlr := subj_vfin_vinf-lex-rule &
+  [ SYNSEM v_subj_cp_prop_inf_io_synsem & [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
+                                                            COMPS < [ OPT +,
+                                                                      LOCAL #lcomp & [ CONT.HOOK.INDEX #ind ],
+                                                                      NON-LOCAL #nlcomp ] > ] ],
+    DTR.SYNSEM v_subj_cp_prop_inf_or_fin_io*_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL #lcomp,
+                                                                                NON-LOCAL #nlcomp ] > ] ]
+  """
+  - "verbos de incumbencia": when the IO is present, it is interpreted as the subject
+  of the infinitive, when it is not, the construction has a generic interpretation.
+  e.g. me conviene que vengas => (me) conviene ir
+  """.
 
 
-; b)- Intransitive verbs taking Vfin/VPinf subject and marked NP (no control)
-; e.g. (el) que las clases sean malas repercute en los alumnos => llegar tarde a clase repercute en los alumnos
-v_subj_cp_prop_inf_or_fin_intr_mrkd_np_dlr := subj_vfin_vinf-lex-rule & 
-  [ SYNSEM v_subj_cp_prop_inf_intr_mrkd_np_synsem &
-           [ LOCAL.CAT.VAL.COMPS #comps ],
-    DTR.SYNSEM v_subj_cp_prop_fin_intr_mrkd_np_synsem &
-               [ LOCAL.CAT.VAL.COMPS #comps ] ].
+v_subj_cp_prop_inf_or_fin_sub_io_dlr := subj_vfin_vinf-lex-rule &
+  [ SYNSEM v_subj_cp_prop_inf_io_synsem & [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
+                                                            COMPS < [ OPT -,
+                                                                      LOCAL #lcomp & [ CONT.HOOK.INDEX #ind ],
+                                                                      NON-LOCAL #nlcomp ] > ] ],
+    DTR.SYNSEM v_subj_cp_prop_fin_sub_io*_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL #lcomp,
+                                                                             NON-LOCAL #nlcomp ] > ] ]
+  """
+  - with "parecer" and psychological verbs the IO is obligatory when it takes a VPinf subject
+  e.g. me gustó que viniese => *(me) gusta llorar
+  """.
 
 
-; c)- Intransitive verbs taking Vfin/VPinf subject, opt. PPa and marked NP (o_control)
-; e.g. de nada (le) sirve que luchen =>  de nada (le) sirve luchar
-v_subj_cp_prop_inf_or_fin_intr_io*_mrkd_np_dlr := subj_vfin_vinf-lex-rule & 
-  [ SYNSEM v_subj_cp_prop_inf_intr_io*_mrkd_np_synsem &
-           [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
-                             COMPS #comps & < [ LOCAL.CONT.HOOK.INDEX #ind ],... > ] ],
-    DTR.SYNSEM v_subj_cp_prop_fin_intr_io*_mrkd_np_synsem &
-               [ LOCAL.CAT.VAL.COMPS #comps ] ].
+v_subj_cp_prop_inf_or_fin_intr_mrkd_np_dlr := subj_vfin_vinf-lex-rule &
+  [ SYNSEM v_subj_cp_prop_inf_intr_mrkd_np_synsem & [ LOCAL.CAT.VAL.COMPS #comps ],
+    DTR.SYNSEM v_subj_cp_prop_fin_intr_mrkd_np_synsem & [ LOCAL.CAT.VAL.COMPS #comps ] ]
+  """
+  b)- Intransitive verbs taking Vfin/VPinf subject and marked NP (no control)
+  e.g. (el) que las clases sean malas repercute en los alumnos => llegar tarde a clase repercute en los alumnos
+  """.
 
 
-; d)- Transitive verbs taking Vfin/VPinf subject and DO (no control)
-; - e.g. que el poder político se descomponga no significa necesariamente una decadencia => perder no significa necesariamente una decadencia
-v_subj_cp_prop_inf_or_fin_trans_np_dlr := subj_vfin_vinf-lex-rule & 
-  [ SYNSEM v_subj_cp_prop_inf_trans_np_synsem &
-           [ LOCAL.CAT.VAL.COMPS #comps ],
-    DTR.SYNSEM v_subj_cp_prop_fin_trans_np_synsem &
-               [ LOCAL.CAT.VAL.COMPS #comps & < [ ] > ] ].
-
-; e)- Transitive verbs taking Vfin subject, DO and marked NP (o_ctrl)
-; e.g. trabajar la obliga a madrugar
-v_subj_cp_prop_inf_or_fin_trans_np_mrkd_np_dlr := subj_vfin_vinf-lex-rule & 
-  [ SYNSEM v_subj_cp_prop_inf_trans_np_synsem &
-           [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
-                             COMPS #comps & < [ LOCAL.CONT.HOOK.INDEX #ind ],... > ] ],
-    DTR.SYNSEM v_subj_cp_prop_fin_trans_np_mrkd_np_synsem &
-               [ LOCAL.CAT.VAL.COMPS #comps ] ].
-
-; f)- Ditransitive verbs taking Vfin subject (o_ctrl)
-; e.g. tener que aguantar los embotellamientos te estropea el día
-v_subj_cp_prop_inf_or_fin_ditrans_dlr := subj_vfin_vinf-lex-rule & 
-  [ SYNSEM v_subj_cp_prop_inf_trans_np_synsem &
-           [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
-                             COMPS #comps & < synsem, [ LOCAL.CONT.HOOK.INDEX #ind ] > ] ],
-    DTR.SYNSEM v_subj_cp_prop_fin_ditrans_synsem &
-               [ LOCAL.CAT.VAL.COMPS #comps ] ].
-
-; g)- Transitive verbs taking Vfin/VPinf subject and completive clause (no control)
-; e.g. que te haya aprobado no significa que no tengas que venir a clase => aprobar no significa que no tengas que venir a clase
-v_subj_cp_prop_inf_or_fin_trans_cp_prop_dlr := subj_vfin_vinf-lex-rule & 
-  [ SYNSEM v_subj_cp_prop_inf_trans_cp_prop_fin_synsem &
-           [ LOCAL.CAT.VAL.COMPS #comps ],
-    DTR.SYNSEM v_subj_cp_prop_fin_trans_cp_prop_fin_synsem &
-               [ LOCAL.CAT.VAL.COMPS #comps & < [ ] > ] ].
-
-; h)- Ditransitive verbs taking Vfin subject, IO and finite completive clauses (o_ctrl)
-; e.g. oír música no (te) impide trabajar
-v_subj_cp_prop_inf_or_fin_ditrans_cp_prop_dlr := subj_vfin_vinf-lex-rule & 
-  [ SYNSEM v_subj_cp_prop_inf_ditrans_cp_prop_fin_synsem &
-           [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
-                             COMPS #comps & < [ LOCAL.CONT.HOOK.INDEX #ind ],... > ] ],
-    DTR.SYNSEM v_subj_cp_prop_fin_ditrans_cp_prop_fin_synsem &
-               [ LOCAL.CAT.VAL.COMPS #comps ] ].
+v_subj_cp_prop_inf_or_fin_intr_io*_mrkd_np_dlr := subj_vfin_vinf-lex-rule &
+  [ SYNSEM v_subj_cp_prop_inf_intr_io*_mrkd_np_synsem & [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
+                                                                          COMPS #comps & < [ LOCAL.CONT.HOOK.INDEX #ind ], ... > ] ],
+    DTR.SYNSEM v_subj_cp_prop_fin_intr_io*_mrkd_np_synsem & [ LOCAL.CAT.VAL.COMPS #comps ] ]
+  """
+  c)- Intransitive verbs taking Vfin/VPinf subject, opt. PPa and marked NP (o_control)
+  e.g. de nada (le) sirve que luchen =>  de nada (le) sirve luchar
+  """.
 
 
-; --- Verbs taking nominal subjects
-vcomp_vfin_vinf-lex-rule := vfin_vinf-lex-rule & 
+v_subj_cp_prop_inf_or_fin_trans_np_dlr := subj_vfin_vinf-lex-rule &
+  [ SYNSEM v_subj_cp_prop_inf_trans_np_synsem & [ LOCAL.CAT.VAL.COMPS #comps ],
+    DTR.SYNSEM v_subj_cp_prop_fin_trans_np_synsem & [ LOCAL.CAT.VAL.COMPS #comps & < [ ] > ] ]
+  """
+  d)- Transitive verbs taking Vfin/VPinf subject and DO (no control)
+  - e.g. que el poder político se descomponga no significa necesariamente una decadencia => perder no significa necesariamente una decadencia
+  """.
+
+
+v_subj_cp_prop_inf_or_fin_trans_np_mrkd_np_dlr := subj_vfin_vinf-lex-rule &
+  [ SYNSEM v_subj_cp_prop_inf_trans_np_synsem & [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
+                                                                  COMPS #comps & < [ LOCAL.CONT.HOOK.INDEX #ind ], ... > ] ],
+    DTR.SYNSEM v_subj_cp_prop_fin_trans_np_mrkd_np_synsem & [ LOCAL.CAT.VAL.COMPS #comps ] ]
+  """
+  e)- Transitive verbs taking Vfin subject, DO and marked NP (o_ctrl)
+  e.g. trabajar la obliga a madrugar
+  """.
+
+
+v_subj_cp_prop_inf_or_fin_ditrans_dlr := subj_vfin_vinf-lex-rule &
+  [ SYNSEM v_subj_cp_prop_inf_trans_np_synsem & [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
+                                                                  COMPS #comps & < synsem,
+                                                                                   [ LOCAL.CONT.HOOK.INDEX #ind ] > ] ],
+    DTR.SYNSEM v_subj_cp_prop_fin_ditrans_synsem & [ LOCAL.CAT.VAL.COMPS #comps ] ]
+  """
+  f)- Ditransitive verbs taking Vfin subject (o_ctrl)
+  e.g. tener que aguantar los embotellamientos te estropea el día
+  """.
+
+
+v_subj_cp_prop_inf_or_fin_trans_cp_prop_dlr := subj_vfin_vinf-lex-rule &
+  [ SYNSEM v_subj_cp_prop_inf_trans_cp_prop_fin_synsem & [ LOCAL.CAT.VAL.COMPS #comps ],
+    DTR.SYNSEM v_subj_cp_prop_fin_trans_cp_prop_fin_synsem & [ LOCAL.CAT.VAL.COMPS #comps & < [ ] > ] ]
+  """
+  g)- Transitive verbs taking Vfin/VPinf subject and completive clause (no control)
+  e.g. que te haya aprobado no significa que no tengas que venir a clase => aprobar no significa que no tengas que venir a clase
+  """.
+
+
+v_subj_cp_prop_inf_or_fin_ditrans_cp_prop_dlr := subj_vfin_vinf-lex-rule &
+  [ SYNSEM v_subj_cp_prop_inf_ditrans_cp_prop_fin_synsem & [ LOCAL.CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.XARG #ind ] >,
+                                                                             COMPS #comps & < [ LOCAL.CONT.HOOK.INDEX #ind ], ... > ] ],
+    DTR.SYNSEM v_subj_cp_prop_fin_ditrans_cp_prop_fin_synsem & [ LOCAL.CAT.VAL.COMPS #comps ] ]
+  """
+  h)- Ditransitive verbs taking Vfin subject, IO and finite completive clauses (o_ctrl)
+  e.g. oír música no (te) impide trabajar
+  """.
+
+
+vcomp_vfin_vinf-lex-rule := vfin_vinf-lex-rule &
   [ ALTS [ RFX #rfx,
            RCP #rcp ],
     SYNSEM [ LOCAL [ CAT [ HEAD.LSYNSEM #lsynsem,
@@ -514,45 +537,55 @@ vcomp_vfin_vinf-lex-rule := vfin_vinf-lex-rule &
                                    INDEX event & #index ],
                             RELS.LIST < #keyrel, ... > ] ],
              LKEYS.KEYREL #keyrel & [ LBL #ltop,
-                                      ARG0 #index ] ], 
+                                      ARG0 #index ] ],
     DTR [ INFLECTED -,
           ALTS [ RFX #rfx,
                  RCP #rcp ],
           SYNSEM [ LOCAL.CAT [ HEAD.LSYNSEM #lsynsem,
                                VAL.SUBJ #subj ],
-                   LKEYS.KEYREL #keyrel ] ] ].
+                   LKEYS.KEYREL #keyrel ] ] ]
+  """
+  --- Verbs taking nominal subjects
+  """.
 
 
-; a)- intransitive verbs taking marked finite/infinitival completive clause (s_ctrl) or indirect questions
-vintr_mrkd_cp_prop-or-ques_lex-rule := vcomp_vfin_vinf-lex-rule & 
-  [ SYNSEM v_intr_mrkd_cp_prop-or-ques_inf_synsem &
-           [ LOCAL [ AGR #agr,
-                     CAT.VAL.COMPS < [ OPT -,
-                                       LOCAL [ CAT.HEAD.KEYS #keys, 
-                                               CONT.HOOK [ INDEX.SF #sf,
-                                                           XARG #agr ] ],
-                                       NON-LOCAL #nloc ] >,
-                     CONT.HOOK.XARG #agr ] ],
-    DTR.SYNSEM v_intr_mrkd_cp_prop-or-ques_fin_synsem &
-               [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.HEAD.KEYS #keys,
-                                                 CONT.HOOK.INDEX.SF #sf ],
-                                         NON-LOCAL #nloc ] > ] ].
+vintr_mrkd_cp_prop-or-ques_lex-rule := vcomp_vfin_vinf-lex-rule &
+  [ SYNSEM v_intr_mrkd_cp_prop-or-ques_inf_synsem & [ LOCAL [ AGR #agr,
+                                                              CAT.VAL.COMPS < [ OPT -,
+                                                                                LOCAL [ CAT.HEAD.KEYS #keys,
+                                                                                        CONT.HOOK [ INDEX.SF #sf,
+                                                                                                    XARG #agr ] ],
+                                                                                NON-LOCAL #nloc ] >,
+                                                              CONT.HOOK.XARG #agr ] ],
+    DTR.SYNSEM v_intr_mrkd_cp_prop-or-ques_fin_synsem & [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.HEAD.KEYS #keys,
+                                                                                          CONT.HOOK.INDEX.SF #sf ],
+                                                                                  NON-LOCAL #nloc ] > ] ]
+  """
+  a)- intransitive verbs taking marked finite/infinitival completive clause (s_ctrl) or indirect questions
+  """.
 
-; e.g. no renuncio a que vengas => no renunciaremos a trabajar 
+
 v_mrkd_cp_prop-or-ques_dlr := vintr_mrkd_cp_prop-or-ques_lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL [ COMPS < [ LOCAL.CAT.VAL.CLTS #clts ] >,
-                           CLTS #clts ], 
+                           CLTS #clts ],
     DTR [ SYNSEM.LOCAL.CAT.VAL.CLTS < >,
           ARG-ST #arg-st ],
-    ARG-ST < #arg-st . #clts > ].
+    ARG-ST < #arg-st . #clts > ]
+  """
+  e.g. no renuncio a que vengas => no renunciaremos a trabajar
+  """.
 
-; e.g. se contenta con que vengas una vez por semana => se contenta con verte una vez por semana
+
 v_pron_mrkd_cp_prop-or-ques_dlr := vintr_mrkd_cp_prop-or-ques_lex-rule &
   [ SYNSEM.LOCAL.CAT.VAL [ COMPS < [ LOCAL.CAT.VAL.CLTS #clts ] >,
                            CLTS < #clt . #clts > ],
     DTR [ SYNSEM.LOCAL.CAT.VAL.CLTS < #clt >,
           ARG-ST #arg-st ],
-    ARG-ST < #arg-st . #clts > ].
+    ARG-ST < #arg-st . #clts > ]
+  """
+  e.g. se contenta con que vengas una vez por semana => se contenta con verte una vez por semana
+  """.
+
 
 ; b)- transitive verbs taking finite/infinitival completive clause (clit. climbing) or indirect questions
 ; e.g. ¿has intentado que lo hagan? => ¿lo has intentado hacer tú?,

--- a/srtypes.tdl
+++ b/srtypes.tdl
@@ -24,19 +24,22 @@ headed-phrase := basic-headed-phrase &
 
 non-headed-phrase := phrase.
 
-; Most but not all phrases have SYNSEM phr-synsem
 phrasal := phrase &
-  [ SYNSEM phr-synsem ].
+  [ SYNSEM phr-synsem ]
+""" Most but not all phrases have SYNSEM phr-synsem
+""".
 
 
+head-compositional := headed-phrase &
+  [ C-CONT.HOOK #hook,
+    HEAD-DTR.SYNSEM.LOCAL.CONT.HOOK #hook ]
+"""
 ; C-CONT is the semantic contribution of the phrase itself. The hook of the phrase is 
 ; identified with the hook of C-CONT (which is possibly but not necessarily identified 
 ; with the hook of one of the daughters. The rels and hcons of the phrase result from 
 ; appending the rels and hcons of C-CONT and the rels and hcons of the daughters.
 ; Head-compositional phrases identify the syntactic head daughter as the semantic head.
-head-compositional := headed-phrase &
-  [ C-CONT.HOOK #hook,
-    HEAD-DTR.SYNSEM.LOCAL.CONT.HOOK #hook ].
+""".
 
 
 basic-unary-phrase := phrase &
@@ -234,10 +237,12 @@ basic-head-final := basic-binary-headed-phrase &
 head-final := basic-head-final & binary-headed-phrase.
 
 
+binary-rule-left-to-right := rule &
+  [ ARGS < [ KEY-ARG + ] , [ KEY-ARG bool ] > ]
+"""
 ; For more efficient parsing, designate one argument or the other
 ; as the KEY-ARG: that which should be unified with first.
-binary-rule-left-to-right := rule &
-  [ ARGS < [ KEY-ARG + ] , [ KEY-ARG bool ] > ].
+""".
 
 binary-rule-right-to-left := rule &
   [ ARGS < [ KEY-ARG bool ], [ KEY-ARG + ] > ].
@@ -245,16 +250,20 @@ binary-rule-right-to-left := rule &
 ternary_rule_left_to_right := rule &
   [ ARGS < [ KEY-ARG + ] , [ KEY-ARG bool ] , [ KEY-ARG bool ] > ].
 
-; *** moved key from daughter 1 to daughter 2
 quad_rule_left_to_right := rule &
-  [ ARGS < [ KEY-ARG bool ], [ KEY-ARG + ], [ KEY-ARG bool ], [ KEY-ARG bool ] > ].
+  [ ARGS < [ KEY-ARG bool ], [ KEY-ARG + ], [ KEY-ARG bool ], [ KEY-ARG bool ] > ]
+"""
+; *** moved key from daughter 1 to daughter 2
+""".
 
 
-; head/nexus phrases pass up the REL and QUE values of the head daughter, 
-; which has amalgamated the REL and QUE values of its arguments to the mother
 head-nexus-rel-phrase := headed-phrase &
   [ SYNSEM.NON-LOCAL.REL #rel,
-    HEAD-DTR.SYNSEM.NON-LOCAL.REL #rel ].
+    HEAD-DTR.SYNSEM.NON-LOCAL.REL #rel ]
+"""
+; head/nexus phrases pass up the REL and QUE values of the head daughter, 
+; which has amalgamated the REL and QUE values of its arguments to the mother
+""".
 
 head-nexus-que-phrase := headed-phrase &
   [ SYNSEM.NON-LOCAL.QUE #que,
@@ -262,11 +271,13 @@ head-nexus-que-phrase := headed-phrase &
 
 head-nexus-phrase := head-nexus-rel-phrase & head-nexus-que-phrase.
 
-; In a head/local dependent phrase, the SLASH feature of the mother is token-identical 
-; to that of the head daughter, which has already amalgamated the SLASH values of its arguments. 
 head-valence-phrase := head-nexus-phrase &
   [ SYNSEM.NON-LOCAL.SLASH #slash,
-    HEAD-DTR.SYNSEM.NON-LOCAL.SLASH #slash ].
+    HEAD-DTR.SYNSEM.NON-LOCAL.SLASH #slash ]
+"""
+; In a head/local dependent phrase, the SLASH feature of the mother is token-identical 
+; to that of the head daughter, which has already amalgamated the SLASH values of its arguments. 
+""".
 
 
 ; --- clause types
@@ -283,16 +294,18 @@ mc-fillhead-phrase := headed-phrase &
 			 QUE 0-dlist ] ],
     HEAD-DTR.SYNSEM.LOCAL.CONT.HOOK.XARG #xarg ].
 
-; The immediate subtypes of clause are now relative-clause and non_rel_clause. 
-; The latter groups together decl, imp, and (wh_)interrog, which are similar in 
-; that they can't serve as modifiers and have empty REL values.
 relative-clause := clause & 
   [ SYNSEM.LOCAL.CAT [ MC na,
                        POSTHEAD +,
                        HEAD verb &
                             [ MOD < [ LOCAL intersective-mod & 
                                             [ CAT.VAL [ SUBJ < >,
-                                                        COMPS < > ] ] ] > ] ] ].
+                                                        COMPS < > ] ] ] > ] ] ]
+"""
+; The immediate subtypes of clause are now relative-clause and non_rel_clause. 
+; The latter groups together decl, imp, and (wh_)interrog, which are similar in 
+; that they can't serve as modifiers and have empty REL values.
+""".
   
 non-rel-phrase := head-nexus-rel-phrase & 
   [ SYNSEM [ LOCAL.CONT.HOOK [ LTOP #ltop,
@@ -432,47 +445,54 @@ norm-basic-head-subj-phrase := basic-head-subj-phrase &
     NON-HEAD-DTR.SYNSEM #synsem ].
 
 
-; In languages which do realize all COMPS before the SUBJ, head-subj-phrase should allow [COMPS olist]
 subj-head-phrase := norm-basic-head-subj-phrase & head-final & 
   [ SYNSEM.LOCAL.CAT [ POSTHEAD +,
                        VAL.COMPS < > ],
     HEAD-DTR.SYNSEM.LOCAL.CAT [ HEAD verb & 
                                      [ INV -, 
                                        VFORM fin ],
-                                VAL.COMPS olist ] ].
+                                VAL.COMPS olist ] ]
+"""
+; In languages which do realize all COMPS before the SUBJ, head-subj-phrase should allow [COMPS olist]
+""".
 
 subj-head_nonque_phrase := subj-head-phrase &
   [ HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist,
     NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ].
 
-; VOS, VPS, VOPS (el sujeto es foco)
-; VSOP (admite una interpretación de foco amplio
 head-subj_phrase := norm-basic-head-subj-phrase & head-initial & 
   [ HEAD-DTR.SYNSEM [ LOCAL.CAT.HEAD verb & 
                                      [ VFORM fin,
                                        TAM.MOOD ind_or_sub_mood ],
                       NON-LOCAL [ QUE 0-dlist,
                                   SLASH 0-dlist ] ], 
-    NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ].
+    NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ]
+"""
+; VOS, VPS, VOPS (el sujeto es foco)
+; VSOP (admite una interpretación de foco amplio
+""".
 
-; for inverted subjects in relative and interrogative clauses
 head-subj_rel_phrase := norm-basic-head-subj-phrase & head-initial & 
   [ HEAD-DTR.SYNSEM [ LOCAL.CAT.HEAD [ VFORM fin,
                                        VOICE active,
                                        TAM.MOOD ind_or_sub_mood ],
                       NON-LOCAL [ SLASH 1-dlist,
                                   QUE 0-dlist ] ],  
-    NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ].  
+    NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ]
+"""
+; for inverted subjects in relative and interrogative clauses
+""".  
 
-; for inverted subjects in imperative (e.g. vengan ustedes)
 head-subj_imperative_phrase := norm-basic-head-subj-phrase & head-initial & 
   [ HEAD-DTR.SYNSEM [ LOCAL.CAT.HEAD [ VFORM fin,
                                        TAM.MOOD imp ],
                       NON-LOCAL [ SLASH 0-dlist,
                                   QUE 0-dlist ] ],  
-    NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ].  
+    NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ]
+"""
+; for inverted subjects in imperative (e.g. vengan ustedes)
+""".  
 
-; for inverted subjects in CPA constructions (e.g. muerto el perro, se acabó la rabia)
 head-subj_cpa_phrase := norm-basic-head-subj-phrase & head-initial & 
   [ HEAD-DTR.SYNSEM [ LOCAL.CAT [ HEAD verb & 
                                        [ AUX -,
@@ -483,19 +503,20 @@ head-subj_cpa_phrase := norm-basic-head-subj-phrase & head-initial &
 ;                                 VAL.COMPS < [ ] > ],
                       NON-LOCAL [ QUE 0-dlist,
                                   SLASH 0-dlist ] ],  
-    NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ].  
+    NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ]
+"""
+; for inverted subjects in CPA constructions (e.g. muerto el perro, se acabó la rabia)
+""".  
 
-; for inverted subjects in VPinf (e.g. empezó tras irrumpir los manifestantes)
 head-subj_vpinf_phrase := norm-basic-head-subj-phrase & head-initial & 
   [ HEAD-DTR.SYNSEM [ LOCAL.CAT.HEAD.VFORM inf,
                       NON-LOCAL [ QUE 0-dlist,
                                   SLASH 0-dlist ] ],
-    NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ].  
+    NON-HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-dlist ]
+"""
+; for inverted subjects in VPinf (e.g. empezó tras irrumpir los manifestantes)
+""".  
 
-; for inverted coordinated subject - mostly, coordinated subjects are in plural, but 
-; there may be partial agreement with one of the subjects when the verb precedes the 
-; subject and when the subject denotes an abstract entity 
-; (e.g. en la corte existía/existían el favoritismo y la corrupción).
 head-subj_coord_phrase := basic-head-subj-phrase & head-initial & 
   [ SYNSEM.LOCAL.CAT.VAL.SUBJ < >,
     HEAD-DTR.SYNSEM [ LOCAL.CAT [ HEAD verb & [ TAM.MOOD ind_or_sub_mood ],
@@ -513,7 +534,13 @@ head-subj_coord_phrase := basic-head-subj-phrase & head-initial &
                                                 XARG #xarg ],
                                          RELS #rels,
                                          HCONS #hcons ] ],
-                          NON-LOCAL #nlocal & [ QUE 0-dlist ] ] ].  
+                          NON-LOCAL #nlocal & [ QUE 0-dlist ] ] ]
+"""
+; for inverted coordinated subject - mostly, coordinated subjects are in plural, but 
+; there may be partial agreement with one of the subjects when the verb precedes the 
+; subject and when the subject denotes an abstract entity 
+; (e.g. en la corte existía/existían el favoritismo y la corrupción).
+""".  
 
 
 ; --- head-comp-phrase types
@@ -661,8 +688,6 @@ clit-head_phrase_cl := clit-head_phrase_basic &
 
 ; --- head-spec-phrase types
 
-; agreement features are percolated from HEAD-DTR.SYNSEM.LOCAL.CONT.HOOK.INDEX 
-; where NUMBER is not checked in 'ad sensum agreement'
 basic-head-spec-phrase := head-valence-phrase & phrasal & very-basic-binary-phrase & 
   [ INFLECTED +,
     SYNSEM [ SLSHD #slshd,
@@ -695,7 +720,11 @@ basic-head-spec-phrase := head-valence-phrase & phrasal & very-basic-binary-phra
                                               COMPS #spcomps ] ] ],
                           MODIFIED #modif ],
     C-CONT [ RELS  <! !>,
-             HCONS <! !> ] ].
+             HCONS <! !> ] ]
+"""
+; agreement features are percolated from HEAD-DTR.SYNSEM.LOCAL.CONT.HOOK.INDEX 
+; where NUMBER is not checked in 'ad sensum agreement'
+""".
 
 norm-basic-head-spec-phrase := basic-head-spec-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD [ MOD #mod,
@@ -736,9 +765,11 @@ head-spec_phrase := norm-basic-head-spec-phrase & binary-headed-phrase &
                                             COMPS < > ] ] ],
                         NON-LOCAL.REL 0-dlist ] ],
     ARGS < #head-dtr, #non-head-dtr >,
-    C-CONT.HOOK #hook ].
+    C-CONT.HOOK #hook ]
+"""
+; for specifiers following nouns
+""".
 
-; for specifiers of nouns
 spec-head_phrase := norm_spec-head-phrase & binary-headed-phrase & 
   [ SYNSEM.LOCAL [ CAT [ HEAD #head & 
                               [ CASE #case, 
@@ -754,9 +785,12 @@ spec-head_phrase := norm_spec-head-phrase & binary-headed-phrase &
                         [ LOCAL [ CAT [ HEAD det & [ KEYS.KEY quant_or_wh_rel ],
                                         VAL.SPEC < [ LOCAL.CAT.HEAD #head ] > ],
                                   CONT.HOOK #hook ] ],
-    C-CONT.HOOK #hook ].
+    C-CONT.HOOK #hook ]
+"""
+; for specifiers of nouns
+""".
 
-; for specifiers of relative pronouns
+
 spec-head_hdrel_phrase := norm_spec-head-phrase & explt-binary-phrase &
   [ INFLECTED +,
     SYNSEM [ PUNCT [ LPUNCT #lpunct,
@@ -778,9 +812,11 @@ spec-head_hdrel_phrase := norm_spec-head-phrase & explt-binary-phrase &
                                           VAL.SPEC < [ LOCAL.CAT.HEAD #head ] > ],
                                     CONT.HOOK #hook ],
                             NON-LOCAL.REL 0-dlist ] ],
-    C-CONT.HOOK #hook ].
+    C-CONT.HOOK #hook ]
+"""
+; for specifiers of relative pronouns
+""".
 
-; for specifiers of determiners (e.g. todos los, casi todos los, sólo los,...) 
 spec-head_hddet_phrase := norm_spec-head-phrase & head-final & head-compositional & 
   [ SYNSEM.LOCAL [ STR.HEADING right_or_no,
                    CAT [ HEAD #head & [ KEYS #keys ],
@@ -791,9 +827,11 @@ spec-head_hddet_phrase := norm_spec-head-phrase & head-final & head-compositiona
                                         COMPS < > ] ] ],
     NON-HEAD-DTR.SYNSEM.LOCAL.CAT [ HEAD det,
                                     VAL [ SPEC < [ LOCAL.CAT.HEAD #head ] >,
-                                          SPR #spr ] ] ].
+                                          SPR #spr ] ] ]
+"""
+; for specifiers of determiners (e.g. todos los, casi todos los, sólo los,...) 
+""".
 
-; for "cuyo"
 spec-head_specrel_phrase := norm_spec-head-phrase & binary-headed-phrase & 
   [ SYNSEM.LOCAL [ STR.HEADING right_or_no,
                    CAT [ HEAD [ CASE #case, 
@@ -810,9 +848,11 @@ spec-head_specrel_phrase := norm_spec-head-phrase & binary-headed-phrase &
                         [ LOCAL [ CAT [ HEAD det ],
                                   CONT.HOOK #hook ],
                           NON-LOCAL.REL 1-dlist ],
-    C-CONT.HOOK #hook ].
+    C-CONT.HOOK #hook ]
+"""
+; for "cuyo"
+""".
 
-; for degree specifiers
 spec-head_specdeg_phrase := norm_spec-head-phrase & head-final & head-compositional & 
   [ SYNSEM.LOCAL.CAT [ HEAD #head & [ KEYS #keys ],
                        VAL.SPR #spr ],
@@ -820,7 +860,10 @@ spec-head_specdeg_phrase := norm_spec-head-phrase & head-final & head-compositio
                             CAT.HEAD.KEYS #keys ],
     NON-HEAD-DTR.SYNSEM.LOCAL.CAT [ HEAD.KEYS.KEY degree_rel,
                                     VAL [ SPEC < [ LOCAL.CAT.HEAD #head ] >,
-                                          SPR #spr ] ] ].
+                                          SPR #spr ] ] ]
+"""
+; for degree specifiers
+""".
 
 
 ; --- head-mod-phrase types
@@ -905,17 +948,21 @@ isect-mod-phrase := head-mod-phrase-simple & head-compositional &
                                 CONT.HOOK.LTOP #hand ],
     C-CONT.HCONS <! !> ].
 
-; scopal adjunct + head
 adj-head_scop_phrase := adj-head-phrase & scopal-mod-phrase &
   [ HEAD-DTR.SYNSEM.LOCAL.CAT.VAL.COMPS < >,
-    NON-HEAD-DTR.SYNSEM.LOCAL.CAT.POSTHEAD - ].
+    NON-HEAD-DTR.SYNSEM.LOCAL.CAT.POSTHEAD - ]
+"""
+; scopal adjunct + head
+""".
                                     
-; intersective adjunct + head
 adj-head_int-xp-xp_phrase :=  adj-head-phrase & isect-mod-phrase &
   [ HEAD-DTR.SYNSEM [ LOCAL.CAT [ HEAD +jrp,
                                   VAL.COMPS < > ],
                       NON-LOCAL.REL 0-dlist ],
-    NON-HEAD-DTR.SYNSEM.LOCAL.CAT.POSTHEAD - ].
+    NON-HEAD-DTR.SYNSEM.LOCAL.CAT.POSTHEAD - ]
+"""
+; intersective adjunct + head
+""".
 
 adj-head_int-xp-n_phrase :=  adj-head-phrase & isect-mod-phrase &
   [ SYNSEM.LOCAL.CAT.VAL.SPR #spr,
@@ -958,7 +1005,6 @@ adj-head_int-pp-vp_phrase := adj-head-phrase & isect-mod-phrase &
 ;                     NON-LOCAL.SLASH <! [ ] !> ], 
     NON-HEAD-DTR.SYNSEM.LOCAL.CAT.HEAD adp & [ KEYS.ALT2KEY non_free_relative_q_rel ] ].
 
-; head + scopal adjunct
 head-adj_scop-xp-cl_phrase := head-adj-phrase & scopal-mod-phrase & 
   [ SYNSEM.LOCAL.CAT [ POSTHEAD #ph, 
                        VAL.SPR #spr ],
@@ -969,7 +1015,10 @@ head-adj_scop-xp-cl_phrase := head-adj-phrase & scopal-mod-phrase &
                                         HEAD adp ],
                                   CONT.HOOK.INDEX event & 
                                                   [ SF prop-or-ques ] ],
-                          NON-LOCAL.REL 0-dlist ] ].
+                          NON-LOCAL.REL 0-dlist ] ]
+"""
+; head + scopal adjunct
+""".
 
 head-adj_scop-xp-xp_phrase := head-adj-phrase & scopal-mod-phrase & 
   [ SYNSEM.LOCAL.CAT [ POSTHEAD #ph, 
@@ -984,7 +1033,6 @@ head-adj_scop-xp-xp_phrase := head-adj-phrase & scopal-mod-phrase &
                           NON-LOCAL [ SLASH 0-dlist,
                                       REL 0-dlist ] ] ].
 
-; head + intersective adjunct
 head-adj_int-ap-xp_phrase := head-adj-phrase & isect-mod-phrase &
   [ SYNSEM.LOCAL.CAT [ POSTHEAD #ph, 
                        VAL.SPR #spr ],
@@ -994,7 +1042,10 @@ head-adj_int-ap-xp_phrase := head-adj-phrase & isect-mod-phrase &
                                   VAL.SPR #spr ] ],
     NON-HEAD-DTR.SYNSEM [ LOCAL.CAT.POSTHEAD +,
                           NON-LOCAL [ SLASH 0-dlist,
-                                      REL 0-dlist & [ LIST < > ] ] ] ].
+                                      REL 0-dlist & [ LIST < > ] ] ] ]
+"""
+; head + intersective adjunct
+""".
 
 head-adj_int-pp-xp_phrase := head-adj-phrase & isect-mod-phrase &
   [ SYNSEM.LOCAL.CAT [ POSTHEAD #ph, 
@@ -1006,7 +1057,6 @@ head-adj_int-pp-xp_phrase := head-adj-phrase & isect-mod-phrase &
                                   VAL.SPR #spr ] ],
     NON-HEAD-DTR.SYNSEM.LOCAL.CAT.POSTHEAD + ].
 
-; verbal head + intersective adjuncts
 head-adj-int-v-xp-phrase := head-adj-phrase & isect-mod-phrase &
   [ SYNSEM.LOCAL.CAT.VAL.SPR #spr,
     HEAD-DTR.SYNSEM [ LOCAL.CAT [ HEAD verb,
@@ -1014,16 +1064,21 @@ head-adj-int-v-xp-phrase := head-adj-phrase & isect-mod-phrase &
                       NON-LOCAL.REL 0-dlist ],
 ;   NON-HEAD-DTR.SYNSEM [ LOCAl.CAT.POSTHEAD +, 
     NON-HEAD-DTR.SYNSEM.NON-LOCAL [ SLASH 0-dlist,
-                                    REL 0-dlist & [ LIST < > ] ] ].
+                                    REL 0-dlist & [ LIST < > ] ] ]
+"""
+; verbal head + intersective adjuncts
+""".
 
-; también le pidió un papel, como Harrison Ford
 head-adj_int-s-xp_phrase := head-adj-int-v-xp-phrase &
   [ SYNSEM.LOCAL.CAT.POSTHEAD #ph,
     HEAD-DTR.SYNSEM [ PUNCT.RPUNCT comma_punct,
                       LOCAL.CAT [ POSTHEAD #ph, 
                                   VAL [ SUBJ < >, 
                                         COMPS < > ] ] ],
-    NON-HEAD-DTR.SYNSEM.LOCAl.CAT.HEAD adp ].
+    NON-HEAD-DTR.SYNSEM.LOCAl.CAT.HEAD adp ]
+"""
+; también le pidió un papel, como Harrison Ford
+""".
 
 head-adj_int-v-pp_phrase := head-adj-int-v-xp-phrase &
   [ HEAD-DTR.SYNSEM [ LOCAL.CAT.POSTHEAD -,
@@ -1046,15 +1101,16 @@ head-adj_int-v-vger_phrase := head-adj-int-v-xp-phrase &
                       MODIFIED notmod-or-rmod ],
     NON-HEAD-DTR.SYNSEM.LOCAL.CAT.HEAD verb & [ VFORM ger ] ].
 
-; for free RC, which can't be separated from the head-dtr with a comma
 head-adj_int-v-frel_phrase := head-adj-int-v-xp-phrase &
   [ HEAD-DTR.SYNSEM [ MODIFIED notmod-or-rmod,
                       LOCAL.CAT.POSTHEAD - ],
     HEAD-DTR.SYNSEM.PUNCT.RPUNCT no_punct,
     NON-HEAD-DTR.SYNSEM.LOCAL [ CAT.HEAD modnp & [ KEYS.KEY prep_mod_rel ],
-                                CONT.RELS.LIST.REST.FIRST.PRED free_relative_q_rel ] ].
+                                CONT.RELS.LIST.REST.FIRST.PRED free_relative_q_rel ] ]
+"""
+; for free RC, which can't be separated from the head-dtr with a comma
+""".
 
-; nominal head + intersective adjuncts
 head-adj-int-n-xp-phrase := head-adj-phrase & isect-mod-phrase &
   [ SYNSEM.LOCAL.CAT [ POSTHEAD #ph, 
                        LASTNMOD - ],
@@ -1065,16 +1121,21 @@ head-adj-int-n-xp-phrase := head-adj-phrase & isect-mod-phrase &
     NON-HEAD-DTR.SYNSEM [ LOCAL.CAT.POSTHEAD +,
                           NON-LOCAL [ SLASH 0-dlist,
                                       QUE 0-dlist & [ LIST < > ],
-                                      REL 0-dlist & [ LIST < > ] ] ] ].
+                                      REL 0-dlist & [ LIST < > ] ] ] ]
+"""
+; nominal head + intersective adjuncts
+""".
 
-; common nouns
 head-adj_int-cn-ap_phrase := head-adj-int-n-xp-phrase &
   [ SYNSEM.LOCAL.CAT.VAL.SPR #spr,
     HEAD-DTR.SYNSEM [ PUNCT.RPUNCT no_punct,
                       LOCAL [ CAT [ HEAD.KEYS.KEY all_common_nom_rel,
                                     VAL.SPR #spr & < [ ] > ],
                               CONT.HOOK.INDEX.PRONTYPE not_pron ] ],
-    NON-HEAD-DTR.SYNSEM.LOCAl.CAT.HEAD adj ].
+    NON-HEAD-DTR.SYNSEM.LOCAl.CAT.HEAD adj ]
+"""
+; common nouns
+""".
 
 head-adj_int-cn-pp_phrase := head-adj-int-n-xp-phrase &
   [ SYNSEM.LOCAL.CAT.VAL.SPR #spr,
@@ -1122,31 +1183,39 @@ head-adj_int-np-xp-crd_phrase := head-adj-int-n-xp-phrase &
                                     VAL.SPR #spr & < > ],
                               CONT.HOOK.INDEX.PRONTYPE not_pron ] ] ].
 
-; proper names
 head-adj_int-pname-xp_phrase := head-adj-int-n-xp-phrase &
   [ SYNSEM.LOCAL.CAT.VAL.SPR < [ LOCAL #local,
                                  NON-LOCAL #nlocal ] >,
     HEAD-DTR.SYNSEM.LOCAL [ CAT [ HEAD.KEYS.KEY named_rel,
                                   VAL.SPR < [ LOCAL #local,
                                               NON-LOCAL #nlocal ] > ],
-                            CONT.HOOK.INDEX.PRONTYPE not_pron ] ].
-; la Rocío del otro día
+                            CONT.HOOK.INDEX.PRONTYPE not_pron ] ]
+"""
+; proper names
+""".
+
 head-adj_int-pn-xp_phrase := head-adj_int-pname-xp_phrase &
   [ SYNSEM.LOCAL.CAT.VAL.SPR < [ OPT - ] >,
-    HEAD-DTR.SYNSEM.PUNCT.RPUNCT no_punct ].
+    HEAD-DTR.SYNSEM.PUNCT.RPUNCT no_punct ]
+"""
+; la Rocío del otro día
+""".
 
-; Andrea Hoffmann es originaria de Kassel, en el land de Hesse
 head-adj_int-pn-xp-pt_phrase := head-adj_int-pname-xp_phrase &
   [ SYNSEM.LOCAL.CAT.VAL.SPR < [ OPT + ] >,
-    HEAD-DTR.SYNSEM.PUNCT.RPUNCT comma_punct ].
+    HEAD-DTR.SYNSEM.PUNCT.RPUNCT comma_punct ]
+"""
+; Andrea Hoffmann es originaria de Kassel, en el land de Hesse
+""".
 
-; pronouns
 head-adj_int-pr-xp_phrase := head-adj-int-n-xp-phrase &
   [ SYNSEM.LOCAL.CAT.VAL.SPR #spr,
     HEAD-DTR.SYNSEM.LOCAL [ CAT.VAL.SPR #spr,
-                            CONT.HOOK.INDEX.PRONTYPE real_pron ] ].
+                            CONT.HOOK.INDEX.PRONTYPE real_pron ] ]
+"""
+; pronouns
+""".
 
-; adjuncts co-ocurring at last positions
 head-adj-int-n-rc-phrase := head-adj-phrase & isect-mod-phrase &
   [ SYNSEM.LOCAL.CAT [ POSTHEAD #ph,
                        LASTNMOD + ],
@@ -1160,7 +1229,10 @@ head-adj-int-n-rc-phrase := head-adj-phrase & isect-mod-phrase &
                                       HEAD verb & [  MOD < [ PUNCT.RPUNCT no_punct ] > ] ],
                           NON-LOCAL [ SLASH 0-dlist,
                                       QUE 0-dlist,
-                                      REL 1-dlist ] ] ].
+                                      REL 1-dlist ] ] ]
+"""
+; adjuncts co-ocurring at last positions
+""".
 
 head-adj_int-n-rc_phrase := head-adj-int-n-rc-phrase &
   [ SYNSEM.LOCAL.CAT.VAL.SPR #spr,
@@ -1227,7 +1299,6 @@ head-adj_int-pr-rcpp_phrase := head-adj-int-n-rcpp-phrase &
     HEAD-DTR.SYNSEM.LOCAL [ CAT.VAL.SPR #spr,
                             CONT.HOOK.INDEX.PRONTYPE real_pron ] ].
 
-; non-restrictive RCs
 head-adj_int-n-rcnr_phrase := non_str-head-adj-phrase & isect-mod-phrase & 
   [ SYNSEM.LOCAL.CAT [ POSTHEAD #ph,
                        LASTNMOD +,
@@ -1243,7 +1314,10 @@ head-adj_int-n-rcnr_phrase := non_str-head-adj-phrase & isect-mod-phrase &
                                       HEAD verb ],
                           NON-LOCAL [ SLASH 0-dlist & [ LIST < > ],
                                       QUE 0-dlist,
-                                      REL 1-dlist ] ] ].
+                                      REL 1-dlist ] ] ]
+"""
+; non-restrictive RCs
+""".
 
 ; apposition
 
@@ -1286,14 +1360,16 @@ basic-appos-phrase := head-nexus-phrase & head-compositional & basic-binary-phra
                        ARG1 #hind,
                        ARG2 #modind ] !> ] ].
 
-; -- appositions between brackets
 head-adj_int-bracket-appos_phrase := basic-appos-phrase &
   [ HEAD-DTR.SYNSEM [ PUNCT.RPUNCT no_punct,
                       NON-LOCAL [ SLASH 0-dlist,
                                   QUE 0-dlist,
                                   REL 0-dlist ] ],
     NON-HEAD-DTR.SYNSEM [ PUNCT [ LPUNCT bracket_op_punct,
-                                  RPUNCT bracket_cl_punct ] ] ].   
+                                  RPUNCT bracket_cl_punct ] ] ]
+"""
+; -- appositions between brackets
+""".   
 
 head-adj_int-cn-cn-appos_phrase := basic-appos-phrase &
   [ HEAD-DTR.SYNSEM [ PUNCT.RPUNCT comma_punct,
@@ -1341,12 +1417,14 @@ head-adj_int-pn-cn-appos_phrase := basic-appos-phrase &
     NON-HEAD-DTR.SYNSEM.LOCAL [ CAT.HEAD noun & [ KEYS.KEY non_modable_rel & non_elliptical_n_rel ],
                                 CONT.HOOK.INDEX [ PRONTYPE not_pron,
                                                   SORT #sort ] ] ]. 
-; muy poco, casi nada, que resñar.
 head-adj_int-prn-prn-appos_phrase := basic-appos-phrase &
   [ HEAD-DTR.SYNSEM [ LOCAL.CONT.HOOK.INDEX.PRONTYPE real_pron ],
     NON-HEAD-DTR.SYNSEM [ PUNCT [ LPUNCT comma_punct,
                                   RPUNCT comma_punct ],
-                          LOCAL.CONT.HOOK.INDEX.PRONTYPE real_pron ] ].   
+                          LOCAL.CONT.HOOK.INDEX.PRONTYPE real_pron ] ]
+"""
+; muy poco, casi nada, que resñar.
+""".   
 
 head-adj_int-modnp-appos_phrase := basic-appos-phrase &
   [ HEAD-DTR.SYNSEM.LOCAL [ CAT.HEAD noun & 
@@ -1365,15 +1443,17 @@ head-adj_int-modnp-adv-appos_phrase := basic-appos-phrase &
                                       VAL.SPR < [ ] > ],
                                 CONT.HOOK.INDEX.SORT #sort & non-temp ] ].
 
-; la propuesta 23
 head-adj_int-nu-appos_phrase := basic-appos-phrase &
   [ HEAD-DTR.SYNSEM [ PUNCT.RPUNCT no_punct,
                       LOCAL.CAT [ HEAD.KEYS.KEY non_elliptical_n_rel,
                                   VAL.SPR < > ] ],
     NON-HEAD-DTR.SYNSEM.LOCAL [ CAT [ HEAD noun & [ KEYS.KEY non_modable_rel ],
                                       VAL.SPR < > ],
-                                CONT.RELS <! [ PRED generic_entity_rel ], [ PRED card_q_rel ] !> ] ].
-; la propuesta número 23
+                                CONT.RELS <! [ PRED generic_entity_rel ], [ PRED card_q_rel ] !> ] ]
+"""
+; la propuesta 23
+""".
+
 head-adj_int-cmp-nu-appos_phrase := basic-appos-phrase &
   [ HEAD-DTR.SYNSEM [ PUNCT.RPUNCT no_punct,
                       LOCAL.CAT [ HEAD.KEYS.KEY non_elliptical_n_rel,
@@ -1384,10 +1464,14 @@ head-adj_int-cmp-nu-appos_phrase := basic-appos-phrase &
                                              [ PRED undef_q_rel ], 
                                              relation, 
                                              [ PRED card_rel ], 
-                                             [ PRED card_q_rel ] !> ] ].
+                                             [ PRED card_q_rel ] !> ] ]
+"""
+; la propuesta número 23
+""".
 
 
 ; compounds
+
 basic_n_n_cmpnd_phrase := head-valence-phrase & head-compositional & basic-binary-phrase &
   [ SYNSEM [ SLSHD #slshd,
              MODIFIED notmod,
@@ -1425,7 +1509,7 @@ basic_np_name_cmpnd_phrase := basic_n_n_cmpnd_phrase &
 	     HCONS <! qeq & [ HARG #rhand,
                               LARG #nhltop ] !> ] ].
 
-; e.g. coche bomba, mesa camilla,...
+
 n_n_cmpnd_phrase := basic_np_name_cmpnd_phrase & head-initial & 
   [ HEAD-DTR.SYNSEM.LOCAL [ CAT [ HEAD.KEYS.KEY common_nom_rel,
                                   VAL.SPR < [ LOCAL.CAT.HEAD det,
@@ -1436,20 +1520,25 @@ n_n_cmpnd_phrase := basic_np_name_cmpnd_phrase & head-initial &
     NON-HEAD-DTR.SYNSEM.LOCAL.CAT.VAL.SPR < [ LOCAL.CAT.HEAD det,
                                               NON-LOCAL [ SLASH 0-dlist & [ LIST < > ],
                                                           QUE 0-dlist,
-                                                          REL 0-dlist ] ] > ].
+                                                          REL 0-dlist ] ] > ]
+"""
+; e.g. coche bomba, mesa camilla,...
+""".
 
-; e.g. número dos
+
 n_n-num_cmpnd_phrase := basic_np_name_cmpnd_phrase & head-initial & 
   [ HEAD-DTR.SYNSEM.LOCAL.CAT [ VAL.SPR < [ LOCAL.CAT.HEAD det,
                                             NON-LOCAL [ SLASH 0-dlist & [ LIST < > ],
                                                         QUE 0-dlist,
                                                         REL 0-dlist ] ] > ],
-    NON-HEAD-DTR.SYNSEM.LOCAL.CONT.RELS <! [ PRED generic_entity_rel ], [ PRED card_q_rel ] !> ].
+    NON-HEAD-DTR.SYNSEM.LOCAL.CONT.RELS <! [ PRED generic_entity_rel ], [ PRED card_q_rel ] !> ]
+"""
+; e.g. número dos
+""".
 
 
 ; --- unary phrase types for optionality
 
-; -- optional subject
 optsubj_phrase := head-valence-phrase & head-only & head-compositional &
   [ INFLECTED #infl,
     SYNSEM [ MODIFIED #mod,
@@ -1486,17 +1575,12 @@ optsubj_phrase := head-valence-phrase & head-only & head-compositional &
                                             CLTS #clit & < > ] ] ],
                         NON-LOCAL #nlocal ] ],
     C-CONT [ RELS  <! !>,
-             HCONS <! !> ] ].
+             HCONS <! !> ] ]
+"""
+; -- optional subject
+""".
 
 
-; -- optional complement
-; The feature DEF-OPT allows the head to specify whether the optional
-; complement is interpreted as definite (+), indefinite (-), or
-; either (underspecified).  basic-head-opt-comp-phrase copies this
-; information into the index of the unexpressed argument.
-; Need to decide what to do about LIGHT here.  
-;   [ SYNSEM.LOCAL.CAT.AGR #agr,
-;     HEAD-DTR.SYNSEM.LOCAL.CAT.AGR #agr ] 
 optcomp-phrase := head-valence-phrase & head-only & head-compositional &
   [ INFLECTED #infl,
     SYNSEM canonical-synsem &
@@ -1528,10 +1612,18 @@ optcomp-phrase := head-valence-phrase & head-only & head-compositional &
                                             CLTS #clit ] ] ],
                         NON-LOCAL #nlocal ] ],
     C-CONT [ RELS  <! !>,
-             HCONS <! !> ] ]. 
+             HCONS <! !> ] ]
+"""
+; -- optional complement
+; The feature DEF-OPT allows the head to specify whether the optional
+; complement is interpreted as definite (+), indefinite (-), or
+; either (underspecified).  basic-head-opt-comp-phrase copies this
+; information into the index of the unexpressed argument.
+; Need to decide what to do about LIGHT here.  
+;   [ SYNSEM.LOCAL.CAT.AGR #agr,
+;     HEAD-DTR.SYNSEM.LOCAL.CAT.AGR #agr ] 
+""". 
 
-; si diem que el subjecte no s'ha cancel·lat, no podem analitzar
-; "volvió el hindú su rostro"
 optcomp-v_phrase := optcomp-phrase &
   [ SYNSEM.LOCAL.CAT [ POSTHEAD #ph,
                        VAL.COMPS #comps ],
@@ -1539,7 +1631,10 @@ optcomp-v_phrase := optcomp-phrase &
                             CAT [ POSTHEAD #ph, 
                                   HEAD verb & [ KEYS.KEY v_event_rel ],
                                   VAL [ SUBJ < [ ] >,
-                                        COMPS < [ NON-LOCAL.SLASH 0-dlist ]. #comps > ] ] ] ]. 
+                                        COMPS < [ NON-LOCAL.SLASH 0-dlist ]. #comps > ] ] ] ]
+"""; si diem que el subjecte no s'ha cancel·lat, no podem analitzar
+; "volvió el hindú su rostro"
+""". 
 
 optcomp-n_phrase := optcomp-phrase &
   [ SYNSEM.LOCAL [ CAT [ POSTHEAD #ph,
@@ -1563,7 +1658,7 @@ optcomp-r_phrase := optcomp-phrase &
                       LOCAL [ STR.HEADED solely,
                               CAT [ HEAD adv & [ KEYS.KEY basic_adv_rel ] ] ] ] ]. 
 
-; -- optional specifier
+
 optspec_phrase := head-valence-phrase & non-clause & head-only & head-compositional & 
   [ INFLECTED #infl,
     SYNSEM [ MODIFIED #mod,
@@ -1595,7 +1690,10 @@ optspec_phrase := head-valence-phrase & non-clause & head-only & head-compositio
                                             COMPS #comps & < >,
                                             SPEC #spec ] ] ] ] ],
     C-CONT [ RELS <! !>,
-             HCONS <! !> ] ].
+             HCONS <! !> ] ]
+"""
+; -- optional specifier
+""".
 
 
 ; --- unary phrase types for interjections
@@ -1662,6 +1760,7 @@ interj-impropias-cmp-phrase := head-valence-phrase & head-compositional & binary
 ; interj_improp_cmp_constr := interj-impropias-cmp-phrase & rule. 
 
 ; --- unary phrase types for Nbare (distinguished by the INDEX [ DIVISIBLE + ])
+
 basic-nbar-phrase := unary-phrase &
   [ SYNSEM synsem & 
            [ LIGHT -, 
@@ -1878,7 +1977,7 @@ npadv_modn_phrase := basic-npadv-phrase &
                    [ ARG2 #index ] !> ].
 
 
-; hace tres semanas ...
+
 pp_npadv_phrase := basic-npadv-phrase &
   [  SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT.HEAD verb ] >,
      ARGS < [ SYNSEM.LOCAL [ CAT [ HEAD verb & 
@@ -1888,10 +1987,12 @@ pp_npadv_phrase := basic-npadv-phrase &
                                                     [ PRED "_hacer_v_rel",
                                                       ARG2 #arg2 & [ SORT tmp ] ] ] ] ] >,
     C-CONT.RELS <! prep-relation &
-                   [ ARG2 #arg2 ] !> ].
+                   [ ARG2 #arg2 ] !> ]
+"""
+; hace tres semanas ...
+""".
 
 
-; unary phrase types for vocatives
 vocative_np_phrase := basic-unary-phrase & phrasal & 
   [ INFLECTED +,
     SYNSEM [ PUNCT #punct,
@@ -1940,7 +2041,10 @@ vocative_np_phrase := basic-unary-phrase & phrasal &
                       PRED addressee_rel,
                       ARG1 #arg1,
                       ARG2 #arg2 ] !>,
-            HCONS <! !> ] ].
+            HCONS <! !> ] ]
+"""
+; unary phrase types for vocatives
+""".
 
 vocative_np_prh_phrase := vocative_np_phrase &
 [ SYNSEM [ PUNCT [ LPUNCT no_punct,
@@ -1952,7 +2056,6 @@ vocative_np_psth_phrase  := vocative_np_phrase &
            LOCAL.CAT.POSTHEAD + ] ].
 
 
-; más de dos niños
 partitive_num_phrase := basic-unary-phrase & phrasal &
   [ SYNSEM [ PUNCT #punct,
              SLSHD #slshd,
@@ -1998,7 +2101,10 @@ partitive_num_phrase := basic-unary-phrase & phrasal &
 	     RELS <! [ PRED generic_entity_rel,
                        LBL #nhand,
                        ARG0 #index ] !>,
-	     HCONS <! !> ] ].
+	     HCONS <! !> ] ]
+"""
+; más de dos niños
+""".
 
 
 ; --- unary phrase types for gerundive constructions
@@ -2065,8 +2171,6 @@ vger_phrase := unary-phrase &
              HCONS <! qeq & [ HARG #main, LARG #modltop ], 
                       qeq & [ HARG #subord, LARG #vpltop ] !> ] ].
 
-; --- unary phrase type for adj-pastpart
-; removed "PRD non-prd" to deal with esos tíos son muy pesados
 adjpart_phrase := unary-phrase & 
   [ SYNSEM [ LIGHT -,
              SLSHD #slshd,
@@ -2108,10 +2212,11 @@ adjpart_phrase := unary-phrase &
                       NON-LOCAL #non-local ] ] >,
     C-CONT [ HOOK #hook,
              RELS <! !>,
-             HCONS <! !> ] ].
-
-; --- unary phrase type for predicative phrases
-; The adjective is not required to be POSTHEAD + to deal with "manipular mejor", comparative adjectives are POSTHEAD -
+             HCONS <! !> ] ]
+"""
+; --- unary phrase type for adj-pastpart
+; removed "PRD non-prd" to deal with esos tíos son muy pesados
+""".
 
 prdp_phrase := unary-phrase & 
   [ SYNSEM [ LIGHT -,
@@ -2166,12 +2271,13 @@ prdp_phrase := unary-phrase &
                        ARG1 #main,
                        ARG2 #subord ] !>,
              HCONS <! qeq & [ HARG #main, LARG #modltop ], 
-                      qeq & [ HARG #subord, LARG #vpltop ] !> ] ].
+                      qeq & [ HARG #subord, LARG #vpltop ] !> ] ]
+"""
+; --- unary phrase type for predicative phrases
+; The adjective is not required to be POSTHEAD + to deal with "manipular mejor", comparative adjectives are POSTHEAD -
+""".
 
 
-; --- unary phrase types for "construcciones de participio absoluto". 
-; Verb (transitive/unaccusative) passive participle + non-pronominal NP (subject)
-; e.g. acabada *ella/la reunión, todos se pusieron a trabajar. 
 cpa_phrase := unary-phrase & phrasal &
   [ SYNSEM [ PUNCT.RPUNCT comma_punct,
              SLSHD #slshd,
@@ -2221,10 +2327,13 @@ cpa_phrase := unary-phrase & phrasal &
                        ARG1 #arg1,
                        ARG2 #arg2 ] !>,
              HCONS <! [ HARG #arg1, LARG #larg1 ],
-                      [ HARG #arg2, LARG #larg2 ] !> ] ].
+                      [ HARG #arg2, LARG #larg2 ] !> ] ]
+"""
+; --- unary phrase types for "construcciones de participio absoluto". 
+; Verb (transitive/unaccusative) passive participle + non-pronominal NP (subject)
+; e.g. acabada *ella/la reunión, todos se pusieron a trabajar. 
+""".
 
-; --- unary phrase types adding the article to finite completive clauses
-; e.g. "El que haya dicho esto no me importa"
 cp-nom_phrase := unary-phrase & phrasal &
   [ SYNSEM [ SLSHD #slshd,
              LOCAL [ AGR.PNG.PN 3sg,
@@ -2256,10 +2365,12 @@ cp-nom_phrase := unary-phrase & phrasal &
     C-CONT [ HOOK.INDEX #index & ref-ind & [ PNG.PN 3sg ],
 	     RELS <! nominalize-relation &
                      [ ARG0 #index,
-                       ARG1 #chand ] !> ] ].
+                       ARG1 #chand ] !> ] ]
+"""
+; --- unary phrase types adding the article to finite completive clauses
+; e.g. "El que haya dicho esto no me importa"
+""".
 
-; --- unary phrase types adding the article to VP inf
-; e.g. 
 vp-nom_phrase := unary-phrase & phrasal &
   [ SYNSEM [ MODIFIED notmod,
              SLSHD #slshd,
@@ -2300,7 +2411,11 @@ vp-nom_phrase := unary-phrase & phrasal &
                           PRONTYPE not_pron ],
 	     RELS <! nominalize-relation &
                      [ ARG0 #index,
-                       ARG1 #chand ] !> ] ].
+                       ARG1 #chand ] !> ] ]
+"""
+; --- unary phrase types adding the article to VP inf
+; e.g. 
+""".
 
 ; --- phrase types for ellipsis
 
@@ -2375,12 +2490,14 @@ basic-ellipis-phrase := basic-headed-phrase & phrasal & basic-binary-phrase &
                         ARG0 #arg0 ]!>,
              HCONS <! !> ] ].
 
-; removed SYNSEM.LOCAL.STR.HEADING right_or_no, to deal with "el próximo, quizá"
 np_ell_phrase := basic-ellipis-phrase & binary-punct-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD.KEYS.ALTKEY _el_q_rel, 
     HEAD-DTR.SYNSEM [ LOCAL.CAT.HEAD +vjp & [ MOD < [ LOCAL.CAT.HEAD.KEYS.ALTKEY def_q_rel ] > ],
                       NON-LOCAL.REL 0-dlist ],
-    NON-HEAD-DTR.SYNSEM.LOCAL.CAT.VAL.SPEC < [ LOCAL.CAT.HEAD.KEYS.ALTKEY def_q_rel ] > ].
+    NON-HEAD-DTR.SYNSEM.LOCAL.CAT.VAL.SPEC < [ LOCAL.CAT.HEAD.KEYS.ALTKEY def_q_rel ] > ]
+"""
+; removed SYNSEM.LOCAL.STR.HEADING right_or_no, to deal with "el próximo, quizá"
+""".
 
 np_ell-indef_phrase := basic-ellipis-phrase & binary-punct-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD.KEYS.ALTKEY art_indef_q_rel, 
@@ -2389,6 +2506,15 @@ np_ell-indef_phrase := basic-ellipis-phrase & binary-punct-phrase &
     NON-HEAD-DTR.SYNSEM.LOCAL.CAT.VAL.SPEC < [ LOCAL.CAT.HEAD.KEYS.ALTKEY art_indef_q_rel ] > ].
 
 
+np_ell-sfrel_phrase := basic-ellipis-phrase & 
+  [ SYNSEM.LOCAL.STR.HEADING no,
+    HEAD-DTR.SYNSEM [ LOCAL.CAT.HEAD verb & 
+                                     [ VFORM fin,
+                                       TAM.MOOD ind_or_sub_mood,
+                                       MOD < [ LOCAL [ CAT.HEAD.KEYS.KEY non_named_non_modable_rel,
+                                                       CONT.HOOK.INDEX.SORT non-temp ] ] > ],
+                      NON-LOCAL.REL 1-dlist ] ]
+"""
 ; -- semi-free relatives (e.g. el/aquel que te dijo eso no conoce las raíces del conflicto)
 ; - el artículo determinado, o pron. demostrativo, informa de los rasgos de género y número 
 ; del antecedente elíptico
@@ -2398,14 +2524,7 @@ np_ell-indef_phrase := basic-ellipis-phrase & binary-punct-phrase &
 ; el verbo de la subordinada el que la selecciona (e.g. aquella de (la) que te hablé era espectacular).
 ; Pero si el determinante del antecedente es el artículo, tales casos son siempre agramaticales 
 ; (e.g. *la de (la) que te hablé era espectacular).
-np_ell-sfrel_phrase := basic-ellipis-phrase & 
-  [ SYNSEM.LOCAL.STR.HEADING no,
-    HEAD-DTR.SYNSEM [ LOCAL.CAT.HEAD verb & 
-                                     [ VFORM fin,
-                                       TAM.MOOD ind_or_sub_mood,
-                                       MOD < [ LOCAL [ CAT.HEAD.KEYS.KEY non_named_non_modable_rel,
-                                                       CONT.HOOK.INDEX.SORT non-temp ] ] > ],
-                      NON-LOCAL.REL 1-dlist ] ].
+""".
 
 
 ; --- filler-head-phrase types
@@ -2599,7 +2718,41 @@ filler-head-non_wh-phrase := filler-head-phrase & mc-fillhead-phrase & non-rel-c
                        LBL #ltop,
                        ARG1 #vind,
                        ARG2 #nhind ] !>,
-	     HCONS <! !> ] ]. 
+	     HCONS <! !> ] ]
+"""
+; i)- focus (foco antepuesto)
+; a). may be place to the left peripherical position of the main clause; i.e. may be separated from its clause by other 
+; clauses (e.g. Manzanas dijo María que compró Juan) or to the left peripherical position of the subordinated clause 
+; (e.g. María dijo que manzanas compró Juan), but it can't be related to any position within a relative, an adverbial 
+; and a subject clause (*A Pedro conocemos la mujer que traicionó); b). focus DO can't be doubled by an acc clitic 
+; (e.g. el diario (*lo) compró Juan); c). tiene que estar adyacente al verbo (*el diario Pedro lo compró);
+; d). puede relacionarse con un pronombre (e.g. su propio auto deberá asegurar cada taxista)      
+;
+; [sentential topic (vs discourse topic) may be associated to different sentential positions, e.g. subject 
+; in passive constructions ('NY es habitada por el rey de Francia), but there are some sentential positions 
+; that can only function as topic. This is the case of the left peripherical position we find in hanging topic 
+; and left dislocation.]
+; ii)- left dislocation ('dislocación a la izquierda')
+; a). puede aparecer en la periferia izquierda de la cláusula matriz o de la subordinada; b). existe una dependencia 
+; gramatical entre el tema y la posición dentro de la cláusula con la que se relationa; c). el tema no puede relacionarse 
+; con un epíteto ni con un pronombre tónico, pero cuando se relaciona con un OD o OI es obligatorio el clítico acc o dat; 
+; d). el tema no puede relacionarse con una posición dentro de una cláusula relativa, adverbial o sujeto
+; e.g. a sus amigos, María los invitó a cenar
+;      estoy segura de que a sus amigos, María los invitó a cenar
+;     *estoy segura de que a Pedro, conocemos la mujer que lo traicionó
+;
+; iii)- hanging topic ('tema vinculante') (may be preceded by the expression 'en cuanto a', 'con respecto a'). 
+; a). can only appear in the left peripherical position of the main clause; b). may be related with any position 
+; within the sentence which is occupied by a pronominal element (tónico o átono), o un epíteto, o puede tener una 
+; relación de tipo inalienable con un sintagma. Esta relación es referencial, no hay dependencia gramatical.
+; c). puede entrar en relación con cualquier posición sintáctica dentro de una cl. relativa, adverbial o de sujeto.
+; e.g. en cuanto al hermano, parece que los padres lo contemplan mucho/hablan de él constantemente
+;      en cuanto a el hermano, parece que el desgraciado se lleva bien con todo el mundo,
+;      en cuanto a la capacidad científica del Sr. González, basta con mencionar que este acaba de ganar un premio
+;      en cuanto al BMW, parece que los frenos le fallan constantemente
+;      (en cuanto a) el Sr. González, conocemos la mujer que lo traicionó 
+; !!! not covered
+""". 
   
 filler-head-non_wh_focus-phrase := filler-head-non_wh-phrase & 
   [ C-CONT.RELS <! [ PRED focus_d_rel ] !> ]. 
@@ -2708,6 +2861,20 @@ filler-head-rel-phrase := filler-head-phrase & relative-clause &
              HCONS <! !> ] ].
 
 
+filler-head-restr-rel-phrase := filler-head-rel-phrase & 
+  [ SYNSEM.LOCAL [ COORD #coord,
+                   COORD-STRAT #coord-strat,
+                   STR.HEADING no,
+                   CAT.HEAD [ VFORM fin_or_inf,
+                              MOD < [ PUNCT.RPUNCT no_punct, 
+                                      LOCAL.CAT.HEAD noun &
+                                                     [ KEYS.KEY nonpro_rel ] ] > ] ],
+    ARGS < [ SYNSEM.NON-LOCAL.REL 1-dlist & [ LIST < [ ] > ] ],
+           [ INFLECTED +,
+             SYNSEM [ PUNCT.LPUNCT no_punct, 
+                      LOCAL [ COORD #coord,
+                              COORD-STRAT #coord-strat ] ] ] > ]
+"""
 ; --- Restrictive RCs (e.g. la casa tenía [dos [habitaciones [que daban al parque]]])
 ; - Tiempo/modo:
 ;   - admiten las construcciones de infinitivo (hallamos el camino por donde escapar) 
@@ -2737,23 +2904,9 @@ filler-head-rel-phrase := filler-head-phrase & relative-clause &
 ;   a la subordinada, sino a la principal, siempre que el antecedente ocupe la posición posverbal.
 ;   e.g. le entregué una lista a María que contenía los nombres de todos los inscritos
 ;        de repente, apareció en la sala un individuo que parecía sacado de una película de terror.
-filler-head-restr-rel-phrase := filler-head-rel-phrase & 
-  [ SYNSEM.LOCAL [ COORD #coord,
-                   COORD-STRAT #coord-strat,
-                   STR.HEADING no,
-                   CAT.HEAD [ VFORM fin_or_inf,
-                              MOD < [ PUNCT.RPUNCT no_punct, 
-                                      LOCAL.CAT.HEAD noun &
-                                                     [ KEYS.KEY nonpro_rel ] ] > ] ],
-    ARGS < [ SYNSEM.NON-LOCAL.REL 1-dlist & [ LIST < [ ] > ] ],
-           [ INFLECTED +,
-             SYNSEM [ PUNCT.LPUNCT no_punct, 
-                      LOCAL [ COORD #coord,
-                              COORD-STRAT #coord-strat ] ] ] > ].
+""".
 
 
-; - RCs modifying elliptical NPs
-; e.g. lo único que importa es esto.
 filler-head-rel-np-mn-ellip-phrase := filler-head-restr-rel-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD.KEYS [ KEY elliptical_n_rel,
                                                             ALTKEY _el_q_rel ],
@@ -2762,13 +2915,15 @@ filler-head-rel-np-mn-ellip-phrase := filler-head-restr-rel-phrase &
     ARGS < [ SYNSEM [ LOCAL.CAT [ HEAD noun & [ KEYS.ALTKEY proper_q_rel ],
                                   VAL.SPR < > ],
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX #ind & [ SORT #sort ] ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - RCs modifying elliptical NPs
+; e.g. lo único que importa es esto.
+""". 
 
 filler-head_rel-fin-np-mn-ellip_phrase := filler-head-rel-np-mn-ellip-phrase & filler-head-phrase-fin.
 
 
-; - RCs modifying proper names
-; e.g. El Luís que más me gusta es el que sabe sobreponerse a cualquier dificultad
 filler-head-restr-rel-pname-phrase := filler-head-rel-phrase & 
   [ SYNSEM.LOCAL [ COORD #coord,
                    COORD-STRAT #coord-strat,
@@ -2791,40 +2946,46 @@ filler-head-restr-rel-pname-phrase := filler-head-rel-phrase &
            [ INFLECTED +,
              SYNSEM [ PUNCT.LPUNCT no_punct, 
                       LOCAL [ COORD #coord,
-                              COORD-STRAT #coord-strat ] ] ] > ].
+                              COORD-STRAT #coord-strat ] ] ] > ]
+"""
+; - RCs modifying proper names
+; e.g. El Luís que más me gusta es el que sabe sobreponerse a cualquier dificultad
+""".
 
 filler-head_rel-fin-np-mpn_phrase := filler-head-restr-rel-pname-phrase & filler-head-phrase-fin.
 
 
-; - RCs modifying common nouns, NP filler - for subject and DO RCs
-; e.g. la casa tenía dos habitaciones que daban al parque; la casa que compramos tenía dos habitaciones
 filler-head-rel-np-mn-phrase := filler-head-restr-rel-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ VAL.SPR < [ ] > ],
                                           CONT.HOOK.INDEX #ind ] ] >,
     ARGS < [ SYNSEM [ LOCAL.CAT [ HEAD noun & [ KEYS.ALTKEY proper_q_rel ],
                                   VAL.SPR < > ],
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX #ind ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - RCs modifying common nouns, NP filler - for subject and DO RCs
+; e.g. la casa tenía dos habitaciones que daban al parque; la casa que compramos tenía dos habitaciones
+""". 
 
 filler-head_rel-fin-np-mn_phrase := filler-head-rel-np-mn-phrase & filler-head-phrase-fin.
 filler-head_rel-inf-np-mn_phrase := filler-head-rel-np-mn-phrase & filler-head-phrase-inf &
   [ ARGS < [ SYNSEM.LOCAL.CAT.HEAD.CASE acc ], [ INFLECTED + ] > ].
 
 
-; - RCs modifying common nouns, MODNP filler - for lcomp/adjunct RCs
-; e.g. recuerdo el modo como llegó, la ciudad donde creció
 filler-head-rel-modnp-mn-phrase := filler-head-restr-rel-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD.KEYS.KEY non_modable_rel,
                                               VAL.SPR < [ LOCAL.CONT.HCONS  <! qeq !> ] > ] ] >,
     ARGS < [ SYNSEM.LOCAL.CAT.HEAD modnp ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - RCs modifying common nouns, MODNP filler - for lcomp/adjunct RCs
+; e.g. recuerdo el modo como llegó, la ciudad donde creció
+""". 
 
 filler-head_rel-fin-modnp-mn_phrase := filler-head-rel-modnp-mn-phrase & filler-head-phrase-fin.
 filler-head_rel-inf-modnp-mn_phrase := filler-head-rel-modnp-mn-phrase & filler-head-phrase-inf.
 
 
-; - RCs modifying common nouns, PP filler - for lcomp/adjunct RCs
-; e.g. la ciudad en la que creció, el país hacia el que partió
 filler-head-rel-pp-mn-phrase := filler-head-restr-rel-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD.KEYS.KEY non_modable_rel,
                                                 VAL.SPR < [ LOCAL.CONT.HCONS  <! qeq !> ] > ],
@@ -2832,41 +2993,47 @@ filler-head-rel-pp-mn-phrase := filler-head-restr-rel-phrase &
     ARGS < [ SYNSEM [ LOCAL.CAT.HEAD adp & [ KEYS [ KEY independent_rel,
                                                     ALT2KEY def_q_rel ] ],
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX #ind & [ SORT #sort ] ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - RCs modifying common nouns, PP filler - for lcomp/adjunct RCs
+; e.g. la ciudad en la que creció, el país hacia el que partió
+""". 
 
 filler-head_rel-fin-pp-mn_phrase := filler-head-rel-pp-mn-phrase & filler-head-phrase-fin.
 filler-head_rel-inf-pp-mn_phrase := filler-head-rel-pp-mn-phrase & filler-head-phrase-inf.
 
 
-; - RCs modifying common nouns, marked NP filler - for PPcomp RCs
-; e.g. la persona en la que más confío
 filler-head-rel-mkn-mn-phrase := filler-head-restr-rel-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD.KEYS.KEY non_modable_rel,
                                                 VAL.SPR < [ LOCAL.CONT.RELS  <! relation !> ] > ],
                                           CONT.HOOK.INDEX #ind & [ SORT #sort ] ] ] >,
     ARGS < [ SYNSEM [ LOCAL.CAT.HEAD adp & [ KEYS.KEY selected_rel ],
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX #ind & [ SORT #sort ] ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - RCs modifying common nouns, marked NP filler - for PPcomp RCs
+; e.g. la persona en la que más confío
+""". 
 
 filler-head_rel-fin-mkn-mn_phrase := filler-head-rel-mkn-mn-phrase & filler-head-phrase-fin.
 filler-head_rel-inf-mkn-mn_phrase := filler-head-rel-mkn-mn-phrase & filler-head-phrase-inf.
 
 
-; - RCs modifying common nouns, prep+donde filler (e.g. la ciudad en donde)
 filler-head-rel-r-mn-phrase := filler-head-restr-rel-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD.KEYS.KEY non_modable_rel,
                                               VAL.SPR < [ LOCAL.CONT.RELS  <! relation !> ] > ] ] >,
     ARGS < [ SYNSEM [ LOCAL [ CAT.HEAD adp,
                               CONT.RELS.LIST.REST.FIRST.PRED state_loc_rel ],
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX.SORT mod ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - RCs modifying common nouns, prep+donde filler (e.g. la ciudad en donde)
+""". 
 
 filler-head_rel-fin-r-mn_phrase := filler-head-rel-r-mn-phrase & filler-head-phrase-fin.
 filler-head_rel-inf-r-mn_phrase := filler-head-rel-r-mn-phrase & filler-head-phrase-inf.
 
 
-; - RCs modifying pronouns, NP filler
-; e.g. 
 filler-head-rel-np-mpr-phrase := filler-head-restr-rel-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD.KEYS [ KEY non_modable_rel,
                                                             ALTKEY def_or_udef_q_rel ],
@@ -2876,15 +3043,17 @@ filler-head-rel-np-mpr-phrase := filler-head-restr-rel-phrase &
     ARGS < [ SYNSEM [ LOCAL.CAT [ HEAD noun & [ KEYS.ALTKEY proper_q_rel ],
                                   VAL.SPR < > ],
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX #ind ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - RCs modifying pronouns, NP filler
+; e.g. 
+""". 
 
 filler-head_rel-fin-np-mpr_phrase := filler-head-rel-np-mpr-phrase & filler-head-phrase-fin.
 filler-head_rel-inf-np-mpr_phrase := filler-head-rel-np-mpr-phrase & filler-head-phrase-inf &
   [ ARGS < [ SYNSEM.LOCAL.CAT.HEAD.CASE acc ], [ ] > ].
 
 
-; - RCs modifying pronouns, PP filler
-; e.g. 
 filler-head-rel-pp-mpr-phrase := filler-head-restr-rel-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD.KEYS.KEY non_modable_rel,
                                                 VAL.SPR < > ],
@@ -2892,14 +3061,16 @@ filler-head-rel-pp-mpr-phrase := filler-head-restr-rel-phrase &
                                                  RELS <! relation, quant-relation !> ] ] ] >,
     ARGS < [ SYNSEM [ LOCAL.CAT.HEAD prep_or_modnp,
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX #ind ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - RCs modifying pronouns, PP filler
+; e.g. 
+""". 
 
 filler-head_rel-fin-pp-mpr_phrase := filler-head-rel-pp-mpr-phrase & filler-head-phrase-fin.
 filler-head_rel-inf-pp-mpr_phrase := filler-head-rel-pp-mpr-phrase & filler-head-phrase-inf.
 
 
-; - RCs modifying pronouns, RCs modifying deictic adverbs (only donde) 
-; e.g. allá donde estés tú estaré yo)
 filler-head-rel-pp-mr-phrase := filler-head-restr-rel-phrase & filler-head-phrase-fin & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD.KEYS.KEY modable_rel,
                                                 VAL.SPR < > ] ,
@@ -2907,7 +3078,11 @@ filler-head-rel-pp-mr-phrase := filler-head-restr-rel-phrase & filler-head-phras
     ARGS < [ SYNSEM [ LOCAL.CAT.HEAD prep_or_modnp,
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX #ind & [ SORT loc-mod ] ] > ] ] ],
            [ INFLECTED +,
-             SYNSEM.LOCAL.CAT.HEAD.VFORM fin ] > ].
+             SYNSEM.LOCAL.CAT.HEAD.VFORM fin ] > ]
+"""
+; - RCs modifying pronouns, RCs modifying deictic adverbs (only donde) 
+; e.g. allá donde estés tú estaré yo)
+""".
 
 filler-head_rel-fin-pp-mr_phrase := filler-head-rel-pp-mr-phrase.
 
@@ -2941,37 +3116,6 @@ filler-head_rel-fin-pp-mr_phrase := filler-head-rel-pp-mr-phrase.
 ; flr-hd_rel-inf-modnp-mntmp_constr := filler-head_rel-inf-modnp-mntmp_phrase & binary-rule-right-to-left.
 
 
-; --- Non-restrictive RCs (e.g. La casa tenía [[dos habitaciones],[que daban al parque]])
-; - vform and mood
-;   - rechazan las construcciones de infinitivo, y, sólo muy esporádicamente, admiten el subjuntivo
-;   e.g. *hallamos el camino, por donde escapar
-; - Relative pronouns
-;   - "el cual" y "quien" pueden aparecer sin restricción alguna.
-;   e.g. el periodista, quien dio la noticia, lleva tres días desaparecido
-;   llevó a reparar la pluma, la cual no escribía bien.
-;   - "que" debe puede concurrir con el artículo cuando aparece como término de ciertas preposiciones
-;   e.g. *donó la pluma, con que solía escribir/donó la pluma, con la que solía escribir
-; - antecedent:
-;   - pueden modificar un SN cuyo núcleo denote por sí solo entidades referenciales (pron. 
-;   personales tónico, nombres propios)
-;   e.g. Él/Luis, que estaba en desacuerdo, fue destituido fulminantemente
-;   - el antecedente puede llevar un posesivo prenominal
-;   e.g. su libro, con el que estudiamos, está un tanto desfasado
-;   - no pueden concurrir con antecedentes inespecíficos 
-;   e.g. *no ha venido nadie, que lo haya autorizado
-;   - pueden tener PPs como antecedentes en oraciones en las que la subordinada aparece introducida 
-;   por un relativo adverbial (como, cuando, donde)
-;   e.g. iremos de vacaciones en la primavera, cuando haya terminado este capítulo 
-;   - !!! pueden tener un antecedente oracional (un SN con valor proposicional), en la subordinada el 
-;   verbo debe seleccionar una completiva. Si la oración subordinada no lleva un verbo copulativo, es 
-;   necesario el artículo neutro
-;   e.g. finalmente, abandonó la reunión, que fue lo más prudente 
-;        presentó el recuso fuera de plazo, *(lo) que provocó que no fuera admitido
-;   - !!! con antecedente coordinado, los determinantes puden ser de distinta clase,
-;   e.g. el dragaminas y una corbeta, que cruzaron el estrecho, se dirigieron...
-; - !!! extraposición de la cláusula de relativo: la subordinada debe tener un inciso parentético,
-; el elemento interpuesto no puede ser confundido con el antecedente
-; e.g. me llamó tu primo ayer, que --por cierto-- no sabía que era tu cumpleaños
 filler-head-nonrestr-rel-phrase := binary-phrase & relative-clause &
   [ SYNSEM phr-synsem & 
            [ SLSHD #slshd,
@@ -3034,10 +3178,41 @@ filler-head-nonrestr-rel-phrase := binary-phrase & relative-clause &
                                   REL 0-dlist ] ] ] >,
     C-CONT [ HOOK.LTOP #ltop,
              RELS <! !>,
-             HCONS <! !> ] ].
+             HCONS <! !> ] ]
+"""
+; --- Non-restrictive RCs (e.g. La casa tenía [[dos habitaciones],[que daban al parque]])
+; - vform and mood
+;   - rechazan las construcciones de infinitivo, y, sólo muy esporádicamente, admiten el subjuntivo
+;   e.g. *hallamos el camino, por donde escapar
+; - Relative pronouns
+;   - "el cual" y "quien" pueden aparecer sin restricción alguna.
+;   e.g. el periodista, quien dio la noticia, lleva tres días desaparecido
+;   llevó a reparar la pluma, la cual no escribía bien.
+;   - "que" debe puede concurrir con el artículo cuando aparece como término de ciertas preposiciones
+;   e.g. *donó la pluma, con que solía escribir/donó la pluma, con la que solía escribir
+; - antecedent:
+;   - pueden modificar un SN cuyo núcleo denote por sí solo entidades referenciales (pron. 
+;   personales tónico, nombres propios)
+;   e.g. Él/Luis, que estaba en desacuerdo, fue destituido fulminantemente
+;   - el antecedente puede llevar un posesivo prenominal
+;   e.g. su libro, con el que estudiamos, está un tanto desfasado
+;   - no pueden concurrir con antecedentes inespecíficos 
+;   e.g. *no ha venido nadie, que lo haya autorizado
+;   - pueden tener PPs como antecedentes en oraciones en las que la subordinada aparece introducida 
+;   por un relativo adverbial (como, cuando, donde)
+;   e.g. iremos de vacaciones en la primavera, cuando haya terminado este capítulo 
+;   - !!! pueden tener un antecedente oracional (un SN con valor proposicional), en la subordinada el 
+;   verbo debe seleccionar una completiva. Si la oración subordinada no lleva un verbo copulativo, es 
+;   necesario el artículo neutro
+;   e.g. finalmente, abandonó la reunión, que fue lo más prudente 
+;        presentó el recuso fuera de plazo, *(lo) que provocó que no fuera admitido
+;   - !!! con antecedente coordinado, los determinantes puden ser de distinta clase,
+;   e.g. el dragaminas y una corbeta, que cruzaron el estrecho, se dirigieron...
+; - !!! extraposición de la cláusula de relativo: la subordinada debe tener un inciso parentético,
+; el elemento interpuesto no puede ser confundido con el antecedente
+; e.g. me llamó tu primo ayer, que --por cierto-- no sabía que era tu cumpleaños
+""".
 
-; - NRRCs modifying common/proper nouns, filler "que"
-; e.g. La casa tenía [[dos habitaciones],[que daban al parque]]
 filler-head_nonrestrel-n-mnp_phrase := filler-head-nonrestr-rel-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD noun & 
                                                      [ KEYS.KEY non_modable_rel ],
@@ -3052,11 +3227,13 @@ filler-head_nonrestrel-n-mnp_phrase := filler-head-nonrestr-rel-phrase &
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX #ind & 
                                                                [ PNG #png,
                                                                  SORT #sort ] ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - NRRCs modifying common/proper nouns, filler "que"
+; e.g. La casa tenía [[dos habitaciones],[que daban al parque]]
+""". 
 
 
-; - NRRCs modifying common/proper nouns, filler "el cual"/"quien"
-; e.g. el periodista, quien dio la noticia, desapareció; reparó la pluma, la cual no escribía bien.
 filler-head_nonrestrel-np-mnp_phrase := filler-head-nonrestr-rel-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD noun & 
                                                      [ KEYS.KEY non_modable_rel ],
@@ -3072,11 +3249,13 @@ filler-head_nonrestrel-np-mnp_phrase := filler-head-nonrestr-rel-phrase &
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX #ind & 
                                                                [ PNG #png,
                                                                  SORT #sort ] ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - NRRCs modifying common/proper nouns, filler "el cual"/"quien"
+; e.g. el periodista, quien dio la noticia, desapareció; reparó la pluma, la cual no escribía bien.
+""". 
 
 
-; - NRRCs modifying common/proper nouns, filler PP
-; e.g. donó la pluma, con la que solía escribir
 filler-head_nonrestrel-pp-mnp_phrase := filler-head-nonrestr-rel-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD noun & 
                                                      [ KEYS [ KEY non_modable_rel,
@@ -3086,11 +3265,13 @@ filler-head_nonrestrel-pp-mnp_phrase := filler-head-nonrestr-rel-phrase &
     ARGS < [ SYNSEM [ LOCAL.CAT.HEAD adp & [ KEYS [ KEY independent_rel,
                                                     ALT2KEY def_q_rel ] ],
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX.SORT #sort ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; - NRRCs modifying common/proper nouns, filler PP
+; e.g. donó la pluma, con la que solía escribir
+""". 
 
 
-; -  NRRCs modifying common/proper nouns, filler marked NP
-; e.g. 
 filler-head_nonrestrel-mkn-mnp_phrase := filler-head-nonrestr-rel-phrase & 
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD noun & 
                                                      [ KEYS [ KEY non_modable_rel,
@@ -3099,11 +3280,13 @@ filler-head_nonrestrel-mkn-mnp_phrase := filler-head-nonrestr-rel-phrase &
                                           CONT.HOOK.INDEX.SORT #sort ] ] >,
     ARGS < [ SYNSEM [ LOCAL.CAT.HEAD adp & [ KEYS.KEY selected_rel ],
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX.SORT #sort ] > ] ] ],
-           [ INFLECTED + ] > ]. 
+           [ INFLECTED + ] > ]
+"""
+; -  NRRCs modifying common/proper nouns, filler marked NP
+; e.g. 
+""". 
 
 
-; - NRRCs modifying common/proper nouns, filler modnp
-; e.g. fue hallada en la casa de Comillas, donde vivió en su juventud
 filler-head_nonrestrel-modnp-mnp_phrase :=  filler-head-nonrestr-rel-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD noun & 
                                                      [ KEYS [ KEY non_modable_rel,
@@ -3111,51 +3294,41 @@ filler-head_nonrestrel-modnp-mnp_phrase :=  filler-head-nonrestr-rel-phrase &
                                               VAL.SPR < > ] ] > ,
     ARGS < [ SYNSEM [ LOCAL.CAT.HEAD modnp,
                       NON-LOCAL.REL 1-dlist & [ LIST < [ ] > ] ] ],
-           [ INFLECTED + ] > ].
+           [ INFLECTED + ] > ]
+"""
+; - NRRCs modifying common/proper nouns, filler modnp
+; e.g. fue hallada en la casa de Comillas, donde vivió en su juventud
+""".
 
 
-; - NRRCs modifying adverbs/PPs, filler modnp
-; e.g. lo hice [discretamente/con precaución], como me había recomendado
 filler-head_nonrestrel-modnp-mpp_phrase :=  filler-head-nonrestr-rel-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT [ HEAD +rp,
                                               VAL.SPR < [ ] > ] ] >,
     ARGS < [ SYNSEM [ LOCAL.CAT.HEAD modnp,
                       NON-LOCAL.REL 1-dlist & [ LIST < [ ] > ] ] ],
-           [ INFLECTED + ] > ].
+           [ INFLECTED + ] > ]
+"""
+; - NRRCs modifying adverbs/PPs, filler modnp
+; e.g. lo hice [discretamente/con precaución], como me había recomendado
+""".
 
 
-; - NRRCs modifying modnp, filler modnp
-; e.g. lo hice así, como me había recomendado; recuerdo ese día, cuando dimitió
 filler-head_nonrestrel-modnp-mr_phrase :=  filler-head-nonrestr-rel-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL [ CAT [ HEAD modnp & [ KEYS.KEY modable_rel ],
                                                 VAL.SPR < > ],
                                           CONT.HOOK.INDEX #ind ] ] >,
     ARGS < [ SYNSEM [ LOCAL.CAT.HEAD modnp,
                       NON-LOCAL.REL 1-dlist & [ LIST < [ INDEX #ind & [ SORT mod ] ] > ] ] ],
-           [ INFLECTED + ] > ].
+           [ INFLECTED + ] > ]
+"""
+; - NRRCs modifying modnp, filler modnp
+; e.g. lo hice así, como me había recomendado; recuerdo ese día, cuando dimitió
+""".
 
 
 ; e.g. vivía sola, como siempre había deseado 
 
 
-; --- Free RCs (es el propio pronombre relativo el que delmita, en virtud de sus propios 
-; rasgos léxicos, el valor del antecedente). El valor de tales construcciones es el de proyecciones 
-; sintagmáticas infraoracionales (SN, SP, SAdv)
-; e.g. [quien te dijo eso] no conoce las raíces del conflicto, [con quien me quiero casar] vive aquí, 
-;      [donde vive tu hermano] es demasiado lejos para ir de vacaciones (NPs)
-;      he soñado [con quien soñé ayer], ayer vi [a quien le compraste el piso] (PPs)
-;      este traje lo llevaba [cuando se casó] (SAdv)
-; - sólo con "quien" y relativos adverbiales.
-; - admiten como máximo una preposición ante el pronombre o adverbio que las encabeza: 
-;   - esté doblemente seleccionada: e.g. he soñado con quien soñé ayer, ayer vi a quien se lo compraste
-;   - si la preposición corresponde al antecedente elíptico, la construcción es gramatical:
-;   e.g. luchó contra quienes se le opusieron
-;   - si la preposición está dentro de la relativa: si la relativa forma parte del sujeto 
-;   preverbal de la oración principal, la construcción es gramatical (e.g. con quien me quiero 
-;   casar vive a la vuelta); si desempeña cualquier otra función, es agramatical, excepto si es el OD
-;   (e.g. no tiene con quien salir). Este tipo de r. libres se construyen en infinitivo. 
-; ARGS < [ SYNSEM [ LOCAL [ CONT.HOOK.XARG #hand ] ],
-;        [ SYNSEM [ LOCAL [ CONT [ HOOK.LTOP #hand ] ] ] >.
 filler-head-free-rel-phrase := binary-phrase & phrasal &
   [ SYNSEM [ SLSHD #slshd,
              LOCAL [ COORD #coord,
@@ -3201,11 +3374,29 @@ filler-head-free-rel-phrase := binary-phrase & phrasal &
                                   REL 0-dlist ] ] ] >,
     C-CONT [ HOOK #hook, 
              RELS <! !>,
-	     HCONS <! !> ] ].
+	     HCONS <! !> ] ]
+"""
+; --- Free RCs (es el propio pronombre relativo el que delmita, en virtud de sus propios 
+; rasgos léxicos, el valor del antecedente). El valor de tales construcciones es el de proyecciones 
+; sintagmáticas infraoracionales (SN, SP, SAdv)
+; e.g. [quien te dijo eso] no conoce las raíces del conflicto, [con quien me quiero casar] vive aquí, 
+;      [donde vive tu hermano] es demasiado lejos para ir de vacaciones (NPs)
+;      he soñado [con quien soñé ayer], ayer vi [a quien le compraste el piso] (PPs)
+;      este traje lo llevaba [cuando se casó] (SAdv)
+; - sólo con "quien" y relativos adverbiales.
+; - admiten como máximo una preposición ante el pronombre o adverbio que las encabeza: 
+;   - esté doblemente seleccionada: e.g. he soñado con quien soñé ayer, ayer vi a quien se lo compraste
+;   - si la preposición corresponde al antecedente elíptico, la construcción es gramatical:
+;   e.g. luchó contra quienes se le opusieron
+;   - si la preposición está dentro de la relativa: si la relativa forma parte del sujeto 
+;   preverbal de la oración principal, la construcción es gramatical (e.g. con quien me quiero 
+;   casar vive a la vuelta); si desempeña cualquier otra función, es agramatical, excepto si es el OD
+;   (e.g. no tiene con quien salir). Este tipo de r. libres se construyen en infinitivo. 
+; ARGS < [ SYNSEM [ LOCAL [ CONT.HOOK.XARG #hand ] ],
+;        [ SYNSEM [ LOCAL [ CONT [ HOOK.LTOP #hand ] ] ] >.
+""".
 
 
-; - argumental free RC, NP filler 
-; e.g. [quien te dijo eso] no conoce las raíces del conflicto
 filler-head-free-rel-np-arg-phrase := filler-head-free-rel-phrase &
   [ SYNSEM.LOCAL [ AGR #agr,
                    CAT.HEAD #head ],
@@ -3215,13 +3406,15 @@ filler-head-free-rel-np-arg-phrase := filler-head-free-rel-phrase &
                       NON-LOCAL.SLASH <! #loc !> ] ], 
            [ SYNSEM.NON-LOCAL.SLASH 1-dlist &
                                     <! #loc & 
-                                       [ CAT.HEAD.KEYS.ALTKEY #altkey ] !> ] > ].
+                                       [ CAT.HEAD.KEYS.ALTKEY #altkey ] !> ] > ]
+"""
+; - argumental free RC, NP filler 
+; e.g. [quien te dijo eso] no conoce las raíces del conflicto
+""".
 
 filler-head_free-rel-fin-np-arg_phrase := filler-head-free-rel-np-arg-phrase & filler-head-phrase-fin.
 
 
-; - argumental free RC, marked NP filler 
-; e.g. [con quien me quiero casar] vive aquí, no tiene [con quien salir]
 filler-head-free-rel-mkn-arg-phrase := filler-head-free-rel-phrase &
   [ SYNSEM [ LOCAL.CAT.HEAD noun & [ MOD < >, 
                                      KEYS [ KEY #altkey,
@@ -3231,7 +3424,11 @@ filler-head-free-rel-mkn-arg-phrase := filler-head-free-rel-phrase &
                               CONT.RELS.LIST.FIRST.PRED free_relative_q_rel ],
                       NON-LOCAL.SLASH <! #loc !> ] ],
            [ SYNSEM.NON-LOCAL.SLASH 1-dlist &
-                                    <! #loc !> ] > ].
+                                    <! #loc !> ] > ]
+"""
+; - argumental free RC, marked NP filler 
+; e.g. [con quien me quiero casar] vive aquí, no tiene [con quien salir]
+""".
 
 filler-head_free-rel-fin-mkn-arg_phrase := filler-head-free-rel-mkn-arg-phrase & filler-head-phrase-fin & 
   [ SYNSEM.LOCAL.CAT.HEAD.CASE nom,
@@ -3242,8 +3439,6 @@ filler-head_free-rel-inf-mkn-arg_phrase := filler-head-free-rel-mkn-arg-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD.CASE acc ].
 
 
-; - argumental free RC, PP filler 
-; e.g. no tiene [donde vivir]
 filler-head-free-rel-pp-arg-phrase := filler-head-free-rel-phrase &
   [ SYNSEM [ LOCAL.CAT.HEAD noun & [ MOD < >, 
                                      KEYS [ KEY #altkey,
@@ -3253,7 +3448,11 @@ filler-head-free-rel-pp-arg-phrase := filler-head-free-rel-phrase &
                               CONT.RELS.LIST.REST.FIRST.PRED free_relative_q_rel ],
                       NON-LOCAL.SLASH <! #loc !> ] ],
            [ SYNSEM.NON-LOCAL.SLASH 1-dlist &
-                                    <! #loc & [ CAT.HEAD.MOD < [ ] > ] !> ] > ].
+                                    <! #loc & [ CAT.HEAD.MOD < [ ] > ] !> ] > ]
+"""
+; - argumental free RC, PP filler 
+; e.g. no tiene [donde vivir]
+""".
 
 filler-head_free-rel-fin-pp-arg_phrase := filler-head-free-rel-pp-arg-phrase & filler-head-phrase-fin & 
   [ SYNSEM.LOCAL [ AGR.PNG.PN 3sg,
@@ -3265,8 +3464,6 @@ filler-head_free-rel-inf-pp-arg_phrase := filler-head-free-rel-pp-arg-phrase & f
   [ SYNSEM.LOCAL.CAT.HEAD.CASE acc ].
 
 
-; - adjunct free RCs, PP filler 
-; e.g. este traje lo llevaba [cuando se casó]
 filler-head-free-rel-pp-adj-phrase := filler-head-free-rel-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD #head,
     ARGS < [ SYNSEM [ LOCAL [ CAT.HEAD #head & adp,
@@ -3288,7 +3485,11 @@ filler-head-free-rel-pp-adj-phrase := filler-head-free-rel-phrase &
                                                VAL #val ],
                                          CONT #cont,
                                          AGR #agr,
-                                         CTXT #ctxt ] !> ] > ].
+                                         CTXT #ctxt ] !> ] > ]
+"""
+; - adjunct free RCs, PP filler 
+; e.g. este traje lo llevaba [cuando se casó]
+""".
 
 filler-head_free-rel-fin-pp-adj_phrase := filler-head-free-rel-pp-adj-phrase & filler-head-phrase-fin.
 filler-head_free-rel-inf-pp-adj_phrase := filler-head-free-rel-pp-adj-phrase & filler-head-phrase-inf.
@@ -3393,6 +3594,13 @@ extcomp-a_phrase := basic-extracted-comp-phrase &
 extcomp-v_phrase := basic-extracted-comp-phrase &
   [ HEAD-DTR.SYNSEM.LOCAL.CAT.HEAD verb & [ KEYS.KEY v_event_rel ] ].
 
+extcomp-n_phrase := basic-extracted-comp-phrase &
+  [ SYNSEM.SLSHD -, 
+    HEAD-DTR.SYNSEM.LOCAL [ CAT [ HEAD noun,
+                                  VAL.COMPS < [ OPT +, 
+                                                LOCAL.CAT.HEAD.KEYS.KEY _de_p_sel_rel ] > ] ,
+                            CONT.HOOK.INDEX.SORT non-temp ] ]
+"""
 ; -- extracción de complementos nominales
 ; - si aparecen realizados simultáneamente un genitivo subjetivo y otro objetivo, no es 
 ; posible la relativización de este último (e.g. *al asesino, cuya descripción de María...)
@@ -3403,18 +3611,8 @@ extcomp-v_phrase := basic-extracted-comp-phrase &
 ; e.g. esa novela, de la que acaban de salir varias traducciones, ha tenido un gran éxito
 ; pero para cubrir "de las ventas totales, el 72% corresponde a la farmacia", quito 
 ; HEAD-DTR.SYNSEM.LOCAL [ CAT [ HEAD noun & [ KEYS.ALTKEY undef_quant_q_rel ],
-extcomp-n_phrase := basic-extracted-comp-phrase &
-  [ SYNSEM.SLSHD -, 
-    HEAD-DTR.SYNSEM.LOCAL [ CAT [ HEAD noun,
-                                  VAL.COMPS < [ OPT +, 
-                                                LOCAL.CAT.HEAD.KEYS.KEY _de_p_sel_rel ] > ] ,
-                            CONT.HOOK.INDEX.SORT non-temp ] ].
+""".
 
-; - con SNs determinados sólo puede aparecer "cuyo". Las codas de los partitivos no pueden 
-; ser relativizadas a través de cuyo
-; e.g. esa novela, cuyas traducciones acaban de salir, ha tenido un gran éxito (subj)
-;      tu amigo, cuyas padres conozco perfectamente, es un cretino (DO)
-;      en un lugar de la Mancha de cuyo nombre no quiero acordarme... (PPcomp)
 extcomp-n-df_phrase := head-only & head-compositional &
   [ SYNSEM.SLSHD -, 
     SYNSEM [ LIGHT -,
@@ -3449,9 +3647,15 @@ extcomp-n-df_phrase := head-only & head-compositional &
                                   QUE 0-dlist,
                                   REL 0-dlist ] ],
     C-CONT [ RELS <! !>,
-	     HCONS <! !> ] ].
+	     HCONS <! !> ] ]
+"""
+; - con SNs determinados sólo puede aparecer "cuyo". Las codas de los partitivos no pueden 
+; ser relativizadas a través de cuyo
+; e.g. esa novela, cuyas traducciones acaban de salir, ha tenido un gran éxito (subj)
+;      tu amigo, cuyas padres conozco perfectamente, es un cretino (DO)
+;      en un lugar de la Mancha de cuyo nombre no quiero acordarme... (PPcomp)
+""".
 
-; verbal adjunct are extracted before canceling the complement because "ayer cumplió usted años"
 basic-extracted-adj-phrase := head-mod-phrase & head-only & phrasal & 
   [ SYNSEM [ LOCAL.CAT [ POSTHEAD #ph,
                          MC #mc,
@@ -3477,7 +3681,10 @@ basic-extracted-adj-phrase := head-mod-phrase & head-only & phrasal &
                       NON-LOCAL.SLASH 0-dlist ],
     C-CONT [ HOOK #hook,
 	     RELS <! !>,
-	     HCONS <! !> ] ].
+	     HCONS <! !> ] ]
+"""
+; verbal adjunct are extracted before canceling the complement because "ayer cumplió usted años"
+""".
 
 extadj-v_phrase := basic-extracted-adj-phrase &
   [ SYNSEM [ SLSHD -, 
@@ -3490,15 +3697,17 @@ extadj-v_phrase := basic-extracted-adj-phrase &
                       LOCAL.CAT [ HEAD verb & [ AUX -, MOD < > ],
                                   VAL.SUBJ #subj ] ] ].
 
-; (possesivos) - cuando el elemento poseído es indeterminado debe expresarse con un SP_de
-; e.g. el vecino del que guardo algunos objetos vendrá mañana.
 extadj-n_phrase := basic-extracted-adj-phrase &
   [ SYNSEM [ SLSHD -, 
              NON-LOCAL.SLASH <! [ CAT.HEAD.KEYS.KEY _de_p_rel ] !> ],
     HEAD-DTR.SYNSEM [ LOCAL.CAT.HEAD noun & [ KEYS [ KEY common_nom_rel, 
                                                      ALTKEY undef_quant_q_rel ] ],
                       NON-LOCAL [ REL 0-dlist,
-                                  QUE 0-dlist ] ] ].
+                                  QUE 0-dlist ] ] ]
+"""
+; (possesivos) - cuando el elemento poseído es indeterminado debe expresarse con un SP_de
+; e.g. el vecino del que guardo algunos objetos vendrá mañana.
+""".
 
 
 
@@ -3589,31 +3798,41 @@ conj_no_verb_phrase := phrase &
                                   QUE 0-dlist,
                                   REL 0-dlist ] ] ], ... >,
     C-CONT [ HOOK #hook,
-	     HCONS #hcons ] ].
+	     HCONS #hcons ] ]
+"""
+;; elliptical constructions both for S+S gapping and VP=VP conjunction reduction, 
+;; where in both cases the verb is missing from the second conjunct.  
+;; The approach is to have a multi-daughter rule where
+;; the first daughter is the full S or VP, the second daughter is a 
+;; conjunction lexical item, and the remaining two or three daughters are
+;; the complements and/or modifiers of the missing verb.
+""".
 
-;; VP+conj+XP+XP
-;;
 conj_reduct_phrase := conj_no_verb_phrase &
   [ ARGS.FIRST.SYNSEM.LOCAL [ CAT [ HEAD.LSYNSEM.LOCAL [ CAT.VAL.SUBJ #subj,
 							 CONT.HOOK.XARG #xarg ],
 				    VAL.SUBJ #subj & < synsem > ] ],
-    C-CONT.HOOK.XARG #xarg ].
-
-
-;; Double complement
+    C-CONT.HOOK.XARG #xarg ]
+"""
+;; VP+conj+XP+XP
 ;;
+""".
+
+
 conj_red_c_c_phrase := conj_reduct_phrase & quad_phrase &
   [ ARGS < [ SYNSEM.LOCAL.CAT.HEAD.LSYNSEM [ LOCAL.CAT.VAL.COMPS < #comp1, #comp2 >, 
 					     LKEYS.KEYREL.LBL #rltop ] ],
 	   [ SYNSEM.LKEYS.KEYREL.R-HNDL #rltop ], 
 	   [ SYNSEM #comp1 ], 
 	   [ SYNSEM #comp2 ] >,
-    C-CONT.RELS <! !> ].
+    C-CONT.RELS <! !> ]
+"""
+;; Double complement
+;;
+""".
 
 conj_red_c_c_constr := conj_red_c_c_phrase & quad_rule_left_to_right.
 
-;; Final phrase is a modifier
-;;
 basic_conj_red_x_m_rule := conj_reduct_phrase & quad_phrase &
   [ ARGS < [ SYNSEM [ LOCAL.CAT #vpcat & 
                                 [ HEAD.LSYNSEM.LOCAL.CAT.VAL.COMPS < #comp > ],
@@ -3623,12 +3842,15 @@ basic_conj_red_x_m_rule := conj_reduct_phrase & quad_phrase &
 	   [ SYNSEM phr-synsem &
 		    [ LOCAL [ CAT.HEAD.MOD < synsem &
 					     [ LOCAL.CAT #vpcat ] >,
-			      CONT.HOOK.LTOP #rltop ] ] ] > ].
+			      CONT.HOOK.LTOP #rltop ] ] ] > ]
+"""
+;; Final phrase is a modifier
+;;
+""".
 
 conj_red_x_m_rule := basic_conj_red_x_m_rule &
   [ C-CONT.RELS <! !> ].
 
-;; Intersective modifier
 basic_conj_red_x_m-int_rule := basic_conj_red_x_m_rule &
   [ ARGS < [ SYNSEM.LOCAL.CAT.HEAD.LSYNSEM.LKEYS.KEYREL [ LBL #ltop,
 							  ARG0 #index ] ],
@@ -3638,38 +3860,45 @@ basic_conj_red_x_m-int_rule := basic_conj_red_x_m_rule &
 							 [ LTOP #ltop,
 							   INDEX #index ] ] ] >,
 			    CONT.HOOK [ LTOP #ltop,
-					XARG #index ] ] ] > ].
+					XARG #index ] ] ] > ]
+"""
+;; Intersective modifier
+""".
 
 conj_red_x_m-int_rule := basic_conj_red_x_m-int_rule & conj_red_x_m_rule.
 
-;; Scopal modifier
 basic_conj_red_x_m-scop_rule := conj_red_x_m_rule &
   [ ARGS < [ SYNSEM.LOCAL.CAT.HEAD.LSYNSEM.LKEYS.KEYREL [ LBL #ltop,
 							  ARG0 #index ] ],
 	   [ ], [ ],
 	   [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL scopal-mod &
 					         [ CONT.HOOK [ LTOP #ltop,
-						               INDEX #index ] ] ] > ] > ].
+						               INDEX #index ] ] ] > ] > ]
+"""
+;; Scopal modifier
+""".
 
-;; Identity of complement followed by intersective modifier
-;;
 conj_red_c_m-int_constr := conj_red_x_m-int_rule & quad_rule_left_to_right &
   [ ARGS < [ SYNSEM.LOCAL.CAT.HEAD.LSYNSEM.LOCAL.CAT.VAL.COMPS < #comp1 > ],
 	   [ ],
 	   [ SYNSEM #comp1 ], 
-	   [ ] > ].
-
-;; Identity of complement followed by scopal modifier
+	   [ ] > ]
+"""
+;; Identity of complement followed by intersective modifier
 ;;
+""".
+
 conj_red_c_m-scop_constr := basic_conj_red_x_m-scop_rule & quad_rule_left_to_right &
   [ ARGS < [ SYNSEM.LOCAL.CAT.HEAD.LSYNSEM.LOCAL.CAT.VAL.COMPS < #comp1 > ],
 	   [ ],
 	   [ SYNSEM #comp1 ], 
-	   [ ] > ].
-
-
-;; For sentence-level gapping: S + SnoV
+	   [ ] > ]
+"""
+;; Identity of complement followed by scopal modifier
 ;;
+""".
+
+
 basic_conj_nov_subj_rule := conj_no_verb_phrase & quad_rule_left_to_right &
 			    quad_phrase &
   [ ARGS < [ SYNSEM.LOCAL [ CAT [ VAL [ SUBJ < >, 
@@ -3679,7 +3908,11 @@ basic_conj_nov_subj_rule := conj_no_verb_phrase & quad_rule_left_to_right &
 	   [ ], 
 	   [ ],
 	   [ ] >,
-    C-CONT.RELS <! !> ].
+    C-CONT.RELS <! !> ]
+"""
+;; For sentence-level gapping: S + SnoV
+;;
+""".
 
 conj_nov_subj_rule := basic_conj_nov_subj_rule &
   [ ARGS < [ SYNSEM.LOCAL.CAT.HEAD.LSYNSEM.LOCAL.CAT.VAL.SUBJ < #subj > ],
@@ -3688,18 +3921,19 @@ conj_nov_subj_rule := basic_conj_nov_subj_rule &
 	   [ ] >,
     C-CONT.RELS <! !> ].
 
-;; S+and+NP+Comp
-;;
+
 conj_nov_sb_c_rule := conj_nov_subj_rule &
   [ ARGS < [ SYNSEM.LOCAL.CAT.HEAD.LSYNSEM [ LOCAL.CAT.VAL.COMPS < #comp1 >,
 					     LKEYS.KEYREL.LBL #rltop ] ],
 	   [ SYNSEM.LKEYS.KEYREL.R-HNDL #rltop ], 
 	   [ ], 
-	   [ SYNSEM #comp1 & [ NON-LOCAL.SLASH.LAST < > ] ] > ].
-
-
-;; S+and+NP+Mod (intersective)
+	   [ SYNSEM #comp1 & [ NON-LOCAL.SLASH.LAST < > ] ] > ]
+"""
+;; S+and+NP+Comp
 ;;
+""".
+
+
 conj_nov_sb_m-int_rule := conj_nov_subj_rule &
   [ ARGS < [ SYNSEM [ LOCAL.CAT.HEAD.LSYNSEM [ LKEYS.KEYREL [ LBL #ltop,
 							      ARG0 #index ] ],
@@ -3714,10 +3948,12 @@ conj_nov_sb_m-int_rule := conj_nov_subj_rule &
 						    [ LTOP #ltop,
 						      INDEX #index ] ] ] >,
 			      CONT.HOOK [ LTOP #ltop,
-					  XARG #index ] ] ] ] > ].
-
-;; S+and+NP+Mod (scopal)
+					  XARG #index ] ] ] ] > ]
+"""
+;; S+and+NP+Mod (intersective)
 ;;
+""".
+
 conj_nov_sb_m-scop_rule := conj_nov_subj_rule &
   [ ARGS < [ SYNSEM [ LOCAL.CAT.HEAD.LSYNSEM [ LKEYS.KEYREL [ LBL #ltop,
 							      ARG0 #ind ] ],
@@ -3730,11 +3966,13 @@ conj_nov_sb_m-scop_rule := conj_nov_subj_rule &
 					       [ CAT.HEAD verb, 
 						 CONT.HOOK [ LTOP #ltop,
 							     INDEX #ind ] ] ] >,
-			      CONT.HOOK.LTOP #rltop ] ] ] > ].
-
-
-;; S+and+Mod+NP (intersective)
+			      CONT.HOOK.LTOP #rltop ] ] ] > ]
+"""
+;; S+and+NP+Mod (scopal)
 ;;
+""".
+
+
 conj_nov_m-int_sb_rule := basic_conj_nov_subj_rule &
   [ ARGS < [ SYNSEM [ LOCAL.CAT.HEAD.LSYNSEM [ LOCAL.CAT.VAL.SUBJ < #subj >,
                                                LKEYS.KEYREL [ LBL #ltop,
@@ -3750,10 +3988,12 @@ conj_nov_m-int_sb_rule := basic_conj_nov_subj_rule &
 						      INDEX #index ] ] ] >,
 			      CONT.HOOK [ LTOP #ltop,
 					  XARG #index ] ] ] ], 
-	   [ SYNSEM #subj ] > ].
+	   [ SYNSEM #subj ] > ]
+"""
+;; S+and+Mod+NP (intersective)
+;;
+""".
 
-
-;;; coordinate reduction
 
 vp-vp_crd-red_phrase := coord-phrase & 
   [ SYNSEM [ SLSHD #slshd,
@@ -3782,7 +4022,10 @@ vp-vp_crd-red_phrase := coord-phrase &
     C-CONT [ RELS <! !>,
 	     HCONS <! !>, 
              HOOK [ LTOP #lbl, 
-                    INDEX #carg ] ] ].
+                    INDEX #carg ] ] ]
+"""
+;;; coordinate reduction
+""".
 
 
 vp-vp_crd-red_constr := vp-vp_crd-red_phrase &  binary-rule-right-to-left. 
@@ -3902,7 +4145,12 @@ monopoly-top-coord-phrase := top-coord-phrase &
   [ SYNSEM.LOCAL.STR.HEADED right,
     LCOORD-DTR.SYNSEM.LOCAL.COORD -,
     RCOORD-DTR.SYNSEM.LOCAL [ COORD +,
-                              STR.HEADING right ] ].
+                              STR.HEADING right ] ]
+"""
+; -- monopoly*: Mandatory monosyndeton with optional polysyndeton. This is the 
+; familiar Indo-European pattern, in which at least one coordinator is mandatory 
+; ("A B and C") and more than one is possible ("A and B and C").
+""".
 
 non_advers-monopoly-top-coord-phrase := monopoly-top-coord-phrase & 
   [ LCOORD-DTR.SYNSEM.LOCAL.COORD-STRAT zero_or_one,
@@ -3958,6 +4206,7 @@ monopoly-mid-coord-phrase := mid-coord-phrase &
 ; *left* daughter instead of the right.
 ;
 ; We use it for complex conjunctions
+
 omni-binary-bottom-coord-phrase := bottom-coord-phrase & binary-phrase &
   [ SYNSEM.LOCAL [ COORD +,
                    COORD-REL null-coord-rel,
@@ -3971,7 +4220,31 @@ omni-binary-bottom-coord-phrase := bottom-coord-phrase & binary-phrase &
                                CAT [ HEAD #mod,
                                      VAL #val ] ],
     C-CONT [ RELS <! !>,
-	     HCONS <! !> ] ].
+	     HCONS <! !> ] ]
+"""
+; -- omni: This handles a variety of polysyndeton, called here for
+; clarity "omnisyndeton", in which for an N-way coordination, N
+; coordinators are required:
+;
+;     "and A and B and C" or "A and B and C and".
+;
+; This coordination strategy requires a significantly approach than
+; the others. Rather than a single kind of bottom rule, there are two
+; kinds. The first kind, still called "bottom", handles the single
+; lowest (rightmost) coordinand.  The other kind, called "left",
+; handles all other coordinands (it's called "left" because it is
+; always the left daughter of a top- or mid- rule).  Because there are
+; N coordinators for N coordinands in this strategy, one of the
+; conjunctions must contribute *no* coordination relation, or else
+; we'd have too many.  The bottom rule is the exceptional one: it
+; requires that its conjunction daughter be of type nosem-conj-lex.
+;
+; The mid- and top- rules are also slightly different from the other
+; coordination strategies, in that they take the COORD-REL from the
+; *left* daughter instead of the right.
+;
+; We use it for complex conjunctions
+""".
 
 omni-conj-first-bottom-coord-phrase := omni-binary-bottom-coord-phrase &
   [ SYNSEM.LOCAL [ STR [ HEADED left,
@@ -4074,6 +4347,20 @@ nom-coord-phrase := coord-phrase &
 
 
 ; N coordination types
+
+n-top-coord-phrase := nom-coord-phrase & 
+  [ SYNSEM.LOCAL [ AGR [ PNG #png,
+                         DIVISIBLE + ],
+                   CONT.HOOK.INDEX.PNG #png ],
+    LCOORD-DTR.SYNSEM.LOCAL [ AGR.PNG #png,
+                              CAT [ HEAD.KEYS.KEY non_named_non_modable_rel, 
+                                    VAL.SPR < [ ] > ] ],
+    RCOORD-DTR.SYNSEM.LOCAL [ CAT [ HEAD.KEYS.KEY non_named_non_modable_rel,
+                                    VAL.SPR < [ ] > ] ],
+    C-CONT [ RELS <! !>,
+	     HCONS <! !> ] ]
+"""
+; N coordination types
 ; - cuando se coordinan dos nombres concretos, que comparten el determinante, el 
 ; resultado sólo designa a un objeto con las propiedades designadas por los dos 
 ; sustantivos. La concordancia con el verbo es en singular (el presidente y 
@@ -4087,17 +4374,7 @@ nom-coord-phrase := coord-phrase &
 ; de sujeto siempre se interpreta como definido y el de objeto como indefinido. 
 ; Sólo aparecen en predicados episódicos (madre e hijo estaban en casa, 
 ; *madre e hijo eran altos).
-n-top-coord-phrase := nom-coord-phrase & 
-  [ SYNSEM.LOCAL [ AGR [ PNG #png,
-                         DIVISIBLE + ],
-                   CONT.HOOK.INDEX.PNG #png ],
-    LCOORD-DTR.SYNSEM.LOCAL [ AGR.PNG #png,
-                              CAT [ HEAD.KEYS.KEY non_named_non_modable_rel, 
-                                    VAL.SPR < [ ] > ] ],
-    RCOORD-DTR.SYNSEM.LOCAL [ CAT [ HEAD.KEYS.KEY non_named_non_modable_rel,
-                                    VAL.SPR < [ ] > ] ],
-    C-CONT [ RELS <! !>,
-	     HCONS <! !> ] ].
+""".
 
 n-middle-coord-phrase := nom-coord-phrase & 
   [ SYNSEM.LOCAL [ COORD-REL #crel,
@@ -4137,6 +4414,14 @@ n-n_crd-omni-left_phrase := n-bottom-coord-phrase & omni-conj-first-left-coord-p
 n-n_crd-omni-bot_phrase := n-bottom-coord-phrase & omni-conj-first-bottom-coord-phrase.
 
 
+np-top-coord-phrase := nom-coord-phrase & 
+  [ SYNSEM.LOCAL [ AGR [ PNG.PN plur,
+                         DIVISIBLE + ],
+                   CAT.VAL.SPR < > ],
+    RCOORD-DTR.SYNSEM.LOCAL.CAT.VAL.SPR < >,
+    C-CONT [ RELS <! !>,
+	     HCONS <! !> ] ]
+"""
 ; NP coordination types
 ; - mostly, coordinated subjects are in plural, but there may be partial agreement 
 ; with one of the subjects when the verb precedes the subject and when the subject denotes
@@ -4157,13 +4442,7 @@ n-n_crd-omni-bot_phrase := n-bottom-coord-phrase & omni-conj-first-bottom-coord-
 ; adopta dos patrones: si el adjetivo concuerda en plural, éste modifica a todo el 
 ; sintagma ([el pensamiento y la acción] políticos); si sólo modifica a una de las
 ; partes, debe concordar con esa parte ([el pensamiento y la acció política]). 
-np-top-coord-phrase := nom-coord-phrase & 
-  [ SYNSEM.LOCAL [ AGR [ PNG.PN plur,
-                         DIVISIBLE + ],
-                   CAT.VAL.SPR < > ],
-    RCOORD-DTR.SYNSEM.LOCAL.CAT.VAL.SPR < >,
-    C-CONT [ RELS <! !>,
-	     HCONS <! !> ] ].
+""".
 
 3per_np-top-coord-phrase := np-top-coord-phrase.
 
@@ -4262,10 +4541,7 @@ np-np_crd-omni-bot_phrase := np-bottom-coord-phrase & omni-conj-first-bottom-coo
 
 
 ; AP coordination types
-; NOTE that in fact qualitative adjectives may be coordinated without restrictions (e.g. 
-; el magnífico y único recital, comidas (muy buenas) y (muy baratas), coordination of 
-; relational adjectives show some restrictions (productos alemanes y suecos, *producto 
-; alemán y sueco, *el verdadero y alemán espía)
+
 adj-coord-phrase := event-coord-phrase &
   [ SYNSEM.LOCAL [ CAT [ MC na,
                          LASTNMOD #lastnmod,
@@ -4280,7 +4556,13 @@ adj-coord-phrase := event-coord-phrase &
     RCOORD-DTR.SYNSEM.LOCAL [ CAT [ LASTNMOD #lastnmod,
                                     POSTHEAD #ph,
                                     HEAD adj & [ MOD < [ LOCAL.CONT #cont ] > ] ],
-                              CONT.HOOK.XARG #xarg ] ].
+                              CONT.HOOK.XARG #xarg ] ]
+"""
+; NOTE that in fact qualitative adjectives may be coordinated without restrictions (e.g. 
+; el magnífico y único recital, comidas (muy buenas) y (muy baratas), coordination of 
+; relational adjectives show some restrictions (productos alemanes y suecos, *producto 
+; alemán y sueco, *el verdadero y alemán espía)
+""".
 
 adj-top-coord-phrase := adj-coord-phrase &
   [ C-CONT [ RELS <! !>,
@@ -4312,17 +4594,23 @@ adj-bottom-coord-phrase := bottom-coord-phrase &
                                CONT.HOOK [ INDEX #ind,
                                            XARG #xarg ] ] ].
 
+a-a_crd-advrs_phrase := adj-top-coord-phrase & advers-monopoly-top-coord-phrase
+"""
 ; binary (adversative) coordination (guapo pero antipático)
-a-a_crd-advrs_phrase := adj-top-coord-phrase & advers-monopoly-top-coord-phrase.
+""".
 
+a-a_crd-mono-top_phrase := i-adj-top-coord-phrase & non_advers-monopoly-top-coord-phrase
+"""
 ; multiple monosyndeton/polysyndeton coordination (guapo, (y) listo y simpático) and 
-a-a_crd-mono-top_phrase := i-adj-top-coord-phrase & non_advers-monopoly-top-coord-phrase.
+""".
 a-a_s-crd-mono-top_phrase := s-adj-top-coord-phrase & non_advers-monopoly-top-coord-phrase.
 a-a_crd-mono-mid_phrase := adj-middle-coord-phrase & monopoly-mid-coord-phrase.
 a-a_crd-mono-bot_phrase := adj-bottom-coord-phrase & conj-first-bottom-coord-phrase.
 
+a-a_crd-omni-top_phrase := adj-top-coord-phrase & omni-top-coord-phrase
+"""
 ; omnisyndeton coordination (no sólo guapo sino simpático)
-a-a_crd-omni-top_phrase := adj-top-coord-phrase & omni-top-coord-phrase.
+""".
 a-a_crd-omni-mid_phrase := adj-middle-coord-phrase & omni-mid-coord-phrase.
 a-a_crd-omni-left_phrase := adj-bottom-coord-phrase & omni-conj-first-left-coord-phrase.
 a-a_crd-omni-bot_phrase := adj-bottom-coord-phrase & omni-conj-first-bottom-coord-phrase.
@@ -4382,10 +4670,6 @@ r-r_crd-omni-bot_phrase := adv-bottom-coord-phrase & omni-conj-first-bottom-coor
 
 ; -- Coordination of verbs
 
-; S coordination types
-; not need to have the same tense and mood (e.g. [Pepa no llegó] y [no pedirá un tinto])
-; !!! they may share a complement (los Pérez trajeron, y los invitados se comieron, una 
-; ensalada deliciosa)- always between commas
 cl-coord-phrase := event-coord-phrase & 
   [ SYNSEM [ LOCAL.CAT [ MC #mc,
                          LASTNMOD #lastnmod,
@@ -4408,7 +4692,13 @@ cl-coord-phrase := event-coord-phrase &
                                          [ VFORM #vform,
                                            MOD #mod,
                                            PRD #prd ] ],
-                        NON-LOCAL #nlocal ] ].
+                        NON-LOCAL #nlocal ] ]
+"""
+; S coordination types
+; not need to have the same tense and mood (e.g. [Pepa no llegó] y [no pedirá un tinto])
+; !!! they may share a complement (los Pérez trajeron, y los invitados se comieron, una 
+; ensalada deliciosa)- always between commas
+""".
 
 cl-top-coord-phrase := cl-coord-phrase & 
   [ C-CONT [ RELS <! !>,
@@ -4448,8 +4738,7 @@ cl-cl_crd-omni-bot_phrase := cl-bottom-coord-phrase & omni-conj-first-bottom-coo
 
 
 ; VP coordination types
-; - only with the same tense and mood (e.g. Magdalena casi [se tropezó y se cayó/*se cae])
-; but "el régimen se tambalea y pronto caerá", so they don't need to have the same tense
+
 vp-coord-phrase := event-coord-phrase & 
   [ SYNSEM.LOCAL.CAT [ LASTNMOD #lastnmod,
                        MC #mc,
@@ -4473,7 +4762,12 @@ vp-coord-phrase := event-coord-phrase &
                                          VFORM #vform ],
                                   VAL [ SUBJ < [ ] >,
                                         COMPS < >,
-                                        CLTS < > ] ] ].
+                                        CLTS < > ] ] ]
+"""
+; VP coordination types
+; - only with the same tense and mood (e.g. Magdalena casi [se tropezó y se cayó/*se cae])
+; but "el régimen se tambalea y pronto caerá", so they don't need to have the same tense
+""".
 
 vp-top-coord-phrase := vp-coord-phrase & 
   [ C-CONT [ RELS <! !>,
@@ -4506,15 +4800,7 @@ vp-vp_crd-omni-bot_phrase := vp-bottom-coord-phrase & omni-conj-first-bottom-coo
 
 
 ; V coordination types
-; - la coordinación de núcleos verbales es más aceptable en la medida en que los 
-; dos verbos se interpretan como relacionados semánticamente (trajo y se llevó un 
-; paquete). El segundo complemento puede ser opcional y de distinto tipo
-; - se pueden coordinar verbos que llevan cliticos (lo leyó y resumió en un santiamén,
-; intentarlo comprar o alquilar) pero (*lee y resúmelo cuanto antes, *lo pensó y dijo).
-; - los verbos auxiliaries funcionales (*hemos y han llamado) presentan más restricciones 
-; que los modales (pueden y quieren salir), los aspectuales (comenzó y terminó de hablar)
-; y los prospectivos  los modales (quieren y van a seguir viniendo). Pero un elemento 
-; proclitico (preposición) no puede preceder a la conjunción (*van a y quieren seguir)
+
 v-coord-phrase := event-coord-phrase & 
   [ SYNSEM.LOCAL.CAT [ MC #mc,
                        LASTNMOD #lastnmod,
@@ -4541,7 +4827,18 @@ v-coord-phrase := event-coord-phrase &
                                          CLIT #clit ],
                                   VAL [ SUBJ #subj,
                                         COMPS < #comps,... >,  
-                                        CLTS #clts ] ] ].
+                                        CLTS #clts ] ] ]
+"""
+; - la coordinación de núcleos verbales es más aceptable en la medida en que los 
+; dos verbos se interpretan como relacionados semánticamente (trajo y se llevó un 
+; paquete). El segundo complemento puede ser opcional y de distinto tipo
+; - se pueden coordinar verbos que llevan cliticos (lo leyó y resumió en un santiamén,
+; intentarlo comprar o alquilar) pero (*lee y resúmelo cuanto antes, *lo pensó y dijo).
+; - los verbos auxiliaries funcionales (*hemos y han llamado) presentan más restricciones 
+; que los modales (pueden y quieren salir), los aspectuales (comenzó y terminó de hablar)
+; y los prospectivos  los modales (quieren y van a seguir viniendo). Pero un elemento 
+; proclitico (preposición) no puede preceder a la conjunción (*van a y quieren seguir)
+""".
 
 v-top-coord-phrase := v-coord-phrase & 
   [ C-CONT [ RELS <! !>,
@@ -4579,13 +4876,8 @@ v-v_crd-omni-bot_phrase := v-bottom-coord-phrase & omni-conj-first-bottom-coord-
 ; - if they function as DO the VP may follow the finite clause (e.g. sugirió que hicieran 
 ; una fiesta e invitar a sus amigos)
 
-
 ; PP coordination types
-; - !!! coordinación de dos complementos preposicionales con un adjetivo (que cada uno 
-; disponga [[del espacio y de la tierra] necesarios]).
-; - es posible coordinar ciertas preposiciones (todo por, para y sin el pueblo). Las 
-; preposiciones con menos contenido semántico y menos peso fonológico (a, de, en) 
-; son menos aceptables en coordinación (viajan *de y a Madrid/desde y hacia Madrid)
+
 prep-coord-phrase := coord-phrase &
   [ SYNSEM.LOCAL.CAT [ MC #mc,
                        LASTNMOD #lastnmod,
@@ -4609,7 +4901,14 @@ prep-coord-phrase := coord-phrase &
                                   HEAD adp  & 
                                        [ MOD #mod,
                                          TAM #tam, 
-                                         PRD #prd ] ] ].
+                                         PRD #prd ] ] ]
+"""
+; - !!! coordinación de dos complementos preposicionales con un adjetivo (que cada uno 
+; disponga [[del espacio y de la tierra] necesarios]).
+; - es posible coordinar ciertas preposiciones (todo por, para y sin el pueblo). Las 
+; preposiciones con menos contenido semántico y menos peso fonológico (a, de, en) 
+; son menos aceptables en coordinación (viajan *de y a Madrid/desde y hacia Madrid)
+""".
 
 mod-prep-coord-phrase := prep-coord-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD.KEYS.KEY prep_mod_rel,
@@ -4672,11 +4971,13 @@ pp-pp_crd-omni-bot_phrase := prep-bottom-coord-phrase & omni-conj-first-bottom-c
   [ SYNSEM.LOCAL.CAT.VAL.COMPS < > ].
 
 
-; INTERJ-INTERJ coordination types (e.g. je, je)
 interj_interj-coord-phrase := event-coord-phrase &
   [ SYNSEM.LOCAL.CAT.HEAD interj,
     LCOORD-DTR.SYNSEM.LOCAL.CAT.HEAD interj,
-    RCOORD-DTR.SYNSEM.LOCAL.CAT.HEAD interj ].
+    RCOORD-DTR.SYNSEM.LOCAL.CAT.HEAD interj ]
+"""
+; INTERJ-INTERJ coordination types (e.g. je, je)
+""".
 
 interj_interj-top-coord-phrase := interj_interj-coord-phrase &
   [  LCOORD-DTR.SYNSEM.LIGHT +,
@@ -4702,9 +5003,6 @@ i-i_crd-mono-mid_phrase := interj_interj-middle-coord-phrase & monopoly-mid-coor
 i-i_crd-mono-bot_phrase := interj-bottom-coord-phrase & conj-first-bottom-coord-phrase.
 
 ; DET coordination types
-; - los demostrativos pueden coordinarse (este y ese participante deben presentarse 
-; en la oficina) y yo creo que los artículos también (el y la estudiente desarrollan 
-; la creatividad, el y la estudiante explore diferentes posibilidades)
 
 d-top-coord-phrase := coord-phrase & 
   [ SYNSEM.LOCAL [ AGR [ PNG.GEN #gen,
@@ -4716,7 +5014,13 @@ d-top-coord-phrase := coord-phrase &
     RCOORD-DTR.SYNSEM.LOCAL [ CAT [ HEAD.KEYS.KEY non_named_non_modable_rel,
                                     VAL.SPR #spr ] ],
     C-CONT [ RELS <! !>,
-	     HCONS <! !> ] ].
+	     HCONS <! !> ] ]
+"""
+; DET coordination types
+; - los demostrativos pueden coordinarse (este y ese participante deben presentarse 
+; en la oficina) y yo creo que los artículos también (el y la estudiente desarrollan 
+; la creatividad, el y la estudiante explore diferentes posibilidades)
+""".
 
 d-bottom-coord-phrase := bottom-coord-phrase &
   [ SYNSEM.LOCAL [ COORD-REL.R-INDEX #ind,
@@ -4733,12 +5037,6 @@ d-d_crd-mono-bot_phrase := d-bottom-coord-phrase & conj-first-bottom-coord-phras
 
 ; Coordination of unlike categories
  
-; Finite completive clauses and VPs may be coordinated with eventive nouns 
-; (e.g. odio las llegadas de Segundino y que Cecilia se niegue a verlo), but not 
-; with non-event nouns (e.g. *odio a Segundino y que Cecilia se niegue a verlo) 
-; unless they are interpreted as two separate events (e.g. Qué cosas te gustaron 
-; más del viaje? El avión y que el piloto nos mostrara las ciudades durante la ruta)
-; Agreement: singular
 #|
 nom_verb-coord-phrase := coord-phrase &
   [ SYNSEM.LOCAL [ AGR.PNG.PN 3per,
@@ -4765,12 +5063,17 @@ n_v-middle-coord-phrase := nom_verb-coord-phrase &
 	     HCONS <! !> ] ].
 
 n_v_crd-mono-top_phrase := n_v-top-coord-phrase & non_advers-monopoly-top-coord-phrase.
-n_v_crd-mono-mid_phrase := n_v-middle-coord-phrase & monopoly-mid-coord-phrase.
+n_v_crd-mono-mid_phrase := n_v-middle-coord-phrase & monopoly-mid-coord-phrase
+"""
+; Finite completive clauses and VPs may be coordinated with eventive nouns 
+; (e.g. odio las llegadas de Segundino y que Cecilia se niegue a verlo), but not 
+; with non-event nouns (e.g. *odio a Segundino y que Cecilia se niegue a verlo) 
+; unless they are interpreted as two separate events (e.g. Qué cosas te gustaron 
+; más del viaje? El avión y que el piloto nos mostrara las ciudades durante la ruta)
+; Agreement: singular
+""".
 |#
 
-; ADV-PP coordination types
-; - si no son complementos, no se rige el criterio de compatibilidad semántica y similitud 
-; jerárquica (e.g. va al médico frecuentemente y sin pretexto)
 adjprep-coord-phrase := event-coord-phrase &
   [ SYNSEM.LOCAL [ CAT [ POSTHEAD #ph,
                          LASTNMOD #lastnmod,
@@ -4778,7 +5081,12 @@ adjprep-coord-phrase := event-coord-phrase &
     LCOORD-DTR.SYNSEM.LOCAL.CAT [ LASTNMOD #lastnmod,
                                   HEAD.MOD #mod ],
     RCOORD-DTR.SYNSEM.LOCAL [ CAT [ POSTHEAD #ph,
-                                    HEAD.MOD #mod ] ] ].
+                                    HEAD.MOD #mod ] ] ]
+"""
+; ADV-PP coordination types
+; - si no son complementos, no se rige el criterio de compatibilidad semántica y similitud 
+; jerárquica (e.g. va al médico frecuentemente y sin pretexto)
+""".
 
 adjprep-top-coord-phrase := adjprep-coord-phrase &
   [ C-CONT [ RELS <! !>,
@@ -4809,8 +5117,7 @@ p_a_crd-mono-top_phrase := adjprep-top-coord-phrase & prep_adj-coord-phrase & no
 p_a_crd-mono-mid_phrase := adjprep-middle-coord-phrase & prep_adj-coord-phrase & monopoly-mid-coord-phrase.
 
 ; ADV-PP coordination types
-; - si no son complementos, no se rige el criterio de compatibilidad semántica y similitud 
-; jerárquica (e.g. va al médico frecuentemente y sin pretexto)
+
 advprep-coord-phrase := event-coord-phrase &
   [ SYNSEM.LOCAL [ AGR #agr,
                    CAT [ POSTHEAD #ph,
@@ -4820,7 +5127,11 @@ advprep-coord-phrase := event-coord-phrase &
                                   HEAD.MOD #mod ],
     RCOORD-DTR.SYNSEM.LOCAL [ AGR #agr,
                               CAT [ POSTHEAD #ph,
-                                    HEAD.MOD #mod ] ] ].
+                                    HEAD.MOD #mod ] ] ]
+"""
+; - si no son complementos, no se rige el criterio de compatibilidad semántica y similitud 
+; jerárquica (e.g. va al médico frecuentemente y sin pretexto)
+""".
 
 advprep-top-coord-phrase := advprep-coord-phrase &
   [ C-CONT [ RELS <! !>,
@@ -4849,7 +5160,6 @@ p_r_crd-mono-top_phrase := advprep-top-coord-phrase & prep_adv-coord-phrase & no
 p_r_crd-mono-mid_phrase := advprep-middle-coord-phrase & prep_adv-coord-phrase & monopoly-mid-coord-phrase.
 
 
-; ADJ-ADV coordination types (e.g. comimos maravillosa y estupendamente)
 adj_adv-coord-phrase := event-coord-phrase &
   [ SYNSEM.LOCAL [ CAT [ POSTHEAD #ph,
                          LASTNMOD #lastnmod,
@@ -4858,7 +5168,10 @@ adj_adv-coord-phrase := event-coord-phrase &
     LCOORD-DTR.SYNSEM.LOCAL.CAT.HEAD adj,
     RCOORD-DTR.SYNSEM.LOCAL [ CAT [ POSTHEAD #ph,
                                     LASTNMOD #lastnmod,
-                                    HEAD adv ] ] ].
+                                    HEAD adv ] ] ]
+"""
+; ADJ-ADV coordination types (e.g. comimos maravillosa y estupendamente)
+""".
 
 adj_adv-top-coord-phrase := adj_adv-coord-phrase &
   [ C-CONT [ RELS <! !>,
@@ -4936,6 +5249,7 @@ np_ell-indef_constr := np_ell-indef_phrase & binary-rule-right-to-left.
 np_ell-sfrel_constr := np_ell-sfrel_phrase & binary-rule-right-to-left.
 
 ; *** all ad-hd below changed from right-to-left to left-to-right
+
 ad-hd_s_constr := adj-head_scop_phrase & binary-rule-left-to-right.
 ad-hd_i-xp-xp_constr := adj-head_int-xp-xp_phrase & binary-rule-left-to-right.
 ad-hd_i-xp-n_constr := adj-head_int-xp-n_phrase & binary-rule-left-to-right.
@@ -4944,7 +5258,9 @@ ad-hd_i-vp-vp_constr := adj-head_int-vp-vp_phrase & binary-rule-left-to-right.
 ad-hd_i-pp-vp_constr := adj-head_int-pp-vp_phrase & binary-rule-left-to-right.
 ad-hd_i-adv-vp_constr := adj-head_int-adv-vp_phrase & binary-rule-left-to-right.
 ad-hd_i-modnp-vp_constr := adj-head_int-modnp-vp_phrase & binary-rule-left-to-right.
+
 ; *** all hd-ad below changed from left-to-right to right-to-left
+
 hd-ad_s-xp-cl_constr := head-adj_scop-xp-cl_phrase & binary-rule-right-to-left.
 hd-ad_s-xp-xp_constr := head-adj_scop-xp-xp_phrase & binary-rule-right-to-left.
 hd-ad_i-ap-xp_constr := head-adj_int-ap-xp_phrase & binary-rule-right-to-left.
@@ -4972,7 +5288,9 @@ hd-ad_i-pn-rcpp_constr := head-adj_int-pn-rcpp_phrase & binary-rule-right-to-lef
 hd-ad_i-pr-rcpp_constr := head-adj_int-pr-rcpp_phrase & binary-rule-right-to-left.
 hd-ad_i-n-rcnr_constr := head-adj_int-n-rcnr_phrase & binary-rule-right-to-left.
 hd-ad_i-brckt-appos_constr := head-adj_int-bracket-appos_phrase & binary-rule-right-to-left. 
+
 ; *** most hd-ad -appos below reverted to left-to-right
+
 hd-ad_i-cn-cn-appos_constr := head-adj_int-cn-cn-appos_phrase & binary-rule-left-to-right. 
 hd-ad_i-cn-cn-cln-appos_constr := head-adj_int-cn-cn-cln-appos_phrase & binary-rule-left-to-right. 
 hd-ad_i-pn-cn-appos_constr := head-adj_int-pn-cn-appos_phrase & binary-rule-left-to-right. 
@@ -4985,11 +5303,15 @@ n_n_cmpnd_constr := n_n_cmpnd_phrase & binary-rule-left-to-right.
 n_n-nu_cmpnd_constr := n_n-num_cmpnd_phrase & binary-rule-left-to-right. 
 
 flr-hd_wh-fin_constr := filler-head_wh-fin_phrase & binary-rule-left-to-right. 
+
 ; *** flr-hd_wh-inf_constr onwards changed from left-to-right to right-to-left
+
 flr-hd_wh-inf_constr := filler-head_wh-inf_phrase & binary-rule-right-to-left.  
 flr-hd_nonwh_constr := filler-head_nonwh_phrase & binary-rule-right-to-left. 
 flr-hd_nonwh-nfin_constr := filler-head_nonwh-nfin_phrase & binary-rule-right-to-left. 
+
 ; *** flr-hd_rel-fin-np-mn-ellip_constr onwards changed from right-to-left to left-to-right
+
 flr-hd_rel-fin-np-mn-ellip_constr := filler-head_rel-fin-np-mn-ellip_phrase & binary-rule-left-to-right.
 flr-hd_rel-fin-np-mpn_constr := filler-head_rel-fin-np-mpn_phrase & binary-rule-left-to-right.
 flr-hd_rel-fin-np-mn_constr := filler-head_rel-fin-np-mn_phrase & binary-rule-left-to-right.
@@ -5033,6 +5355,7 @@ pt-hd_constr := punct-head_phrase & binary-rule-left-to-right.
 pt-hd_clt_constr := punct-head_clt_phrase & binary-rule-left-to-right.
 
 ; *** crd mono-bot/omni-bot/omni-left changed from right-to-left to left-to-right
+
 n-n_crd-advrs_constr := n-n_crd-advrs_phrase & binary-rule-right-to-left.
 n-n_crd-mono-top_constr := n-n_crd-mono-top_phrase & binary-rule-right-to-left.
 n-n_crd-mono-mid_constr := n-n_crd-mono-mid_phrase & binary-rule-right-to-left.

--- a/util/add_docstrings.py
+++ b/util/add_docstrings.py
@@ -1,0 +1,52 @@
+'''
+Go through all types in a TDL file and convert comments into docstrings.
+Remove the original comments.
+'''
+
+import sys, copy
+from delphin import tdl
+
+def save_tdl_objects(tdl_objects, filename):
+    with open(filename, 'w') as f:
+        for event, obj, lineno in tdl_objects:
+            if event == 'LineComment':
+                if not obj.startswith(';'):
+                    f.write('; ' + obj + '\n\n')
+                else:
+                    f.write(obj + '\n\n')
+            elif event == 'BlockComment':
+                f.write('#|' + obj + '|#\n\n')
+            else:
+                f.write(tdl.format(obj) + '\n\n')
+
+
+def convert_comments_to_docstrings(tdl_file):
+    output = []
+    cur_comment = ''
+    is_type_comment = False
+    for event, obj, lineno in tdl.iterparse(tdl_file):
+        if event == 'LineComment' or event == 'BlockComment':
+            if 'proper names' in obj:
+                print('stop')
+            cur_comment = cur_comment + obj + '\n'
+            cur_ln = lineno
+            new_type = obj
+        if event == 'TypeDefinition':
+            if cur_comment != '' and lineno == cur_ln + 1:
+                ds = cur_comment.strip('\n')
+                is_type_comment = True
+                conj = copy.deepcopy(obj.conjunction)
+                new_type = tdl.TypeDefinition(obj.identifier, conj, ds)
+                output.append((event, new_type, lineno))
+                cur_comment = ''
+            else:
+                new_type = obj
+                if cur_comment != '':
+                    is_type_comment = False
+                cur_comment = ''
+        if not is_type_comment:
+            output.append((event, new_type, lineno))
+    save_tdl_objects(output, 'docstring_output.tdl')
+
+
+convert_comments_to_docstrings(sys.argv[1])

--- a/util/add_docstrings.py
+++ b/util/add_docstrings.py
@@ -3,13 +3,15 @@ Go through all types in a TDL file and convert comments into docstrings.
 Remove the original comments.
 '''
 
-import sys, copy
+import sys, copy, re
 from delphin import tdl
 
 def save_tdl_objects(tdl_objects, filename):
     with open(filename, 'w') as f:
         for event, obj, lineno in tdl_objects:
             if event == 'LineComment':
+                #if "--- head-spec-phrase types" in obj:
+                #    print('stop')
                 if not obj.startswith(';'):
                     f.write('; ' + obj + '\n')
                 else:
@@ -20,22 +22,30 @@ def save_tdl_objects(tdl_objects, filename):
                 f.write('\n' + tdl.format(obj) + '\n\n')
 
 
+'''
+Does not fully work! Use at your own risk.
+May eat up some tdl!
+'''
 def convert_comments_to_docstrings(tdl_file):
     output = []
     cur_comment = ''
     is_type_comment = False
+    prev = None
     for event, obj, lineno in tdl.iterparse(tdl_file):
         if event == 'LineComment' or event == 'BlockComment':
             cur_comment = cur_comment + obj + '\n'
             cur_ln = lineno
             new_type = obj
+            prev = (event, obj, lineno, is_type_comment)
         if event == 'TypeDefinition':
             if cur_comment != '' and lineno == cur_ln + 1:
                 ds = cur_comment.strip('\n')
                 is_type_comment = True
+                prev = (prev[0], prev[1], prev[2], True)
                 conj = copy.deepcopy(obj.conjunction)
                 new_type = tdl.TypeDefinition(obj.identifier, conj, ds)
-                output.append((event, new_type, lineno))
+                output.append(prev)
+                output.append((event, new_type, lineno, False))
                 cur_comment = ''
             else:
                 new_type = obj
@@ -46,5 +56,53 @@ def convert_comments_to_docstrings(tdl_file):
             output.append((event, new_type, lineno))
     save_tdl_objects(output, 'docstring_output.tdl')
 
+# Unfinished:
 
-convert_comments_to_docstrings(sys.argv[1])
+
+# def plain_text_convert(filename, output_filename):
+#     output_lines = []
+#     with open(filename, 'r') as f:
+#         lines = f.readlines()
+#     cur = 0
+#     cur_comment = ''
+#     prev = ''
+#     i = 0
+#     while i < len(lines):
+#         ln = lines[i]
+#         while i < len(lines) and (ln.startswith(';') or not ln.strip()): # line is a comment
+#             cur_comment = cur_comment + ln
+#             prev = ln
+#             ln = lines[i+1]
+#             i +=1 # comments may be multiline
+#         if i < len(lines) - 1:
+#             next_ln = lines[i+1]
+#             if next_ln.strip() != '' and prev.strip() != '': # if the comment is not followed by a blank line, the comment belongs to the type that follows it
+#                 p_i, line_with_period = find_period(i+1, lines)
+#                 # create docstring from the preceding comment
+#                 docstring = '\n"""' + cur_comment + '"""'
+#                 if "crd mono-bot/omni-bot" in docstring:
+#                     print('stop')
+#                 type_with_docstring = ''.join(lines[i:line_with_period])[:-2] + docstring + '.'
+#                 print(type_with_docstring)
+#                 docstring = ''
+#                 if line_with_period + 1 < len(lines):
+#                     i = line_with_period + 1
+#             else:
+#                 # if the comment does not need to be moved into a docstring, print the contents as is
+#                 if cur_comment != '':
+#                     print(cur_comment)
+#                     cur_comment = ''
+#                 print(ln)
+#                 if i < len(lines):
+#                     i +=1
+
+
+
+def find_period(start, lines):
+    for i, ln in enumerate(lines[start:]):
+        if '.' not in ln:
+            continue
+        return ln.find('.'), start + i +1 # return the index of the period and the index of the line it was found in
+
+#convert_comments_to_docstrings(sys.argv[1])
+plain_text_convert(sys.argv[1], sys.argv[2])

--- a/util/add_docstrings.py
+++ b/util/add_docstrings.py
@@ -103,7 +103,7 @@ def convert_all_comments_to_docstrings(tdl_file):
         if event == 'LineComment':
             cur_comment = cur_comment + obj + '\n'
         if event == 'TypeDefinition':
-            ds = cur_comment.strip('\n')
+            ds = obj.docstring + '\n' + cur_comment.strip('\n') if obj.docstring else cur_comment.strip('\n')
             conj = copy.deepcopy(obj.conjunction)
             new_type = tdl.TypeDefinition(obj.identifier, conj, ds)
             output.append((event, new_type, lineno))

--- a/util/add_docstrings.py
+++ b/util/add_docstrings.py
@@ -11,13 +11,13 @@ def save_tdl_objects(tdl_objects, filename):
         for event, obj, lineno in tdl_objects:
             if event == 'LineComment':
                 if not obj.startswith(';'):
-                    f.write('; ' + obj + '\n\n')
+                    f.write('; ' + obj + '\n')
                 else:
-                    f.write(obj + '\n\n')
+                    f.write(obj + '\n')
             elif event == 'BlockComment':
                 f.write('#|' + obj + '|#\n\n')
             else:
-                f.write(tdl.format(obj) + '\n\n')
+                f.write('\n' + tdl.format(obj) + '\n\n')
 
 
 def convert_comments_to_docstrings(tdl_file):
@@ -26,8 +26,6 @@ def convert_comments_to_docstrings(tdl_file):
     is_type_comment = False
     for event, obj, lineno in tdl.iterparse(tdl_file):
         if event == 'LineComment' or event == 'BlockComment':
-            if 'proper names' in obj:
-                print('stop')
             cur_comment = cur_comment + obj + '\n'
             cur_ln = lineno
             new_type = obj

--- a/util/add_docstrings.py
+++ b/util/add_docstrings.py
@@ -96,6 +96,19 @@ def convert_comments_to_docstrings(tdl_file):
 #                 if i < len(lines):
 #                     i +=1
 
+def convert_all_comments_to_docstrings(tdl_file):
+    output = []
+    cur_comment = ''
+    for event, obj, lineno in tdl.iterparse(tdl_file):
+        if event == 'LineComment':
+            cur_comment = cur_comment + obj + '\n'
+        if event == 'TypeDefinition':
+            ds = cur_comment.strip('\n')
+            conj = copy.deepcopy(obj.conjunction)
+            new_type = tdl.TypeDefinition(obj.identifier, conj, ds)
+            output.append((event, new_type, lineno))
+            cur_comment = ''
+    save_tdl_objects(output, 'docstring_output.tdl')
 
 
 def find_period(start, lines):
@@ -104,5 +117,5 @@ def find_period(start, lines):
             continue
         return ln.find('.'), start + i +1 # return the index of the period and the index of the line it was found in
 
-#convert_comments_to_docstrings(sys.argv[1])
-plain_text_convert(sys.argv[1], sys.argv[2])
+convert_all_comments_to_docstrings(sys.argv[1])
+#plain_text_convert(sys.argv[1], sys.argv[2])

--- a/util/freeling_api/srg-freeling.dat
+++ b/util/freeling_api/srg-freeling.dat
@@ -12,6 +12,11 @@ fue @any
 fuimos @any
 fuisteis @any
 fueron @any
+uno @any
+una @any
+unos @any
+unas @any
+un @any
 </NoDisambiguate>
 
 ## List of words for which the list of output analysis given

--- a/util/freeling_api/srg-freeling.dat
+++ b/util/freeling_api/srg-freeling.dat
@@ -20,9 +20,6 @@ fueron @any
 ##      form lemma1 tag1 lemma2 tag2 ...
 <ReplaceAll>
 quería querer VMII4S0
-un un Z
-uno uno Z
-una una Z
 acá acá NC00000
 acullá acullá NC00000
 ahí ahí NC00000

--- a/util/parse_sppp_dat.py
+++ b/util/parse_sppp_dat.py
@@ -10,7 +10,8 @@ def parse_sppp(filepath):
     for i,ln in enumerate(lines):
         if not ln.startswith('#'):
             if ln.strip() == '<NoDisambiguate>':
-                pass
+                end_nodiambiguate = find_concluding_line(lines, i, '<NoDisambiguate>')
+                no_disambiguate = parse_nodisambiguate(lines[i+1:end_nodiambiguate])
             elif ln.strip() == '<ReplaceAll>':
                 end_replace = find_concluding_line(lines, i, '<ReplaceAll>')
                 replace = parse_replace(lines[i+1:end_replace])
@@ -27,6 +28,13 @@ def find_concluding_line(lines, start, opening):
         if lines[i].strip() == closing:
             return i
     return None
+
+def parse_nodisambiguate(lines):
+    nodisambiguate = {}
+    for ln in lines:
+        word, position = ln.strip().split()
+        nodisambiguate[word] = position
+    return nodisambiguate
 
 def parse_fusion(lines):
     fuse = {}

--- a/util/populate_tokens.py
+++ b/util/populate_tokens.py
@@ -69,7 +69,7 @@ def parse_recursive_dicts(input_string):
 def update_testsuite(ts, override_dicts):
     ftt = Freeling_tok_tagger()
     sentence_list = read_testsuite(ts)
-    output = ftt.tokenize_and_tag(sentence_list)
+    output = ftt.tokenize_and_tag(sentence_list, override_dicts)
     yy = convert_sentences(output, override_dicts)
     assert len(yy) == len(ts['item'])
     print('{} items in the corpus'.format(len(yy)))

--- a/util/srg_freeling2yy.py
+++ b/util/srg_freeling2yy.py
@@ -55,14 +55,20 @@ def convert_sentences(sentences, override_dicts):
     for i, sent in enumerate(sentences):
         output = ""
         _num = 0       # lattice ID
-        _from = 0      # lattice from
+        _from = 0
+        _to = 1
+        _keep_from = 0
+        _keep_to = 1
         if not sent['tokens']:
             output = '(1,0,1, <0:{}>,1,"{}" "{}",0, "np00v00", "np00v00" 1.0)'.format(len(sent['sentence']),
                                                                                       sent['sentence'].replace('"','\\"'),
                                                                                       sent['sentence'].replace('"','\\"'))
         else:
             for j,tok in enumerate(sent['tokens']):
+                is_additional = tok['additional']
                 surface = tok['form']
+                if tok['lemma'] == 'más':
+                    print('debug')
                 tag_prob = {'tag': tok['selected-tag'], 'prob':tok['selected-prob']}
                 pos_conf = override_tag(tag_prob, surface.lower(), tok['lemma'], override_dicts)
                 if len(pos_conf['tags']) > 1:
@@ -76,8 +82,10 @@ def convert_sentences(sentences, override_dicts):
                 output += ', '
                 output += str(_from)
                 output += ', '
-                _from += 1
-                output += str(_from)
+                output += str(_to)
+                if not is_additional or ('last' in tok and tok['last']):
+                    _to += 1
+                    _from += 1
                 output += ', <'
                 output += str(int(tok['start'])) # - subtract)
                 output += ':'

--- a/util/srg_freeling2yy.py
+++ b/util/srg_freeling2yy.py
@@ -67,8 +67,8 @@ def convert_sentences(sentences, override_dicts):
             for j,tok in enumerate(sent['tokens']):
                 is_additional = tok['additional']
                 surface = tok['form']
-                if tok['lemma'] == 'más':
-                    print('debug')
+                #if tok['lemma'] == 'más':
+                #    print('debug')
                 tag_prob = {'tag': tok['selected-tag'], 'prob':tok['selected-prob']}
                 pos_conf = override_tag(tag_prob, surface.lower(), tok['lemma'], override_dicts)
                 if len(pos_conf['tags']) > 1:

--- a/util/srg_freeling2yy.py
+++ b/util/srg_freeling2yy.py
@@ -35,7 +35,7 @@ def override_tag(selected, word, lemma, override_dicts):
                     return {'tags': [tags[0][:-3]], 'prob': -1 }
             else:
                 print("More than two tags in Freeling output: {}".format(selected['tag']))
-    if lemma in override_dicts['replace']:
+    if lemma in override_dicts['replace'] and len(override_dicts['replace'][lemma]['lemma']) == 1:
         return {'tags': override_dicts['replace'][lemma]['tag'], 'prob': -1 }
     return {'tags': [selected['tag']], 'prob': selected['prob']}
     #raise Exception("selected tag not in tag list")
@@ -53,8 +53,6 @@ def override_lemma(lemma, tag, override_dicts):
 def convert_sentences(sentences, override_dicts):
     yy_sentences = []
     for i, sent in enumerate(sentences):
-        if i == 149:
-            print("stop")
         output = ""
         _num = 0       # lattice ID
         _from = 0      # lattice from

--- a/util/srg_freeling2yy.py
+++ b/util/srg_freeling2yy.py
@@ -69,7 +69,7 @@ def convert_sentences(sentences, override_dicts):
                 surface = tok['form']
                 #if tok['lemma'] == 'más':
                 #    print('debug')
-                tag_prob = {'tag': tok['selected-tag'], 'prob':tok['selected-prob']}
+                tag_prob = {'tag': tok['tag'], 'prob':tok['prob']}
                 pos_conf = override_tag(tag_prob, surface.lower(), tok['lemma'], override_dicts)
                 if len(pos_conf['tags']) > 1:
                     print("Warning: more than one tag for token: {}".format(tok['form']))

--- a/util/tokenize_and_tag.py
+++ b/util/tokenize_and_tag.py
@@ -61,8 +61,8 @@ class Freeling_tok_tagger:
         # process input text
         for i,lin in enumerate(sentence_list):
             output.append({'sentence': lin, 'tokens':[]})
-            #if "Más" in lin:
-            #    print("debug")
+            if "tanto" in lin:
+                print("debug")
             # With the basic NER Freeling module, may need this, as it will assume that
             # all uppercased items are all named entities.
             #s = self.tk.tokenize(lin.lower().capitalize()) if lin.isupper() else self.tk.tokenize(lin)
@@ -85,11 +85,11 @@ class Freeling_tok_tagger:
                     #print("lemma: {}, form: {}, start: {}, end: {}, tag: {}".format(w.get_lemma(), w.get_form(), w.get_span_start(), w.get_span_finish(), w.get_tag()))
                     output[i]['tokens'].append({'lemma':w.get_lemma(), 'form': w.get_form(),
                                                 'start':w.get_span_start(), 'end': w.get_span_finish(),
-                                                'selected-tag': tag, 'selected-prob': prob, 'additional': additional})
+                                                'tag': tag, 'prob': prob, 'additional': additional})
                     for k,arc in enumerate(additional_arcs):
                         entry = {'lemma': arc['lemma'], 'form': w.get_form(),
                                                     'start': w.get_span_start(), 'end': w.get_span_finish(),
-                                                    'selected-tag': arc['tag'], 'selected-prob': -1, 'additional': True}
+                                                    'tag': arc['tag'], 'prob': prob, 'additional': True}
                         if k == len(additional_arcs) - 1:
                             entry['last'] = True
                         output[i]['tokens'].append(entry)
@@ -123,6 +123,12 @@ class Freeling_tok_tagger:
                                 tags.append(({'additional':True, 'tag': additional_tag, 'prob': -1, 'lemma': additional_lemma}))
                             else:
                                 additional_arcs.append(({'additional':True, 'tag': additional_tag, 'prob': -1, 'lemma': additional_lemma}))
-            #else:
-            #    print("Non-selected analysis: {}".format(a.get_tag()))
+            else:
+                # There are words for which Freeling selected analysis should be ignored (no analysis discarded).
+                # In principle, there is also one tag for which it should be done if the word is in the first position:
+                # NP00000 @begin
+                # This is not yet implemented and will lead to mismatches with the old treebanks, especially with proper names.
+                if w.get_form().lower() in override_dicts['no_disambiguate']:
+                    additional_arcs.append(({'additional': True, 'tag': a.get_tag(), 'prob': a.get_prob(), 'lemma': a.get_lemma()}))
+                    #print("Non-selected analysis: {}".format(a.get_tag()))
         return tags, additional_arcs

--- a/util/tokenize_and_tag.py
+++ b/util/tokenize_and_tag.py
@@ -61,8 +61,8 @@ class Freeling_tok_tagger:
         # process input text
         for i,lin in enumerate(sentence_list):
             output.append({'sentence': lin, 'tokens':[]})
-            if "Más" in lin:
-                print("debug")
+            #if "Más" in lin:
+            #    print("debug")
             # With the basic NER Freeling module, may need this, as it will assume that
             # all uppercased items are all named entities.
             #s = self.tk.tokenize(lin.lower().capitalize()) if lin.isupper() else self.tk.tokenize(lin)
@@ -86,11 +86,11 @@ class Freeling_tok_tagger:
                     output[i]['tokens'].append({'lemma':w.get_lemma(), 'form': w.get_form(),
                                                 'start':w.get_span_start(), 'end': w.get_span_finish(),
                                                 'selected-tag': tag, 'selected-prob': prob, 'additional': additional})
-                    for i,arc in enumerate(additional_arcs):
+                    for k,arc in enumerate(additional_arcs):
                         entry = {'lemma': arc['lemma'], 'form': w.get_form(),
                                                     'start': w.get_span_start(), 'end': w.get_span_finish(),
                                                     'selected-tag': arc['tag'], 'selected-prob': -1, 'additional': True}
-                        if i == len(additional_arcs) - 1:
+                        if k == len(additional_arcs) - 1:
                             entry['last'] = True
                         output[i]['tokens'].append(entry)
         # clean up

--- a/util/treebanking-scripts/report_stats.py
+++ b/util/treebanking-scripts/report_stats.py
@@ -17,11 +17,13 @@ def report_stats(treebanks_path):
         for response in items:
             all_sentences.append(response['i-input'])
             sentences.append(response['i-input'])
+            # In a thinned parsed forest, results will be empty if the item was not accepted as correct in treebanking.
             if len(response['results']) > 0:
                 accepted.append(response['i-input'])
                 all_accepted.append(response['i-input'])
                 #deriv = response.result(0).derivation()
             else:
+                #print('Rejected: {}'.format(response['i-input']))
                 rejected.append(response['i-input'])
                 all_rejected.append(response['i-input'])
         acc = len(accepted)/len(sentences)


### PR DESCRIPTION
Two major changes:

1. Docstrings in most of TDL files.
2. Yet more reverse-engineering of the old Freeling interface; now most of the old sppp.dat file is implemented in util/freeling_api/tokenize_and_tag.py and freeling2srg.dat which is a modified version of sppp.dat.