### PR TITLE
Started porting overgeneration fixes from GAUSS

### DIFF
--- a/letypes.tdl
+++ b/letypes.tdl
@@ -4544,7 +4544,7 @@ v_cop-nsbj := v_copula &
 
 v_ap_ser_synsem := v_copula_synsem &
   [ LOCAL [ CAT.VAL [ SUBJ < [ LOCAL.CONT.HOOK.INDEX #sind ] >,
-                      COMPS < [ LOCAL [ CAT.HEAD adj & [ MOD < [ LOCAL.CAT.HEAD noun ] >,
+                      COMPS < [ LOCAL [ CAT.HEAD adj & [ MOD < [ LOCAL [ CAT.HEAD noun, AGR #sind ] ] >,
                                                          PRD.COPV ser ],
                                         CONT.HOOK.XARG #sind ] ] > ],
             CONT.HOOK.XARG #sind ] ]


### PR DESCRIPTION
We are starting to integrate fixes we implemented as part of our work with the learner corpus in https://github.com/olzama/gauss where we can identify overgeneration. Currently we look at gender agreement.

With this fix, agreement is enforced between the subject and the complement of the copula v_ap_ser_synsem; no regressions on TIBIDABO 1-12; improvements on the learner treebanks 4-10